### PR TITLE
feat: set evaluation-context in setProviderAndWait()

### DIFF
--- a/android/src/main/java/dev/openfeature/sdk/async/Extensions.kt
+++ b/android/src/main/java/dev/openfeature/sdk/async/Extensions.kt
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk.async
 
+import dev.openfeature.sdk.EvaluationContext
 import dev.openfeature.sdk.FeatureProvider
 import dev.openfeature.sdk.OpenFeatureAPI
 import dev.openfeature.sdk.OpenFeatureClient
@@ -27,9 +28,10 @@ fun OpenFeatureClient.toAsync(): AsyncClient? {
 
 suspend fun OpenFeatureAPI.setProviderAndWait(
     provider: FeatureProvider,
-    dispatcher: CoroutineDispatcher
+    dispatcher: CoroutineDispatcher,
+    initialContext: EvaluationContext? = null
 ) {
-    setProvider(provider)
+    setProvider(provider, initialContext)
     provider.awaitReady(dispatcher)
 }
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- makes it possible to use `setProviderAndWait` and also pass the `EvaluationContext` in the same call.
