### PR TITLE
docs: add eventing section to read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Logging customization is not yet available in the Kotlin SDK.
 
 Support for named clients is not yet available in the Kotlin SDK.
 
+### Eventing
+
+Support for eventing is not yet available in the Kotlin SDK.
 
 ### Shutdown
 


### PR DESCRIPTION
This addresses a linting issue when pulling the readme into the docs.

Relates to https://github.com/open-feature/kotlin-sdk/pull/124
