### PR TITLE
refactor: Rename shutdown event to notready event

### DIFF
--- a/android/src/main/java/dev/openfeature/sdk/events/EventHandler.kt
+++ b/android/src/main/java/dev/openfeature/sdk/events/EventHandler.kt
@@ -31,7 +31,7 @@ class EventHandler(dispatcher: CoroutineDispatcher) :
     ProviderStatus {
     private val sharedFlow: MutableSharedFlow<OpenFeatureEvents> = MutableSharedFlow()
     private val currentStatus: MutableStateFlow<OpenFeatureEvents> =
-        MutableStateFlow(OpenFeatureEvents.ProviderShutDown)
+        MutableStateFlow(OpenFeatureEvents.ProviderNotReady)
     private val job = Job()
     private val coroutineScope = CoroutineScope(job + dispatcher)
 
@@ -40,7 +40,7 @@ class EventHandler(dispatcher: CoroutineDispatcher) :
             sharedFlow.collect {
                 currentStatus.value = it
                 when (it) {
-                    is OpenFeatureEvents.ProviderShutDown -> {
+                    is OpenFeatureEvents.ProviderNotReady -> {
                         job.cancelChildren()
                     }
 

--- a/android/src/main/java/dev/openfeature/sdk/events/OpenFeatureEvents.kt
+++ b/android/src/main/java/dev/openfeature/sdk/events/OpenFeatureEvents.kt
@@ -1,8 +1,8 @@
 package dev.openfeature.sdk.events
 
 sealed interface OpenFeatureEvents {
+    object ProviderNotReady : OpenFeatureEvents
     object ProviderReady : OpenFeatureEvents
     data class ProviderError(val error: Throwable) : OpenFeatureEvents
     object ProviderStale : OpenFeatureEvents
-    object ProviderShutDown : OpenFeatureEvents
 }

--- a/android/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
+++ b/android/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
@@ -181,7 +181,7 @@ class EventsHandlerTest {
         val eventHandler = EventHandler(dispatcher)
         val provider = TestFeatureProvider(dispatcher, eventHandler)
 
-        Assert.assertEquals(OpenFeatureEvents.ProviderShutDown, provider.getProviderStatus())
+        Assert.assertEquals(OpenFeatureEvents.ProviderNotReady, provider.getProviderStatus())
 
         provider.emitReady()
 
@@ -201,6 +201,6 @@ class EventsHandlerTest {
 
         provider.shutdown()
 
-        Assert.assertEquals(OpenFeatureEvents.ProviderShutDown, provider.getProviderStatus())
+        Assert.assertEquals(OpenFeatureEvents.ProviderNotReady, provider.getProviderStatus())
     }
 }

--- a/android/src/test/java/dev/openfeature/sdk/TestFeatureProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/TestFeatureProvider.kt
@@ -18,7 +18,7 @@ class TestFeatureProvider(
     }
 
     override fun shutdown() {
-        eventHandler.publish(OpenFeatureEvents.ProviderShutDown)
+        eventHandler.publish(OpenFeatureEvents.ProviderNotReady)
     }
 
     override fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {


### PR DESCRIPTION
## This PR
"NotReady" is not an [Event](https://openfeature.dev/specification/types#provider-status) yet in the Spec (but it is a [Status](https://openfeature.dev/specification/types#provider-status) as of the day of writing this PR). However, this transitional change is supposed to bring this implementation one step closer to the Spec (note that "ShutDown" is neither and "Event" nor a "Status"). This also brings the current implementation closer to the Swift implementation.

### Related Issues
- https://github.com/open-feature/spec/issues/238
- https://github.com/open-feature/swift-sdk/pull/36

