### PR TITLE
fix: setProviderAndWait does not hang on ProviderError

### DIFF
--- a/android/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
+++ b/android/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
@@ -8,10 +8,11 @@ interface FeatureProvider : EventObserver, ProviderStatus {
     val metadata: ProviderMetadata
 
     // Called by OpenFeatureAPI whenever the new Provider is registered
+    // This function should never throw
     fun initialize(initialContext: EvaluationContext?)
 
-    // called when the lifecycle of the OpenFeatureClient is over
-    // to release resources/threads.
+    // Called when the lifecycle of the OpenFeatureClient is over
+    // to release resources/threads
     fun shutdown()
 
     // Called by OpenFeatureAPI whenever a new EvaluationContext is set by the application

--- a/android/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
+++ b/android/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
@@ -14,7 +14,7 @@ object OpenFeatureAPI {
         try {
             provider.initialize(context)
         } catch (e: Throwable) {
-            // TODO What to do here?
+            // This is not allowed to happen
         }
     }
 

--- a/android/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
+++ b/android/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
@@ -11,7 +11,11 @@ object OpenFeatureAPI {
     fun setProvider(provider: FeatureProvider, initialContext: EvaluationContext? = null) {
         this@OpenFeatureAPI.provider = provider
         if (initialContext != null) context = initialContext
-        provider.initialize(context)
+        try {
+            provider.initialize(context)
+        } catch (e: Throwable) {
+            // TODO What to do here?
+        }
     }
 
     fun getProvider(): FeatureProvider? {

--- a/android/src/main/java/dev/openfeature/sdk/events/EventHandler.kt
+++ b/android/src/main/java/dev/openfeature/sdk/events/EventHandler.kt
@@ -19,8 +19,13 @@ interface ProviderStatus {
     fun getProviderStatus(): OpenFeatureEvents
 }
 
-fun FeatureProvider.isProviderReady(): Boolean =
-    getProviderStatus() == OpenFeatureEvents.ProviderReady
+fun FeatureProvider.isProviderReady(): Boolean {
+    val providerStatus = getProviderStatus()
+    return providerStatus == OpenFeatureEvents.ProviderReady
+}
+
+fun FeatureProvider.isProviderError(): Boolean =
+    getProviderStatus() is OpenFeatureEvents.ProviderError
 
 interface EventsPublisher {
     fun publish(event: OpenFeatureEvents)

--- a/android/src/main/java/dev/openfeature/sdk/events/EventHandler.kt
+++ b/android/src/main/java/dev/openfeature/sdk/events/EventHandler.kt
@@ -1,6 +1,5 @@
 package dev.openfeature.sdk.events
 
-import dev.openfeature.sdk.FeatureProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -18,14 +17,6 @@ interface EventObserver {
 interface ProviderStatus {
     fun getProviderStatus(): OpenFeatureEvents
 }
-
-fun FeatureProvider.isProviderReady(): Boolean {
-    val providerStatus = getProviderStatus()
-    return providerStatus == OpenFeatureEvents.ProviderReady
-}
-
-fun FeatureProvider.isProviderError(): Boolean =
-    getProviderStatus() is OpenFeatureEvents.ProviderError
 
 interface EventsPublisher {
     fun publish(event: OpenFeatureEvents)

--- a/android/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
+++ b/android/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
@@ -4,7 +4,6 @@ import dev.openfeature.sdk.async.observeProviderReady
 import dev.openfeature.sdk.async.toAsync
 import dev.openfeature.sdk.events.EventHandler
 import dev.openfeature.sdk.events.OpenFeatureEvents
-import dev.openfeature.sdk.events.isProviderReady
 import dev.openfeature.sdk.events.observe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/android/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
@@ -7,6 +7,7 @@ import dev.openfeature.sdk.ProviderEvaluation
 import dev.openfeature.sdk.ProviderMetadata
 import dev.openfeature.sdk.Value
 import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.exceptions.OpenFeatureError
 import dev.openfeature.sdk.exceptions.OpenFeatureError.FlagNotFoundError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -74,7 +75,7 @@ class AlwaysBrokenProvider(
     override fun observe(): Flow<OpenFeatureEvents> = flow { }
 
     override fun getProviderStatus(): OpenFeatureEvents =
-        OpenFeatureEvents.ProviderError(FlagNotFoundError("test"))
+        OpenFeatureEvents.ProviderError(OpenFeatureError.GeneralError("Unknown error"))
 
     class AlwaysBrokenProviderMetadata(override val name: String? = "test") : ProviderMetadata
 }

--- a/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
@@ -1,0 +1,84 @@
+package dev.openfeature.sdk.helpers
+
+import dev.openfeature.sdk.*
+import dev.openfeature.sdk.events.EventHandler
+import dev.openfeature.sdk.events.OpenFeatureEvents
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+
+class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dispatcher: CoroutineDispatcher) : FeatureProvider {
+    override val metadata: ProviderMetadata = SlowProviderMetadata("Slow provider")
+    private var ready = false
+    private var eventHandler = EventHandler(dispatcher)
+    override fun initialize(initialContext: EvaluationContext?) {
+        CoroutineScope(dispatcher).launch {
+            Thread.sleep(2000) // TODO Improve without sleep
+            ready = true
+            eventHandler.publish(OpenFeatureEvents.ProviderReady)
+        }
+    }
+
+    override fun shutdown() {
+        // no-op
+    }
+
+    override fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) {
+        // no-op
+    }
+
+    override fun getBooleanEvaluation(
+        key: String,
+        defaultValue: Boolean,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Boolean> {
+        return ProviderEvaluation(!defaultValue)
+    }
+
+    override fun getStringEvaluation(
+        key: String,
+        defaultValue: String,
+        context: EvaluationContext?
+    ): ProviderEvaluation<String> {
+        return ProviderEvaluation(defaultValue.reversed())
+    }
+
+    override fun getIntegerEvaluation(
+        key: String,
+        defaultValue: Int,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Int> {
+        return ProviderEvaluation(defaultValue * 100)
+    }
+
+    override fun getDoubleEvaluation(
+        key: String,
+        defaultValue: Double,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Double> {
+        return ProviderEvaluation(defaultValue * 100)
+    }
+
+    override fun getObjectEvaluation(
+        key: String,
+        defaultValue: Value,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Value> {
+        return ProviderEvaluation(Value.Null)
+    }
+
+    override fun observe(): Flow<OpenFeatureEvents> = flowOf()
+
+    override fun getProviderStatus(): OpenFeatureEvents = if (ready) {
+        OpenFeatureEvents.ProviderReady
+    } else {
+        OpenFeatureEvents.ProviderStale
+    }
+
+    data class SlowProviderMetadata(override val name: String?) : ProviderMetadata
+}

--- a/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
@@ -1,6 +1,11 @@
 package dev.openfeature.sdk.helpers
 
-import dev.openfeature.sdk.*
+import dev.openfeature.sdk.EvaluationContext
+import dev.openfeature.sdk.FeatureProvider
+import dev.openfeature.sdk.Hook
+import dev.openfeature.sdk.ProviderEvaluation
+import dev.openfeature.sdk.ProviderMetadata
+import dev.openfeature.sdk.Value
 import dev.openfeature.sdk.events.EventHandler
 import dev.openfeature.sdk.events.OpenFeatureEvents
 import kotlinx.coroutines.CoroutineDispatcher

--- a/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
@@ -8,8 +8,10 @@ import dev.openfeature.sdk.ProviderMetadata
 import dev.openfeature.sdk.Value
 import dev.openfeature.sdk.events.EventHandler
 import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -20,7 +22,7 @@ class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dis
     private var eventHandler = EventHandler(dispatcher)
     override fun initialize(initialContext: EvaluationContext?) {
         CoroutineScope(dispatcher).launch {
-            Thread.sleep(2000) // TODO Improve without sleep
+            delay(10000)
             ready = true
             eventHandler.publish(OpenFeatureEvents.ProviderReady)
         }
@@ -42,6 +44,7 @@ class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dis
         defaultValue: Boolean,
         context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
         return ProviderEvaluation(!defaultValue)
     }
 
@@ -50,6 +53,7 @@ class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dis
         defaultValue: String,
         context: EvaluationContext?
     ): ProviderEvaluation<String> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
         return ProviderEvaluation(defaultValue.reversed())
     }
 
@@ -58,6 +62,7 @@ class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dis
         defaultValue: Int,
         context: EvaluationContext?
     ): ProviderEvaluation<Int> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
         return ProviderEvaluation(defaultValue * 100)
     }
 
@@ -66,6 +71,7 @@ class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dis
         defaultValue: Double,
         context: EvaluationContext?
     ): ProviderEvaluation<Double> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
         return ProviderEvaluation(defaultValue * 100)
     }
 
@@ -74,6 +80,7 @@ class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dis
         defaultValue: Value,
         context: EvaluationContext?
     ): ProviderEvaluation<Value> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
         return ProviderEvaluation(Value.Null)
     }
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
`setContextAndWait` shouldn't hang if the Provider fails the initalization phase for some reason.

### Related Issues
N/A

### Follow-up Tasks
Similar logic will need to be added to setEvaluationContext 

### How to test
Added unit tests
