### PR TITLE
fix: Coroutine resume bug

### DIFF
--- a/android/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
@@ -3,11 +3,14 @@ package dev.openfeature.sdk
 import dev.openfeature.sdk.events.OpenFeatureEvents
 import dev.openfeature.sdk.exceptions.ErrorCode
 import dev.openfeature.sdk.helpers.AlwaysBrokenProvider
+import dev.openfeature.sdk.helpers.AutoHealingProvider
 import dev.openfeature.sdk.helpers.DoSomethingProvider
 import dev.openfeature.sdk.helpers.GenericSpyHookMock
 import dev.openfeature.sdk.helpers.SlowProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.toCollection
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -107,5 +110,22 @@ class DeveloperExperienceTests {
         }
         advanceUntilIdle()
         Assert.assertEquals(eventCount, 1)
+    }
+
+    @Test
+    fun testProviderThatHealsWithErrorThenReady() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val healing = AutoHealingProvider(dispatcher = dispatcher, healDelay = 100)
+        val resultEvents = mutableListOf<OpenFeatureEvents>()
+        val r = async {
+            OpenFeatureAPI.observe<OpenFeatureEvents>().toCollection(resultEvents)
+        }
+        OpenFeatureAPI.setProviderAndWait(healing, dispatcher, ImmutableContext())
+        testScheduler.advanceUntilIdle()
+        Assert.assertEquals(2, resultEvents.size)
+        Assert.assertTrue(resultEvents[0] is OpenFeatureEvents.ProviderError)
+        Assert.assertEquals(OpenFeatureEvents.ProviderReady, resultEvents[1])
+        OpenFeatureAPI.shutdown()
+        r.cancel()
     }
 }

--- a/android/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
+++ b/android/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
@@ -22,7 +22,7 @@ class EventsHandlerTest {
     fun observing_event_observer_works() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
         var emitted = false
 
         val job = backgroundScope.launch(dispatcher) {
@@ -41,7 +41,7 @@ class EventsHandlerTest {
     fun multiple_subscribers_works() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
         val numberOfSubscribers = 10
         val parentJob = Job()
         var emitted = 0
@@ -65,7 +65,7 @@ class EventsHandlerTest {
     fun canceling_one_subscriber_does_not_cancel_others() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
         val numberOfSubscribers = 10
         val parentJob = Job()
         var emitted = 0
@@ -95,7 +95,7 @@ class EventsHandlerTest {
     fun the_provider_status_stream_works() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
         var isProviderReady = false
 
         // observing the provider status after the provider ready event is published
@@ -118,7 +118,7 @@ class EventsHandlerTest {
         var isProviderReady = false
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
 
         // observing the provider status after the provider ready event is published
         val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -137,7 +137,7 @@ class EventsHandlerTest {
     fun the_provider_status_stream_is_replays_current_status() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
         provider.emitReady()
         var isProviderReady = false
 
@@ -158,7 +158,7 @@ class EventsHandlerTest {
     fun the_provider_becomes_stale() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
         var isProviderStale = false
 
         val job = backgroundScope.launch(dispatcher) {
@@ -179,7 +179,7 @@ class EventsHandlerTest {
     fun accessing_status_from_provider_works() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val eventHandler = EventHandler(dispatcher)
-        val provider = TestFeatureProvider(dispatcher, eventHandler)
+        val provider = TestFeatureProvider(eventHandler)
 
         Assert.assertEquals(OpenFeatureEvents.ProviderNotReady, provider.getProviderStatus())
 

--- a/android/src/test/java/dev/openfeature/sdk/TestFeatureProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/TestFeatureProvider.kt
@@ -2,10 +2,8 @@ package dev.openfeature.sdk
 
 import dev.openfeature.sdk.events.EventHandler
 import dev.openfeature.sdk.events.OpenFeatureEvents
-import kotlinx.coroutines.CoroutineDispatcher
 
 class TestFeatureProvider(
-    dispatcher: CoroutineDispatcher,
     private val eventHandler: EventHandler
 ) : FeatureProvider {
     override val hooks: List<Hook<*>>

--- a/android/src/test/java/dev/openfeature/sdk/helpers/AutoHealingProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/AutoHealingProvider.kt
@@ -1,0 +1,101 @@
+package dev.openfeature.sdk.helpers
+
+import dev.openfeature.sdk.EvaluationContext
+import dev.openfeature.sdk.FeatureProvider
+import dev.openfeature.sdk.Hook
+import dev.openfeature.sdk.ProviderEvaluation
+import dev.openfeature.sdk.ProviderMetadata
+import dev.openfeature.sdk.Value
+import dev.openfeature.sdk.events.EventHandler
+import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.exceptions.OpenFeatureError
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestDispatcher
+
+class AutoHealingProvider(
+    val dispatcher: TestDispatcher,
+    val healDelay: Long = 1000L,
+    override val hooks: List<Hook<*>> = emptyList()
+) : FeatureProvider {
+    override val metadata: ProviderMetadata = object : ProviderMetadata {
+        override val name: String = "AutoHealingProvider"
+    }
+    private var ready = false
+    private var eventHandler = EventHandler(dispatcher)
+    override fun initialize(initialContext: EvaluationContext?) {
+        CoroutineScope(dispatcher).launch {
+            ready = false
+            eventHandler.publish(OpenFeatureEvents.ProviderError(OpenFeatureError.ProviderNotReadyError("AutoHealingProvider is trying to heal")))
+            delay(healDelay)
+            ready = true
+            eventHandler.publish(OpenFeatureEvents.ProviderReady)
+        }
+    }
+
+    override fun shutdown() {
+        // no-op
+    }
+
+    override fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) {
+        // no-op
+    }
+
+    override fun getBooleanEvaluation(
+        key: String,
+        defaultValue: Boolean,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Boolean> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
+        return ProviderEvaluation(!defaultValue)
+    }
+
+    override fun getStringEvaluation(
+        key: String,
+        defaultValue: String,
+        context: EvaluationContext?
+    ): ProviderEvaluation<String> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
+        return ProviderEvaluation(defaultValue.reversed())
+    }
+
+    override fun getIntegerEvaluation(
+        key: String,
+        defaultValue: Int,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Int> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
+        return ProviderEvaluation(defaultValue * 100)
+    }
+
+    override fun getDoubleEvaluation(
+        key: String,
+        defaultValue: Double,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Double> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
+        return ProviderEvaluation(defaultValue * 100)
+    }
+
+    override fun getObjectEvaluation(
+        key: String,
+        defaultValue: Value,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Value> {
+        if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
+        return ProviderEvaluation(Value.Null)
+    }
+
+    override fun observe(): Flow<OpenFeatureEvents> = eventHandler.observe()
+
+    override fun getProviderStatus(): OpenFeatureEvents = if (ready) {
+        OpenFeatureEvents.ProviderReady
+    } else {
+        OpenFeatureEvents.ProviderStale
+    }
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Fixes a crash where a Provider emits first an error event and then a ready event as part of the same `setProviderAndAwait()` call

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #116 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
This issue would also be solved when the `FeatureProvider.initialize` is a suspending function.

### How to test
<!-- if applicable, add testing instructions under this section -->
A test case was added which shows an example provider that had this crash.

