### PR TITLE
refactor: make targeting key immutable

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/EvaluationContext.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/EvaluationContext.kt
@@ -2,7 +2,7 @@ package dev.openfeature.sdk
 
 interface EvaluationContext : Structure {
     fun getTargetingKey(): String
-    fun setTargetingKey(targetingKey: String)
+    fun withTargetingKey(targetingKey: String): EvaluationContext
 
     // Make sure these are implemented for correct object comparisons
     override fun hashCode(): Int

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
@@ -1,15 +1,19 @@
 package dev.openfeature.sdk
 
-class ImmutableContext
-(private var targetingKey: String = "", attributes: Map<String, Value> = mapOf()) : EvaluationContext {
+class ImmutableContext(
+    private val targetingKey: String = "",
+    attributes: Map<String, Value> = mapOf()
+) : EvaluationContext {
     private val structure: ImmutableStructure = ImmutableStructure(attributes)
     override fun getTargetingKey(): String {
         return targetingKey
     }
 
-    override fun setTargetingKey(targetingKey: String) {
-        this.targetingKey = targetingKey
-    }
+    override fun withTargetingKey(targetingKey: String): ImmutableContext =
+        ImmutableContext(
+            targetingKey = targetingKey,
+            attributes = this.structure.asMap()
+        )
 
     override fun keySet(): Set<String> {
         return structure.keySet()

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
@@ -7,10 +7,12 @@ import java.util.Date
 class EvalContextTests {
 
     @Test
-    fun testContextStoresTargetingKey() {
+    fun testContextIsImmutableButStoresTargetingKey() {
         val ctx = ImmutableContext()
-        ctx.setTargetingKey("test")
-        Assert.assertEquals("test", ctx.getTargetingKey())
+        Assert.assertEquals("", ctx.getTargetingKey())
+
+        val newCtx = ctx.withTargetingKey("test")
+        Assert.assertEquals("test", newCtx.getTargetingKey())
     }
 
     @Test


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- makes the targeting key in the immutable context truly immutable.
