### PR TITLE
test: fix flaky test

### DIFF
--- a/android/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
@@ -258,11 +258,9 @@ class DeveloperExperienceTests {
         waitAssert {
             assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
         }
-        testScheduler.advanceTimeBy(1)
         waitAssert {
-            assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+            assertTrue(OpenFeatureAPI.getStatus() is OpenFeatureStatus.Error)
         }
-        testScheduler.advanceTimeBy(healDelayMillis)
         waitAssert {
             assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
         }

--- a/android/src/test/java/dev/openfeature/sdk/StatusTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/StatusTests.kt
@@ -81,8 +81,6 @@ class StatusTests {
         waitAssert {
             assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
         }
-        job.cancelAndJoin()
-
         assertEquals(
             listOf(
                 OpenFeatureStatus.NotReady,
@@ -95,6 +93,7 @@ class StatusTests {
             ),
             statuses
         )
+        job.cancelAndJoin()
     }
 }
 


### PR DESCRIPTION
Fixing the test assertion and removing unnecessary schedule advances.
This manual test run shows the test suite is stable (50/50 runs) https://github.com/open-feature/kotlin-sdk/actions/runs/13660084832/job/38188994009.