### PR TITLE
build: define group and version in root build.gradle

### DIFF
--- a/OpenFeature/build.gradle.kts
+++ b/OpenFeature/build.gradle.kts
@@ -8,9 +8,7 @@ plugins {
     kotlin("plugin.serialization") version "1.9.10"
 }
 
-// x-release-please-start-version
-val releaseVersion = "0.0.3"
-// x-release-please-end
+val releaseVersion = project.extra["version"].toString()
 
 android {
     namespace = "dev.openfeature.sdk"
@@ -51,7 +49,7 @@ android {
 publishing {
     publications {
         register<MavenPublication>("release") {
-            groupId = "dev.openfeature"
+            groupId = project.extra["groupId"].toString()
             artifactId = "kotlin-sdk"
             version = releaseVersion
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,14 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint").version("11.6.1").apply(true)
     id("io.github.gradle-nexus.publish-plugin").version("1.3.0").apply(true)
 }
+allprojects {
+    extra["groupId"] = "dev.openfeature"
+// x-release-please-start-version
+    ext["version"] = "0.0.3"
+// x-release-please-end
+}
+group = project.extra["groupId"].toString()
+version = project.extra["version"].toString()
 
 nexusPublishing {
     this.repositories {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
             "versioning": "default",
             "extra-files": [
                 "README.md",
+                "build.gradle.kts",
                 "OpenFeature/build.gradle.kts"
             ]
         }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- moves the definition of the group id and the version to the root gradle file
- set the group and version in the root since sonatype nexus gradle plugin wants it that way.
