### PR TITLE
fix: bring back provider eventing

### DIFF
--- a/android/api/android.api
+++ b/android/api/android.api
@@ -63,12 +63,14 @@ public abstract interface class dev/openfeature/sdk/FeatureProvider {
 	public abstract fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
 	public abstract fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
 	public abstract fun initialize (Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun observe ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun onContextSet (Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun shutdown ()V
 	public abstract fun track (Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/TrackingEventDetails;)V
 }
 
 public final class dev/openfeature/sdk/FeatureProvider$DefaultImpls {
+	public static fun observe (Ldev/openfeature/sdk/FeatureProvider;)Lkotlinx/coroutines/flow/Flow;
 	public static fun track (Ldev/openfeature/sdk/FeatureProvider;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/TrackingEventDetails;)V
 }
 
@@ -237,6 +239,7 @@ public class dev/openfeature/sdk/NoOpProvider : dev/openfeature/sdk/FeatureProvi
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun observe ()Lkotlinx/coroutines/flow/Flow;
 	public fun onContextSet (Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun shutdown ()V
 	public fun track (Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/TrackingEventDetails;)V
@@ -257,13 +260,14 @@ public final class dev/openfeature/sdk/OpenFeatureAPI {
 	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureAPI;
 	public final fun addHooks (Ljava/util/List;)V
 	public final fun clearHooks ()V
-	public final fun clearProvider ()V
+	public final fun clearProvider (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getClient (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/sdk/Client;
 	public static synthetic fun getClient$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/sdk/Client;
 	public final fun getEvaluationContext ()Ldev/openfeature/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
 	public final fun getProvider ()Ldev/openfeature/sdk/FeatureProvider;
 	public final fun getProviderMetadata ()Ldev/openfeature/sdk/ProviderMetadata;
+	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getStatus ()Ldev/openfeature/sdk/OpenFeatureStatus;
 	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
 	public final fun setEvaluationContext (Ldev/openfeature/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
@@ -271,9 +275,9 @@ public final class dev/openfeature/sdk/OpenFeatureAPI {
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setProvider (Ldev/openfeature/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/sdk/EvaluationContext;)V
 	public static synthetic fun setProvider$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ldev/openfeature/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/sdk/EvaluationContext;ILjava/lang/Object;)V
-	public final fun setProviderAndWait (Ldev/openfeature/sdk/FeatureProvider;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun setProviderAndWait$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ldev/openfeature/sdk/FeatureProvider;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun shutdown ()V
+	public final fun setProviderAndWait (Ldev/openfeature/sdk/FeatureProvider;Ldev/openfeature/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setProviderAndWait$default (Ldev/openfeature/sdk/OpenFeatureAPI;Ldev/openfeature/sdk/FeatureProvider;Ldev/openfeature/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/openfeature/sdk/OpenFeatureClient : dev/openfeature/sdk/Client {
@@ -325,7 +329,8 @@ public final class dev/openfeature/sdk/OpenFeatureStatus$Error : dev/openfeature
 }
 
 public final class dev/openfeature/sdk/OpenFeatureStatus$Fatal : dev/openfeature/sdk/OpenFeatureStatus {
-	public static final field INSTANCE Ldev/openfeature/sdk/OpenFeatureStatus$Fatal;
+	public fun <init> (Ldev/openfeature/sdk/exceptions/OpenFeatureError;)V
+	public final fun getError ()Ldev/openfeature/sdk/exceptions/OpenFeatureError;
 }
 
 public final class dev/openfeature/sdk/OpenFeatureStatus$NotReady : dev/openfeature/sdk/OpenFeatureStatus {
@@ -587,6 +592,36 @@ public final class dev/openfeature/sdk/Value$Structure : dev/openfeature/sdk/Val
 	public fun hashCode ()I
 	public fun isNull ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/openfeature/sdk/events/OpenFeatureProviderEvents {
+}
+
+public final class dev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged : dev/openfeature/sdk/events/OpenFeatureProviderEvents {
+	public static final field INSTANCE Ldev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
+}
+
+public final class dev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderError : dev/openfeature/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> (Ldev/openfeature/sdk/exceptions/OpenFeatureError;)V
+	public final fun component1 ()Ldev/openfeature/sdk/exceptions/OpenFeatureError;
+	public final fun copy (Ldev/openfeature/sdk/exceptions/OpenFeatureError;)Ldev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderError;
+	public static synthetic fun copy$default (Ldev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderError;Ldev/openfeature/sdk/exceptions/OpenFeatureError;ILjava/lang/Object;)Ldev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ldev/openfeature/sdk/exceptions/OpenFeatureError;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderNotReady : dev/openfeature/sdk/events/OpenFeatureProviderEvents {
+	public static final field INSTANCE Ldev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderNotReady;
+}
+
+public final class dev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderReady : dev/openfeature/sdk/events/OpenFeatureProviderEvents {
+	public static final field INSTANCE Ldev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderReady;
+}
+
+public final class dev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderStale : dev/openfeature/sdk/events/OpenFeatureProviderEvents {
+	public static final field INSTANCE Ldev/openfeature/sdk/events/OpenFeatureProviderEvents$ProviderStale;
 }
 
 public final class dev/openfeature/sdk/exceptions/ErrorCode : java/lang/Enum {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.7.3")
 }
 
 signing {

--- a/android/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
+++ b/android/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
@@ -1,6 +1,9 @@
 package dev.openfeature.sdk
 
+import dev.openfeature.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.sdk.exceptions.OpenFeatureError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlin.jvm.Throws
 
 interface FeatureProvider {
@@ -52,5 +55,13 @@ interface FeatureProvider {
      */
     fun track(trackingEventName: String, context: EvaluationContext?, details: TrackingEventDetails?) {
         // an empty default implementation to make implementing this functionality optional
+    }
+
+    /**
+     * Used by providers to expose internal events to the SDK or the application.
+     * This can be optionally implemented by the provider to expose a flow of internal events.
+     */
+    fun observe(): Flow<OpenFeatureProviderEvents> {
+        return emptyFlow()
     }
 }

--- a/android/src/main/java/dev/openfeature/sdk/OpenFeatureClient.kt
+++ b/android/src/main/java/dev/openfeature/sdk/OpenFeatureClient.kt
@@ -221,7 +221,7 @@ class OpenFeatureClient(
         val providerStatus = openFeatureAPI.getStatus()
         if (providerStatus == OpenFeatureStatus.NotReady) {
             throw OpenFeatureError.ProviderNotReadyError()
-        } else if (providerStatus == OpenFeatureStatus.Fatal) {
+        } else if (providerStatus is OpenFeatureStatus.Fatal) {
             throw OpenFeatureError.ProviderFatalError()
         }
     }

--- a/android/src/main/java/dev/openfeature/sdk/OpenFeatureStatus.kt
+++ b/android/src/main/java/dev/openfeature/sdk/OpenFeatureStatus.kt
@@ -19,14 +19,14 @@ sealed interface OpenFeatureStatus {
     class Error(val error: OpenFeatureError) : OpenFeatureStatus
 
     /**
+     * The provider has entered an irrecoverable error state.
+     */
+    class Fatal(val error: OpenFeatureError) : OpenFeatureStatus
+
+    /**
      * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
      */
     object Stale : OpenFeatureStatus
-
-    /**
-     * The provider has entered an irrecoverable error state.
-     */
-    object Fatal : OpenFeatureStatus
 
     /**
      * The provider is reconciling its state with a context change.

--- a/android/src/main/java/dev/openfeature/sdk/events/OpenFeatureProviderEvents.kt
+++ b/android/src/main/java/dev/openfeature/sdk/events/OpenFeatureProviderEvents.kt
@@ -1,0 +1,13 @@
+package dev.openfeature.sdk.events
+
+import dev.openfeature.sdk.exceptions.OpenFeatureError
+
+sealed interface OpenFeatureProviderEvents {
+    object ProviderReady : OpenFeatureProviderEvents
+
+    @Deprecated("Use ProviderError instead", ReplaceWith("ProviderError"))
+    object ProviderNotReady : OpenFeatureProviderEvents
+    object ProviderStale : OpenFeatureProviderEvents
+    data class ProviderError(val error: OpenFeatureError) : OpenFeatureProviderEvents
+    object ProviderConfigurationChanged : OpenFeatureProviderEvents
+}

--- a/android/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
@@ -317,16 +317,18 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.shutdown()
         testScheduler.advanceUntilIdle()
 
-        assertEquals(
-            listOf(
-                OpenFeatureStatus.NotReady,
-                OpenFeatureStatus.Ready,
-                OpenFeatureStatus.NotReady,
-                OpenFeatureStatus.Ready,
-                OpenFeatureStatus.NotReady
-            ),
-            emittedStatuses
-        )
+        waitAssert {
+            assertEquals(
+                listOf(
+                    OpenFeatureStatus.NotReady,
+                    OpenFeatureStatus.Ready,
+                    OpenFeatureStatus.NotReady,
+                    OpenFeatureStatus.Ready,
+                    OpenFeatureStatus.NotReady
+                ),
+                emittedStatuses
+            )
+        }
         job.cancelAndJoin()
     }
 

--- a/android/src/test/java/dev/openfeature/sdk/FlagEvaluationsTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/FlagEvaluationsTests.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 class FlagEvaluationsTests {
 
     @After
-    fun tearDown() {
+    fun tearDown() = runTest {
         OpenFeatureAPI.shutdown()
     }
 

--- a/android/src/test/java/dev/openfeature/sdk/HookSpecTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/HookSpecTests.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class HookSpecTests {
 
     @After
-    fun tearDown() {
+    fun tearDown() = runTest {
         OpenFeatureAPI.shutdown()
     }
 

--- a/android/src/test/java/dev/openfeature/sdk/HookSupportTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/HookSupportTests.kt
@@ -2,13 +2,14 @@ package dev.openfeature.sdk
 
 import dev.openfeature.sdk.exceptions.OpenFeatureError.InvalidContextError
 import dev.openfeature.sdk.helpers.GenericSpyHookMock
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert
 import org.junit.Test
 
 class HookSupportTests {
     @After
-    fun tearDown() {
+    fun tearDown() = runTest {
         OpenFeatureAPI.shutdown()
     }
 

--- a/android/src/test/java/dev/openfeature/sdk/OpenFeatureClientTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/OpenFeatureClientTests.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class OpenFeatureClientTests {
 
     @After
-    fun tearDown() {
+    fun tearDown() = runTest {
         OpenFeatureAPI.shutdown()
     }
 

--- a/android/src/test/java/dev/openfeature/sdk/ProviderEventingTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/ProviderEventingTests.kt
@@ -1,0 +1,142 @@
+package dev.openfeature.sdk
+
+import dev.openfeature.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.sdk.exceptions.OpenFeatureError
+import dev.openfeature.sdk.helpers.DoSomethingProvider
+import dev.openfeature.sdk.helpers.OverlyEmittingProvider
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.toCollection
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ProviderEventingTests {
+
+    @Before
+    fun tearDown() = runTest {
+        OpenFeatureAPI.shutdown()
+    }
+
+    @Test
+    fun testProviderThatErrorsAndThenSendsConfigurationChanged() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val healDelayMillis = 1000L
+        val provider = object : DoSomethingProvider() {
+            val flow = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
+            override suspend fun initialize(initialContext: EvaluationContext?) {
+                // no-op
+            }
+
+            override suspend fun onContextSet(
+                oldContext: EvaluationContext?,
+                newContext: EvaluationContext
+            ) {
+                flow.emit(
+                    OpenFeatureProviderEvents.ProviderError(
+                        OpenFeatureError.ProviderNotReadyError(
+                            "test error"
+                        )
+                    )
+                )
+                delay(healDelayMillis)
+                flow.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged)
+            }
+
+            override fun observe(): Flow<OpenFeatureProviderEvents> = flow
+        }
+        val statusList = mutableListOf<OpenFeatureStatus>()
+        val j = async(testDispatcher) {
+            OpenFeatureAPI.statusFlow.toCollection(statusList)
+        }
+
+        OpenFeatureAPI.setProviderAndWait(
+            provider,
+            dispatcher = testDispatcher,
+            initialContext = ImmutableContext()
+        )
+        testScheduler.advanceUntilIdle()
+        waitAssert {
+            Assert.assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+        }
+        OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("new"))
+        testScheduler.advanceUntilIdle()
+        OpenFeatureAPI.shutdown()
+        testScheduler.advanceUntilIdle()
+        j.cancelAndJoin()
+        waitAssert {
+            Assert.assertEquals(5, statusList.size)
+        }
+        Assert.assertEquals(OpenFeatureStatus.Ready, statusList[0])
+        Assert.assertEquals(OpenFeatureStatus.Reconciling, statusList[1])
+        Assert.assertTrue(statusList[2] is OpenFeatureStatus.Error)
+        Assert.assertEquals(OpenFeatureStatus.Ready, statusList[3])
+        Assert.assertEquals(OpenFeatureStatus.NotReady, statusList[4])
+    }
+
+    @Test
+    fun testProviderEventFlowShouldSupportSwappingProviders() = runTest {
+        val firstProvider = OverlyEmittingProvider("First Provider")
+        val secondProvider = OverlyEmittingProvider("Second Provider")
+
+        val emittedEvents = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect {
+                emittedEvents.add(it)
+            }
+        }
+
+        // emits ProviderReady
+        OpenFeatureAPI.setProviderAndWait(
+            firstProvider,
+            initialContext = ImmutableContext("first")
+        )
+        // emits ProviderStale + ProviderConfigurationChanged
+        OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("first.v2"))
+        testScheduler.advanceUntilIdle()
+        Assert.assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady,
+                OpenFeatureProviderEvents.ProviderStale,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged
+            ),
+            emittedEvents
+        )
+        // emits ProviderReady
+        OpenFeatureAPI.setProviderAndWait(
+            secondProvider,
+            initialContext = ImmutableContext("second")
+        )
+        testScheduler.advanceUntilIdle()
+        // emits ProviderStale + ProviderStale + ProviderStale
+        OpenFeatureAPI.getClient().track("hello-world")
+        testScheduler.advanceUntilIdle()
+
+        // emits ProviderStale + ProviderConfigurationChanged
+        OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("second.v2"))
+        testScheduler.advanceUntilIdle()
+
+        OpenFeatureAPI.shutdown()
+        job.cancelAndJoin()
+        Assert.assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady,
+                OpenFeatureProviderEvents.ProviderStale,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged,
+                OpenFeatureProviderEvents.ProviderReady,
+                OpenFeatureProviderEvents.ProviderStale,
+                OpenFeatureProviderEvents.ProviderStale,
+                OpenFeatureProviderEvents.ProviderStale,
+                OpenFeatureProviderEvents.ProviderStale,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged
+            ),
+            emittedEvents
+        )
+    }
+}

--- a/android/src/test/java/dev/openfeature/sdk/StatusTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/StatusTests.kt
@@ -4,17 +4,20 @@ import dev.openfeature.sdk.helpers.BrokenInitProvider
 import dev.openfeature.sdk.helpers.DoSomethingProvider
 import junit.framework.Assert.assertEquals
 import junit.framework.Assert.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 class StatusTests {
 
-    @After
-    fun tearDown() {
-        // It becomes important to clear the provider after each test since the SDK is a singleton
+    @Before
+    fun tearDown() = runTest {
         OpenFeatureAPI.shutdown()
     }
 
@@ -60,12 +63,19 @@ class StatusTests {
             }
         }
         OpenFeatureAPI.setProviderAndWait(DoSomethingProvider())
+        testScheduler.advanceUntilIdle()
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("some value"))
         testScheduler.advanceUntilIdle()
-        assertEquals(4, statuses.size)
+        waitAssert {
+            assertEquals(4, statuses.size)
+        }
+
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("some other value"))
         testScheduler.advanceUntilIdle()
-        assertEquals(6, statuses.size)
+        waitAssert {
+            assertEquals(6, statuses.size)
+        }
+
         OpenFeatureAPI.shutdown()
         testScheduler.advanceUntilIdle()
         assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
@@ -83,5 +93,18 @@ class StatusTests {
             ),
             statuses
         )
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+suspend fun TestScope.waitAssert(function: () -> Unit) {
+    while (true) {
+        try {
+            function()
+            return
+        } catch (e: Throwable) {
+            delay(100)
+            advanceUntilIdle()
+        }
     }
 }

--- a/android/src/test/java/dev/openfeature/sdk/StatusTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/StatusTests.kt
@@ -78,8 +78,11 @@ class StatusTests {
 
         OpenFeatureAPI.shutdown()
         testScheduler.advanceUntilIdle()
-        assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+        waitAssert {
+            assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+        }
         job.cancelAndJoin()
+
         assertEquals(7, statuses.size)
         assertEquals(
             listOf(

--- a/android/src/test/java/dev/openfeature/sdk/TrackingProviderTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/TrackingProviderTests.kt
@@ -18,7 +18,7 @@ class TrackingProviderTests {
     }
 
     @After
-    fun tearDown() {
+    fun tearDown() = runTest {
         OpenFeatureAPI.shutdown()
     }
 

--- a/android/src/test/java/dev/openfeature/sdk/helpers/BrokenInitProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/BrokenInitProvider.kt
@@ -15,7 +15,7 @@ class BrokenInitProvider(
 ) :
     FeatureProvider {
     override suspend fun initialize(initialContext: EvaluationContext?) {
-        throw OpenFeatureError.ProviderNotReadyError("test error")
+        throw OpenFeatureError.ProviderNotReadyError("test error from $this")
     }
 
     override fun shutdown() {

--- a/android/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
@@ -6,16 +6,18 @@ import dev.openfeature.sdk.FeatureProvider
 import dev.openfeature.sdk.Hook
 import dev.openfeature.sdk.ProviderEvaluation
 import dev.openfeature.sdk.ProviderMetadata
+import dev.openfeature.sdk.TrackingEventDetails
 import dev.openfeature.sdk.Value
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import dev.openfeature.sdk.events.OpenFeatureProviderEvents
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 
-class DoSomethingProvider(
+open class DoSomethingProvider(
     override val hooks: List<Hook<*>> = listOf(),
-    override val metadata: ProviderMetadata = DoSomethingProviderMetadata(),
-    private var dispatcher: CoroutineDispatcher = Dispatchers.IO
+    override val metadata: ProviderMetadata = DoSomethingProviderMetadata()
 ) : FeatureProvider {
+    protected val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
     companion object {
         val evaluationMetadata = EvaluationMetadata.builder()
             .putString("key1", "value1")
@@ -25,6 +27,7 @@ class DoSomethingProvider(
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
         delay(1000)
+        events.emit(OpenFeatureProviderEvents.ProviderReady)
     }
 
     override fun shutdown() {
@@ -36,6 +39,7 @@ class DoSomethingProvider(
         newContext: EvaluationContext
     ) {
         delay(500)
+        events.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged)
     }
 
     override fun getBooleanEvaluation(
@@ -82,4 +86,33 @@ class DoSomethingProvider(
     }
 
     class DoSomethingProviderMetadata(override val name: String? = "something") : ProviderMetadata
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> {
+        return events
+    }
+}
+
+class OverlyEmittingProvider(name: String) : DoSomethingProvider(
+    metadata = object : ProviderMetadata {
+        override val name: String = name
+    }
+) {
+    override suspend fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) {
+        events.emit(OpenFeatureProviderEvents.ProviderStale)
+        events.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged)
+    }
+
+    override fun track(
+        trackingEventName: String,
+        context: EvaluationContext?,
+        details: TrackingEventDetails?
+    ) {
+        super.track(trackingEventName, context, details)
+        events.tryEmit(OpenFeatureProviderEvents.ProviderStale)
+        events.tryEmit(OpenFeatureProviderEvents.ProviderStale)
+        events.tryEmit(OpenFeatureProviderEvents.ProviderStale)
+    }
 }


### PR DESCRIPTION
This PR brings back and enhances the possibility for providers to emit events which will then be handled by the SDK to set the SDK status.