### PR TITLE
feat: Add new error for type mismatch

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/Reason.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/Reason.kt
@@ -26,8 +26,5 @@ enum class Reason {
     STALE,
 
     // / The resolved value was the result of an error.
-    ERROR,
-
-    // / The resolved value had the wrong type.
-    TYPE_MISMATCH
+    ERROR
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/Reason.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/Reason.kt
@@ -26,5 +26,8 @@ enum class Reason {
     STALE,
 
     // / The resolved value was the result of an error.
-    ERROR
+    ERROR,
+
+    // / The resolved value had the wrong type.
+    TYPE_MISMATCH
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.kt
@@ -43,4 +43,11 @@ sealed class OpenFeatureError : Exception() {
             return ErrorCode.PROVIDER_NOT_READY
         }
     }
+
+    class TypeMismatchError(override val message: String = "The value has not the expected type") :
+        OpenFeatureError() {
+        override fun errorCode(): ErrorCode {
+            return ErrorCode.TYPE_MISMATCH
+        }
+    }
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.kt
@@ -44,7 +44,7 @@ sealed class OpenFeatureError : Exception() {
         }
     }
 
-    class TypeMismatchError(override val message: String = "The value has not the expected type") :
+    class TypeMismatchError(override val message: String = "The value doesn't match the expected type") :
         OpenFeatureError() {
         override fun errorCode(): ErrorCode {
             return ErrorCode.TYPE_MISMATCH


### PR DESCRIPTION
## This PR
The standard error `TypeMismatch` has no exception in the SDK.
This PR exposes the exception.
