### PR TITLE
refactor: changing vars to vals

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/FlagEvaluationDetails.kt
@@ -4,11 +4,11 @@ import dev.openfeature.sdk.exceptions.ErrorCode
 
 data class FlagEvaluationDetails<T>(
     val flagKey: String,
-    override var value: T,
-    override var variant: String? = null,
-    override var reason: String? = null,
-    override var errorCode: ErrorCode? = null,
-    override var errorMessage: String? = null
+    override val value: T,
+    override val variant: String? = null,
+    override val reason: String? = null,
+    override val errorCode: ErrorCode? = null,
+    override val errorMessage: String? = null
 ) : BaseEvaluation<T> {
     companion object
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/FlagEvaluationOptions.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/FlagEvaluationOptions.kt
@@ -1,6 +1,6 @@
 package dev.openfeature.sdk
 
 data class FlagEvaluationOptions(
-    var hooks: List<Hook<*>> = listOf(),
-    var hookHints: Map<String, Any> = mapOf()
+    val hooks: List<Hook<*>> = listOf(),
+    val hookHints: Map<String, Any> = mapOf()
 )

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/HookContext.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/HookContext.kt
@@ -1,10 +1,10 @@
 package dev.openfeature.sdk
 
 data class HookContext<T>(
-    var flagKey: String,
+    val flagKey: String,
     val type: FlagValueType,
-    var defaultValue: T,
-    var ctx: EvaluationContext?,
-    var clientMetadata: ClientMetadata?,
-    var providerMetadata: ProviderMetadata
+    val defaultValue: T,
+    val ctx: EvaluationContext?,
+    val clientMetadata: ClientMetadata?,
+    val providerMetadata: ProviderMetadata
 )

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
@@ -2,7 +2,7 @@ package dev.openfeature.sdk
 
 class ImmutableContext
 (private var targetingKey: String = "", attributes: Map<String, Value> = mapOf()) : EvaluationContext {
-    private var structure: ImmutableStructure = ImmutableStructure(attributes)
+    private val structure: ImmutableStructure = ImmutableStructure(attributes)
     override fun getTargetingKey(): String {
         return targetingKey
     }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableStructure.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableStructure.kt
@@ -1,6 +1,6 @@
 package dev.openfeature.sdk
 
-class ImmutableStructure(private var attributes: Map<String, Value> = mapOf()) : Structure {
+class ImmutableStructure(private val attributes: Map<String, Value> = mapOf()) : Structure {
     override fun keySet(): Set<String> {
         return attributes.keys
     }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
@@ -1,7 +1,7 @@
 package dev.openfeature.sdk
 
-class NoOpProvider : FeatureProvider {
-    override var metadata: ProviderMetadata = NoOpProviderMetadata("No-op provider")
+class NoOpProvider(override val hooks: List<Hook<*>> = listOf()) : FeatureProvider {
+    override val metadata: ProviderMetadata = NoOpProviderMetadata("No-op provider")
     override fun initialize(initialContext: EvaluationContext?) {
         // no-op
     }
@@ -17,7 +17,6 @@ class NoOpProvider : FeatureProvider {
         // no-op
     }
 
-    override var hooks: List<Hook<*>> = listOf()
     override fun getBooleanEvaluation(
         key: String,
         defaultValue: Boolean,
@@ -58,5 +57,5 @@ class NoOpProvider : FeatureProvider {
         return ProviderEvaluation(defaultValue, "Passed in default", Reason.DEFAULT.toString())
     }
 
-    data class NoOpProviderMetadata(override var name: String?) : ProviderMetadata
+    data class NoOpProviderMetadata(override val name: String?) : ProviderMetadata
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ProviderEvaluation.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ProviderEvaluation.kt
@@ -3,9 +3,9 @@ package dev.openfeature.sdk
 import dev.openfeature.sdk.exceptions.ErrorCode
 
 data class ProviderEvaluation<T>(
-    var value: T,
-    var variant: String? = null,
-    var reason: String? = null,
-    var errorCode: ErrorCode? = null,
-    var errorMessage: String? = null
+    val value: T,
+    val variant: String? = null,
+    val reason: String? = null,
+    val errorCode: ErrorCode? = null,
+    val errorMessage: String? = null
 )

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/HookSpecTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/HookSpecTests.kt
@@ -39,11 +39,13 @@ class HookSpecTests {
 
     @Test
     fun testHookEvaluationOrder() = runTest {
-        val provider = NoOpProvider()
         val evalOrder: MutableList<String> = mutableListOf()
         val addEval: (String) -> Unit = { eval: String -> evalOrder += eval }
 
-        provider.hooks = listOf(GenericSpyHookMock("provider", addEval))
+        val provider = NoOpProvider(
+            hooks = listOf(GenericSpyHookMock("provider", addEval))
+        )
+
         OpenFeatureAPI.setProvider(provider)
         OpenFeatureAPI.addHooks(listOf(GenericSpyHookMock("api", addEval)))
         val client = OpenFeatureAPI.getClient()

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
@@ -65,5 +65,5 @@ class AlwaysBrokenProvider(override var hooks: List<Hook<*>> = listOf(), overrid
         throw FlagNotFoundError(key)
     }
 
-    class AlwaysBrokenProviderMetadata(override var name: String? = "test") : ProviderMetadata
+    class AlwaysBrokenProviderMetadata(override val name: String? = "test") : ProviderMetadata
 }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
@@ -7,7 +7,10 @@ import dev.openfeature.sdk.ProviderEvaluation
 import dev.openfeature.sdk.ProviderMetadata
 import dev.openfeature.sdk.Value
 
-class DoSomethingProvider(override val hooks: List<Hook<*>> = listOf(), override val metadata: ProviderMetadata = DoSomethingProviderMetadata()) : FeatureProvider {
+class DoSomethingProvider(
+    override val hooks: List<Hook<*>> = listOf(),
+    override val metadata: ProviderMetadata = DoSomethingProviderMetadata()
+) : FeatureProvider {
     override fun initialize(initialContext: EvaluationContext?) {
         // no-op
     }
@@ -62,5 +65,5 @@ class DoSomethingProvider(override val hooks: List<Hook<*>> = listOf(), override
     ): ProviderEvaluation<Value> {
         return ProviderEvaluation(Value.Null)
     }
-    class DoSomethingProviderMetadata(override var name: String? = "something") : ProviderMetadata
+    class DoSomethingProviderMetadata(override val name: String? = "something") : ProviderMetadata
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

Release-As: 0.1.0

## This PR
<!-- add the description of the PR here -->

- Changes a bunch of `var`s to `val`s
- Could definitely be considered a breaking change but since we're not at 1.0 I don't think we should bump major.