### PR TITLE
ci: change to closeAndRelease

### DIFF
--- a/.github/workflows/release_please.yaml
+++ b/.github/workflows/release_please.yaml
@@ -75,7 +75,7 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        run: ./gradlew publishToSonatype closeSonatypeStagingRepository --no-daemon --stacktrace
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-daemon --stacktrace
 
       - name: Clean up signing secrets
         run: rm ~/.gradle/gradle.properties


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Makes the maven-central release drop automatically when closed.

_To be merged when we know that the closing is successful._