### PR TITLE
build: add plugin to validate api binary compatibility

### DIFF
--- a/android/api/android.api
+++ b/android/api/android.api
@@ -1,0 +1,666 @@
+public abstract interface class dev/openfeature/sdk/BaseEvaluation {
+	public abstract fun getErrorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public abstract fun getErrorMessage ()Ljava/lang/String;
+	public abstract fun getReason ()Ljava/lang/String;
+	public abstract fun getValue ()Ljava/lang/Object;
+	public abstract fun getVariant ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class dev/openfeature/sdk/Builder {
+	public fun <init> ()V
+	public final fun build ()Ldev/openfeature/sdk/EvaluationMetadata;
+	public final fun putBoolean (Ljava/lang/String;Z)Ldev/openfeature/sdk/Builder;
+	public final fun putDouble (Ljava/lang/String;D)Ldev/openfeature/sdk/Builder;
+	public final fun putInt (Ljava/lang/String;I)Ldev/openfeature/sdk/Builder;
+	public final fun putString (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/sdk/Builder;
+}
+
+public abstract interface class dev/openfeature/sdk/Client : dev/openfeature/sdk/Features, dev/openfeature/sdk/Tracking {
+	public abstract fun addHooks (Ljava/util/List;)V
+	public abstract fun getHooks ()Ljava/util/List;
+	public abstract fun getMetadata ()Ldev/openfeature/sdk/ClientMetadata;
+}
+
+public abstract interface class dev/openfeature/sdk/ClientMetadata {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class dev/openfeature/sdk/EvaluationContext : dev/openfeature/sdk/Structure {
+	public abstract fun equals (Ljava/lang/Object;)Z
+	public abstract fun getTargetingKey ()Ljava/lang/String;
+	public abstract fun hashCode ()I
+	public abstract fun withTargetingKey (Ljava/lang/String;)Ldev/openfeature/sdk/EvaluationContext;
+}
+
+public final class dev/openfeature/sdk/EvaluationMetadata {
+	public static final field Companion Ldev/openfeature/sdk/EvaluationMetadata$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoolean (Ljava/lang/String;)Ljava/lang/Boolean;
+	public final fun getDouble (Ljava/lang/String;)Ljava/lang/Double;
+	public final fun getInt (Ljava/lang/String;)Ljava/lang/Integer;
+	public final fun getString (Ljava/lang/String;)Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class dev/openfeature/sdk/EvaluationMetadata$Companion {
+	public final fun builder ()Ldev/openfeature/sdk/Builder;
+	public final fun getEMPTY ()Ldev/openfeature/sdk/EvaluationMetadata;
+}
+
+public abstract interface class dev/openfeature/sdk/FeatureProvider {
+	public abstract fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public abstract fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public abstract fun getHooks ()Ljava/util/List;
+	public abstract fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public abstract fun getMetadata ()Ldev/openfeature/sdk/ProviderMetadata;
+	public abstract fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public abstract fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public abstract fun initialize (Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onContextSet (Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun shutdown ()V
+	public abstract fun track (Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/TrackingEventDetails;)V
+}
+
+public final class dev/openfeature/sdk/FeatureProvider$DefaultImpls {
+	public static fun track (Ldev/openfeature/sdk/FeatureProvider;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/TrackingEventDetails;)V
+}
+
+public abstract interface class dev/openfeature/sdk/Features {
+	public abstract fun getBooleanDetails (Ljava/lang/String;Z)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getBooleanDetails (Ljava/lang/String;ZLdev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getBooleanValue (Ljava/lang/String;Z)Z
+	public abstract fun getBooleanValue (Ljava/lang/String;ZLdev/openfeature/sdk/FlagEvaluationOptions;)Z
+	public abstract fun getDoubleDetails (Ljava/lang/String;D)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getDoubleDetails (Ljava/lang/String;DLdev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getDoubleValue (Ljava/lang/String;D)D
+	public abstract fun getDoubleValue (Ljava/lang/String;DLdev/openfeature/sdk/FlagEvaluationOptions;)D
+	public abstract fun getIntegerDetails (Ljava/lang/String;I)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getIntegerDetails (Ljava/lang/String;ILdev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getIntegerValue (Ljava/lang/String;I)I
+	public abstract fun getIntegerValue (Ljava/lang/String;ILdev/openfeature/sdk/FlagEvaluationOptions;)I
+	public abstract fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/sdk/Value;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getObjectValue (Ljava/lang/String;Ldev/openfeature/sdk/Value;)Ldev/openfeature/sdk/Value;
+	public abstract fun getObjectValue (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/Value;
+	public abstract fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public abstract fun getStringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getStringValue (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/FlagEvaluationDetails {
+	public static final field Companion Ldev/openfeature/sdk/FlagEvaluationDetails$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ldev/openfeature/sdk/EvaluationMetadata;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/FlagEvaluationDetails;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;ILjava/lang/Object;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public final fun getErrorMessage ()Ljava/lang/String;
+	public final fun getFlagKey ()Ljava/lang/String;
+	public final fun getMetadata ()Ldev/openfeature/sdk/EvaluationMetadata;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/FlagEvaluationDetails$Companion {
+}
+
+public final class dev/openfeature/sdk/FlagEvaluationDetailsKt {
+	public static final fun from (Ldev/openfeature/sdk/FlagEvaluationDetails$Companion;Ldev/openfeature/sdk/ProviderEvaluation;Ljava/lang/String;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+}
+
+public final class dev/openfeature/sdk/FlagEvaluationOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Ldev/openfeature/sdk/FlagEvaluationOptions;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/FlagEvaluationOptions;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Ldev/openfeature/sdk/FlagEvaluationOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHookHints ()Ljava/util/Map;
+	public final fun getHooks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/FlagValueType : java/lang/Enum {
+	public static final field BOOLEAN Ldev/openfeature/sdk/FlagValueType;
+	public static final field DOUBLE Ldev/openfeature/sdk/FlagValueType;
+	public static final field INTEGER Ldev/openfeature/sdk/FlagValueType;
+	public static final field OBJECT Ldev/openfeature/sdk/FlagValueType;
+	public static final field STRING Ldev/openfeature/sdk/FlagValueType;
+	public static fun valueOf (Ljava/lang/String;)Ldev/openfeature/sdk/FlagValueType;
+	public static fun values ()[Ldev/openfeature/sdk/FlagValueType;
+}
+
+public abstract interface class dev/openfeature/sdk/Hook {
+	public abstract fun after (Ldev/openfeature/sdk/HookContext;Ldev/openfeature/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
+	public abstract fun before (Ldev/openfeature/sdk/HookContext;Ljava/util/Map;)V
+	public abstract fun error (Ldev/openfeature/sdk/HookContext;Ljava/lang/Exception;Ljava/util/Map;)V
+	public abstract fun finallyAfter (Ldev/openfeature/sdk/HookContext;Ljava/util/Map;)V
+	public abstract fun supportsFlagValueType (Ldev/openfeature/sdk/FlagValueType;)Z
+}
+
+public final class dev/openfeature/sdk/Hook$DefaultImpls {
+	public static fun after (Ldev/openfeature/sdk/Hook;Ldev/openfeature/sdk/HookContext;Ldev/openfeature/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
+	public static fun before (Ldev/openfeature/sdk/Hook;Ldev/openfeature/sdk/HookContext;Ljava/util/Map;)V
+	public static fun error (Ldev/openfeature/sdk/Hook;Ldev/openfeature/sdk/HookContext;Ljava/lang/Exception;Ljava/util/Map;)V
+	public static fun finallyAfter (Ldev/openfeature/sdk/Hook;Ldev/openfeature/sdk/HookContext;Ljava/util/Map;)V
+	public static fun supportsFlagValueType (Ldev/openfeature/sdk/Hook;Ldev/openfeature/sdk/FlagValueType;)Z
+}
+
+public final class dev/openfeature/sdk/HookContext {
+	public fun <init> (Ljava/lang/String;Ldev/openfeature/sdk/FlagValueType;Ljava/lang/Object;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/ClientMetadata;Ldev/openfeature/sdk/ProviderMetadata;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/openfeature/sdk/FlagValueType;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun component4 ()Ldev/openfeature/sdk/EvaluationContext;
+	public final fun component5 ()Ldev/openfeature/sdk/ClientMetadata;
+	public final fun component6 ()Ldev/openfeature/sdk/ProviderMetadata;
+	public final fun copy (Ljava/lang/String;Ldev/openfeature/sdk/FlagValueType;Ljava/lang/Object;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/ClientMetadata;Ldev/openfeature/sdk/ProviderMetadata;)Ldev/openfeature/sdk/HookContext;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/HookContext;Ljava/lang/String;Ldev/openfeature/sdk/FlagValueType;Ljava/lang/Object;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/ClientMetadata;Ldev/openfeature/sdk/ProviderMetadata;ILjava/lang/Object;)Ldev/openfeature/sdk/HookContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientMetadata ()Ldev/openfeature/sdk/ClientMetadata;
+	public final fun getCtx ()Ldev/openfeature/sdk/EvaluationContext;
+	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getFlagKey ()Ljava/lang/String;
+	public final fun getProviderMetadata ()Ldev/openfeature/sdk/ProviderMetadata;
+	public final fun getType ()Ldev/openfeature/sdk/FlagValueType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/HookSupport {
+	public fun <init> ()V
+	public final fun afterAllHooks (Ldev/openfeature/sdk/FlagValueType;Ldev/openfeature/sdk/HookContext;Ljava/util/List;Ljava/util/Map;)V
+	public final fun afterHooks (Ldev/openfeature/sdk/FlagValueType;Ldev/openfeature/sdk/HookContext;Ldev/openfeature/sdk/FlagEvaluationDetails;Ljava/util/List;Ljava/util/Map;)V
+	public final fun beforeHooks (Ldev/openfeature/sdk/FlagValueType;Ldev/openfeature/sdk/HookContext;Ljava/util/List;Ljava/util/Map;)V
+	public final fun errorHooks (Ldev/openfeature/sdk/FlagValueType;Ldev/openfeature/sdk/HookContext;Ljava/lang/Exception;Ljava/util/List;Ljava/util/Map;)V
+}
+
+public final class dev/openfeature/sdk/ImmutableContext : dev/openfeature/sdk/EvaluationContext {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun asMap ()Ljava/util/Map;
+	public fun asObjectMap ()Ljava/util/Map;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTargetingKey ()Ljava/lang/String;
+	public fun getValue (Ljava/lang/String;)Ldev/openfeature/sdk/Value;
+	public fun hashCode ()I
+	public fun keySet ()Ljava/util/Set;
+	public synthetic fun withTargetingKey (Ljava/lang/String;)Ldev/openfeature/sdk/EvaluationContext;
+	public fun withTargetingKey (Ljava/lang/String;)Ldev/openfeature/sdk/ImmutableContext;
+}
+
+public final class dev/openfeature/sdk/ImmutableStructure : dev/openfeature/sdk/Structure {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([Lkotlin/Pair;)V
+	public fun asMap ()Ljava/util/Map;
+	public fun asObjectMap ()Ljava/util/Map;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue (Ljava/lang/String;)Ldev/openfeature/sdk/Value;
+	public fun hashCode ()I
+	public fun keySet ()Ljava/util/Set;
+}
+
+public class dev/openfeature/sdk/NoOpProvider : dev/openfeature/sdk/FeatureProvider {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public fun getHooks ()Ljava/util/List;
+	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public fun getMetadata ()Ldev/openfeature/sdk/ProviderMetadata;
+	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public fun initialize (Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onContextSet (Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun shutdown ()V
+	public fun track (Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/TrackingEventDetails;)V
+}
+
+public final class dev/openfeature/sdk/NoOpProvider$NoOpProviderMetadata : dev/openfeature/sdk/ProviderMetadata {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/openfeature/sdk/NoOpProvider$NoOpProviderMetadata;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/NoOpProvider$NoOpProviderMetadata;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/sdk/NoOpProvider$NoOpProviderMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/OpenFeatureAPI {
+	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureAPI;
+	public final fun addHooks (Ljava/util/List;)V
+	public final fun clearHooks ()V
+	public final fun clearProvider ()V
+	public final fun getClient (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/sdk/Client;
+	public static synthetic fun getClient$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/sdk/Client;
+	public final fun getEvaluationContext ()Ldev/openfeature/sdk/EvaluationContext;
+	public final fun getHooks ()Ljava/util/List;
+	public final fun getProvider ()Ldev/openfeature/sdk/FeatureProvider;
+	public final fun getProviderMetadata ()Ldev/openfeature/sdk/ProviderMetadata;
+	public final fun getStatus ()Ldev/openfeature/sdk/OpenFeatureStatus;
+	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun setEvaluationContext (Ldev/openfeature/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
+	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ldev/openfeature/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
+	public final fun setEvaluationContextAndWait (Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setProvider (Ldev/openfeature/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/sdk/EvaluationContext;)V
+	public static synthetic fun setProvider$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ldev/openfeature/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/sdk/EvaluationContext;ILjava/lang/Object;)V
+	public final fun setProviderAndWait (Ldev/openfeature/sdk/FeatureProvider;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setProviderAndWait$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ldev/openfeature/sdk/FeatureProvider;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun shutdown ()V
+}
+
+public final class dev/openfeature/sdk/OpenFeatureClient : dev/openfeature/sdk/Client {
+	public fun <init> (Ldev/openfeature/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ldev/openfeature/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun addHooks (Ljava/util/List;)V
+	public fun getBooleanDetails (Ljava/lang/String;Z)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getBooleanDetails (Ljava/lang/String;ZLdev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getBooleanValue (Ljava/lang/String;Z)Z
+	public fun getBooleanValue (Ljava/lang/String;ZLdev/openfeature/sdk/FlagEvaluationOptions;)Z
+	public fun getDoubleDetails (Ljava/lang/String;D)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getDoubleDetails (Ljava/lang/String;DLdev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getDoubleValue (Ljava/lang/String;D)D
+	public fun getDoubleValue (Ljava/lang/String;DLdev/openfeature/sdk/FlagEvaluationOptions;)D
+	public fun getHooks ()Ljava/util/List;
+	public fun getIntegerDetails (Ljava/lang/String;I)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getIntegerDetails (Ljava/lang/String;ILdev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getIntegerValue (Ljava/lang/String;I)I
+	public fun getIntegerValue (Ljava/lang/String;ILdev/openfeature/sdk/FlagEvaluationOptions;)I
+	public fun getMetadata ()Ldev/openfeature/sdk/ClientMetadata;
+	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/sdk/Value;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/sdk/Value;)Ldev/openfeature/sdk/Value;
+	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/Value;
+	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ldev/openfeature/sdk/FlagEvaluationDetails;
+	public fun getStringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public fun getStringValue (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/FlagEvaluationOptions;)Ljava/lang/String;
+	public fun track (Ljava/lang/String;Ldev/openfeature/sdk/TrackingEventDetails;)V
+}
+
+public final class dev/openfeature/sdk/OpenFeatureClient$Metadata : dev/openfeature/sdk/ClientMetadata {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/openfeature/sdk/OpenFeatureClient$Metadata;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/OpenFeatureClient$Metadata;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/sdk/OpenFeatureClient$Metadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/openfeature/sdk/OpenFeatureStatus {
+}
+
+public final class dev/openfeature/sdk/OpenFeatureStatus$Error : dev/openfeature/sdk/OpenFeatureStatus {
+	public fun <init> (Ldev/openfeature/sdk/exceptions/OpenFeatureError;)V
+	public final fun getError ()Ldev/openfeature/sdk/exceptions/OpenFeatureError;
+}
+
+public final class dev/openfeature/sdk/OpenFeatureStatus$Fatal : dev/openfeature/sdk/OpenFeatureStatus {
+	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureStatus$Fatal;
+}
+
+public final class dev/openfeature/sdk/OpenFeatureStatus$NotReady : dev/openfeature/sdk/OpenFeatureStatus {
+	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureStatus$NotReady;
+}
+
+public final class dev/openfeature/sdk/OpenFeatureStatus$Ready : dev/openfeature/sdk/OpenFeatureStatus {
+	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureStatus$Ready;
+}
+
+public final class dev/openfeature/sdk/OpenFeatureStatus$Reconciling : dev/openfeature/sdk/OpenFeatureStatus {
+	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureStatus$Reconciling;
+}
+
+public final class dev/openfeature/sdk/OpenFeatureStatus$Stale : dev/openfeature/sdk/OpenFeatureStatus {
+	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureStatus$Stale;
+}
+
+public final class dev/openfeature/sdk/ProviderEvaluation {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ldev/openfeature/sdk/EvaluationMetadata;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/ProviderEvaluation;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/exceptions/ErrorCode;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationMetadata;ILjava/lang/Object;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public final fun getErrorMessage ()Ljava/lang/String;
+	public final fun getMetadata ()Ldev/openfeature/sdk/EvaluationMetadata;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/openfeature/sdk/ProviderMetadata {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Reason : java/lang/Enum {
+	public static final field CACHED Ldev/openfeature/sdk/Reason;
+	public static final field DEFAULT Ldev/openfeature/sdk/Reason;
+	public static final field DISABLED Ldev/openfeature/sdk/Reason;
+	public static final field ERROR Ldev/openfeature/sdk/Reason;
+	public static final field SPLIT Ldev/openfeature/sdk/Reason;
+	public static final field STALE Ldev/openfeature/sdk/Reason;
+	public static final field STATIC Ldev/openfeature/sdk/Reason;
+	public static final field TARGETING_MATCH Ldev/openfeature/sdk/Reason;
+	public static final field UNKNOWN Ldev/openfeature/sdk/Reason;
+	public static fun valueOf (Ljava/lang/String;)Ldev/openfeature/sdk/Reason;
+	public static fun values ()[Ldev/openfeature/sdk/Reason;
+}
+
+public abstract interface class dev/openfeature/sdk/Structure {
+	public abstract fun asMap ()Ljava/util/Map;
+	public abstract fun asObjectMap ()Ljava/util/Map;
+	public abstract fun equals (Ljava/lang/Object;)Z
+	public abstract fun getValue (Ljava/lang/String;)Ldev/openfeature/sdk/Value;
+	public abstract fun hashCode ()I
+	public abstract fun keySet ()Ljava/util/Set;
+}
+
+public abstract interface class dev/openfeature/sdk/Tracking {
+	public abstract fun track (Ljava/lang/String;Ldev/openfeature/sdk/TrackingEventDetails;)V
+}
+
+public final class dev/openfeature/sdk/Tracking$DefaultImpls {
+	public static synthetic fun track$default (Ldev/openfeature/sdk/Tracking;Ljava/lang/String;Ldev/openfeature/sdk/TrackingEventDetails;ILjava/lang/Object;)V
+}
+
+public final class dev/openfeature/sdk/TrackingEventDetails : dev/openfeature/sdk/Structure {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Number;Ldev/openfeature/sdk/Structure;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ldev/openfeature/sdk/Structure;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun asMap ()Ljava/util/Map;
+	public fun asObjectMap ()Ljava/util/Map;
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ldev/openfeature/sdk/Structure;
+	public final fun copy (Ljava/lang/Number;Ldev/openfeature/sdk/Structure;)Ldev/openfeature/sdk/TrackingEventDetails;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/TrackingEventDetails;Ljava/lang/Number;Ldev/openfeature/sdk/Structure;ILjava/lang/Object;)Ldev/openfeature/sdk/TrackingEventDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStructure ()Ldev/openfeature/sdk/Structure;
+	public final fun getValue ()Ljava/lang/Number;
+	public fun getValue (Ljava/lang/String;)Ldev/openfeature/sdk/Value;
+	public fun hashCode ()I
+	public fun keySet ()Ljava/util/Set;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/openfeature/sdk/Value {
+	public abstract fun asBoolean ()Ljava/lang/Boolean;
+	public abstract fun asDate ()Ljava/util/Date;
+	public abstract fun asDouble ()Ljava/lang/Double;
+	public abstract fun asInteger ()Ljava/lang/Integer;
+	public abstract fun asList ()Ljava/util/List;
+	public abstract fun asString ()Ljava/lang/String;
+	public abstract fun asStructure ()Ljava/util/Map;
+	public abstract fun isNull ()Z
+}
+
+public final class dev/openfeature/sdk/Value$Boolean : dev/openfeature/sdk/Value {
+	public fun <init> (Z)V
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public final fun component1 ()Z
+	public final fun copy (Z)Ldev/openfeature/sdk/Value$Boolean;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/Value$Boolean;ZILjava/lang/Object;)Ldev/openfeature/sdk/Value$Boolean;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoolean ()Z
+	public fun hashCode ()I
+	public fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$Date : dev/openfeature/sdk/Value {
+	public fun <init> (Ljava/util/Date;)V
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public final fun component1 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;)Ldev/openfeature/sdk/Value$Date;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/Value$Date;Ljava/util/Date;ILjava/lang/Object;)Ldev/openfeature/sdk/Value$Date;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$DefaultImpls {
+	public static fun asBoolean (Ldev/openfeature/sdk/Value;)Ljava/lang/Boolean;
+	public static fun asDate (Ldev/openfeature/sdk/Value;)Ljava/util/Date;
+	public static fun asDouble (Ldev/openfeature/sdk/Value;)Ljava/lang/Double;
+	public static fun asInteger (Ldev/openfeature/sdk/Value;)Ljava/lang/Integer;
+	public static fun asList (Ldev/openfeature/sdk/Value;)Ljava/util/List;
+	public static fun asString (Ldev/openfeature/sdk/Value;)Ljava/lang/String;
+	public static fun asStructure (Ldev/openfeature/sdk/Value;)Ljava/util/Map;
+	public static fun isNull (Ldev/openfeature/sdk/Value;)Z
+}
+
+public final class dev/openfeature/sdk/Value$Double : dev/openfeature/sdk/Value {
+	public fun <init> (D)V
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public final fun component1 ()D
+	public final fun copy (D)Ldev/openfeature/sdk/Value$Double;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/Value$Double;DILjava/lang/Object;)Ldev/openfeature/sdk/Value$Double;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDouble ()D
+	public fun hashCode ()I
+	public fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$Integer : dev/openfeature/sdk/Value {
+	public fun <init> (I)V
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public final fun component1 ()I
+	public final fun copy (I)Ldev/openfeature/sdk/Value$Integer;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/Value$Integer;IILjava/lang/Object;)Ldev/openfeature/sdk/Value$Integer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInteger ()I
+	public fun hashCode ()I
+	public fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$List : dev/openfeature/sdk/Value {
+	public fun <init> (Ljava/util/List;)V
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Ldev/openfeature/sdk/Value$List;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/Value$List;Ljava/util/List;ILjava/lang/Object;)Ldev/openfeature/sdk/Value$List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$Null : dev/openfeature/sdk/Value {
+	public static final field INSTANCE Ldev/openfeature/sdk/Value$Null;
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun isNull ()Z
+}
+
+public final class dev/openfeature/sdk/Value$String : dev/openfeature/sdk/Value {
+	public fun <init> (Ljava/lang/String;)V
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/openfeature/sdk/Value$String;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/Value$String;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/sdk/Value$String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getString ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$Structure : dev/openfeature/sdk/Value {
+	public fun <init> (Ljava/util/Map;)V
+	public fun asBoolean ()Ljava/lang/Boolean;
+	public fun asDate ()Ljava/util/Date;
+	public fun asDouble ()Ljava/lang/Double;
+	public fun asInteger ()Ljava/lang/Integer;
+	public fun asList ()Ljava/util/List;
+	public fun asString ()Ljava/lang/String;
+	public fun asStructure ()Ljava/util/Map;
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Ldev/openfeature/sdk/Value$Structure;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/Value$Structure;Ljava/util/Map;ILjava/lang/Object;)Ldev/openfeature/sdk/Value$Structure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStructure ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/ErrorCode : java/lang/Enum {
+	public static final field FLAG_NOT_FOUND Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static final field GENERAL Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static final field INVALID_CONTEXT Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static final field PARSE_ERROR Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static final field PROVIDER_FATAL Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static final field PROVIDER_NOT_READY Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static final field TARGETING_KEY_MISSING Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static final field TYPE_MISMATCH Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static fun valueOf (Ljava/lang/String;)Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public static fun values ()[Ldev/openfeature/sdk/exceptions/ErrorCode;
+}
+
+public abstract class dev/openfeature/sdk/exceptions/OpenFeatureError : java/lang/Exception {
+	public abstract fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$FlagNotFoundError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> (Ljava/lang/String;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$GeneralError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> (Ljava/lang/String;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$InvalidContextError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$ParseError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> (Ljava/lang/String;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$ProviderFatalError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$ProviderNotReadyError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$TargetingKeyMissingError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/exceptions/OpenFeatureError$TypeMismatchError : dev/openfeature/sdk/exceptions/OpenFeatureError {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun errorCode ()Ldev/openfeature/sdk/exceptions/ErrorCode;
+	public fun getMessage ()Ljava/lang/String;
+}
+

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("maven-publish")
     id("signing")
     id("org.jlleitschuh.gradle.ktlint")
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 val releaseVersion = project.extra["version"].toString()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.android").version("1.8.10").apply(false)
     id("org.jlleitschuh.gradle.ktlint").version("11.6.1").apply(true)
     id("io.github.gradle-nexus.publish-plugin").version("2.0.0").apply(true)
+    id("org.jetbrains.kotlinx.binary-compatibility-validator").version("0.17.0").apply(false)
 }
 allprojects {
     extra["groupId"] = "dev.openfeature"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds the [binary-compatibility-validator plugin](https://github.com/Kotlin/binary-compatibility-validator) together with the current "spec" of the API.
This plugin will run as part of the gradle `check` phase and:
> The tool allows dumping binary API of a JVM part of a Kotlin library that is public in the sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that makes this change binary incompatible.

The idea with this tool is that we can easily detect changes in the SDK API because the `./android/api/android.api` file will need to be updated in the PR that introduces the change.

This plugin will run as part of the CI and will validate all PRs.

When a deliberate API change is done, the "spec file" should be updated using 
```
./gradlew apiDump
```

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Introduced as a mitigation to #120.
