### PR TITLE
feat: Update observeEvents() API

### DIFF
--- a/android/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
+++ b/android/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
@@ -1,15 +1,21 @@
 package dev.openfeature.sdk
 
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
 @Suppress("TooManyFunctions")
 object OpenFeatureAPI {
     private var provider: FeatureProvider? = null
     private var context: EvaluationContext? = null
+    private val providersFlow: MutableSharedFlow<FeatureProvider> = MutableSharedFlow(replay = 1)
+    internal val sharedProvidersFlow: SharedFlow<FeatureProvider> get() = providersFlow
 
     var hooks: List<Hook<*>> = listOf()
         private set
 
     fun setProvider(provider: FeatureProvider, initialContext: EvaluationContext? = null) {
         this@OpenFeatureAPI.provider = provider
+        providersFlow.tryEmit(provider)
         if (initialContext != null) context = initialContext
         try {
             provider.initialize(context)

--- a/android/src/main/java/dev/openfeature/sdk/async/Extensions.kt
+++ b/android/src/main/java/dev/openfeature/sdk/async/Extensions.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.take

--- a/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/SlowProvider.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 
 class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dispatcher: CoroutineDispatcher) : FeatureProvider {
@@ -84,7 +83,7 @@ class SlowProvider(override val hooks: List<Hook<*>> = listOf(), private var dis
         return ProviderEvaluation(Value.Null)
     }
 
-    override fun observe(): Flow<OpenFeatureEvents> = flowOf()
+    override fun observe(): Flow<OpenFeatureEvents> = eventHandler.observe()
 
     override fun getProviderStatus(): OpenFeatureEvents = if (ready) {
         OpenFeatureEvents.ProviderReady


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Update the `OpenFeatureAPI.observeEvents()` API:
- It can be called by the Application layer before any provider is configured, and it will still receive events once a new provider is configured and emitting events
  - Thanks to this, we can now recommend setting up the observation before `setProvider` is called, thus ensuring no event from the configured provider is lost due to raciness between `observer` and `setProvider`

Usage example (from Application layer):
```
viewModelScope.launch {
    OpenFeatureAPI.observeEvents().collect {
        println(">> Event received: $it")
    }
}

viewModelScope.launch {
    OpenFeatureAPI.setProviderAndWait(
        ConfidenceFeatureProvider.create(
            app.applicationContext,
            clientSecret
        ),
        Dispatchers.IO,
        ctx
    )
}