### PR TITLE
fix: Immutability of context

### DIFF
--- a/android/api/android.api
+++ b/android/api/android.api
@@ -557,7 +557,8 @@ public final class dev/openfeature/sdk/Value$Integer : dev/openfeature/sdk/Value
 }
 
 public final class dev/openfeature/sdk/Value$List : dev/openfeature/sdk/Value {
-	public fun <init> (Ljava/util/List;)V
+	public static final field Companion Ldev/openfeature/sdk/Value$List$Companion;
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun asBoolean ()Ljava/lang/Boolean;
 	public fun asDate ()Ljava/util/Date;
 	public fun asDouble ()Ljava/lang/Double;
@@ -573,6 +574,10 @@ public final class dev/openfeature/sdk/Value$List : dev/openfeature/sdk/Value {
 	public fun hashCode ()I
 	public fun isNull ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$List$Companion {
+	public final fun invoke (Ljava/util/List;)Ldev/openfeature/sdk/Value$List;
 }
 
 public final class dev/openfeature/sdk/Value$Null : dev/openfeature/sdk/Value {
@@ -609,7 +614,8 @@ public final class dev/openfeature/sdk/Value$String : dev/openfeature/sdk/Value 
 }
 
 public final class dev/openfeature/sdk/Value$Structure : dev/openfeature/sdk/Value {
-	public fun <init> (Ljava/util/Map;)V
+	public static final field Companion Ldev/openfeature/sdk/Value$Structure$Companion;
+	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun asBoolean ()Ljava/lang/Boolean;
 	public fun asDate ()Ljava/util/Date;
 	public fun asDouble ()Ljava/lang/Double;
@@ -625,6 +631,10 @@ public final class dev/openfeature/sdk/Value$Structure : dev/openfeature/sdk/Val
 	public fun hashCode ()I
 	public fun isNull ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/sdk/Value$Structure$Companion {
+	public final fun invoke (Ljava/util/Map;)Ldev/openfeature/sdk/Value$Structure;
 }
 
 public abstract interface class dev/openfeature/sdk/events/OpenFeatureProviderEvents {

--- a/android/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
+++ b/android/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
@@ -4,7 +4,7 @@ class ImmutableContext(
     private val targetingKey: String = "",
     attributes: Map<String, Value> = mapOf()
 ) : EvaluationContext {
-    private val structure: ImmutableStructure = ImmutableStructure(attributes)
+    private val structure: ImmutableStructure = ImmutableStructure(attributes.toMap())
     override fun getTargetingKey(): String {
         return targetingKey
     }

--- a/android/src/main/java/dev/openfeature/sdk/ImmutableStructure.kt
+++ b/android/src/main/java/dev/openfeature/sdk/ImmutableStructure.kt
@@ -1,6 +1,8 @@
 package dev.openfeature.sdk
 
-class ImmutableStructure(private val attributes: Map<String, Value> = mapOf()) : Structure {
+class ImmutableStructure(attributes: Map<String, Value> = mapOf()) : Structure {
+    private val attributes: Map<String, Value> = attributes.toMap()
+
     constructor(vararg pairs: Pair<String, Value>) : this(pairs.toMap())
 
     override fun keySet(): Set<String> {
@@ -12,22 +14,22 @@ class ImmutableStructure(private val attributes: Map<String, Value> = mapOf()) :
     }
 
     override fun asMap(): Map<String, Value> {
-        return attributes
+        return attributes.toMap()
     }
 
     override fun asObjectMap(): Map<String, Any?> {
-        return attributes.mapValues { convertValue(it.value) }
+        return attributes.mapValues { convertValue(it.value) }.toMap()
     }
 
     private fun convertValue(value: Value): Any? {
         return when (value) {
-            is Value.List -> value.list.map { t -> convertValue(t) }
-            is Value.Structure -> value.structure.mapValues { t -> convertValue(t.value) }
+            is Value.List -> value.list.map { t -> convertValue(t) }.toList()
+            is Value.Structure -> value.structure.mapValues { t -> convertValue(t.value) }.toMap()
             is Value.Null -> return null
             is Value.String -> value.asString()
             is Value.Boolean -> value.asBoolean()
             is Value.Integer -> value.asInteger()
-            is Value.Date -> value.asDate()
+            is Value.Date -> value.asDate()?.clone()
             is Value.Double -> value.asDouble()
         }
     }

--- a/android/src/test/java/dev/openfeature/sdk/DeepCopyTest.kt
+++ b/android/src/test/java/dev/openfeature/sdk/DeepCopyTest.kt
@@ -1,0 +1,54 @@
+package dev.openfeature.sdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DeepCopyTest {
+
+    @Test
+    fun testDeepCopyOfStructure() {
+        val nestedMap = mutableMapOf<String, Value>()
+        nestedMap["key1"] = Value.String("value1")
+
+        val structure = Value.Structure(nestedMap)
+
+        nestedMap["key1"] = Value.String("modified")
+        nestedMap["key2"] = Value.Integer(42)
+
+        assertEquals("value1", structure.structure["key1"]?.asString())
+        assertNull(structure.structure["key2"])
+    }
+
+    @Test
+    fun testDeepCopyOfList() {
+        val nestedList = mutableListOf<Value>()
+        nestedList.add(Value.String("item1"))
+
+        val list = Value.List(nestedList)
+
+        nestedList[0] = Value.String("modified")
+        nestedList.add(Value.Integer(42))
+
+        assertEquals("item1", list.list[0]?.asString())
+        assertEquals(1, list.list.size)
+    }
+
+    @Test
+    fun testDeepCopyOfNestedStructures() {
+        val innerMap = mutableMapOf<String, Value>()
+        innerMap["innerKey"] = Value.String("innerValue")
+
+        val outerMap = mutableMapOf<String, Value>()
+        outerMap["outerKey"] = Value.Structure(innerMap)
+
+        val structure = Value.Structure(outerMap)
+
+        innerMap["innerKey"] = Value.String("modified")
+        innerMap["newKey"] = Value.Integer(123)
+
+        val outerStructure = structure.structure["outerKey"]?.asStructure()
+        assertEquals("innerValue", outerStructure?.get("innerKey")?.asString())
+        assertNull(outerStructure?.get("newKey"))
+    }
+}

--- a/android/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
@@ -167,4 +167,23 @@ class EvalContextTests {
 
         Assert.assertEquals(ctx1, ctx2)
     }
+
+    @Test
+    fun testContextIsTrulyImmutable() {
+        val mutableAttributes = mutableMapOf("key1" to Value.String("value1"), "key2" to Value.Integer(42))
+        val context = ImmutableContext("targetingKey", mutableAttributes)
+
+        // Verify initial state
+        Assert.assertEquals("value1", context.getValue("key1")?.asString())
+        Assert.assertEquals(42, context.getValue("key2")?.asInteger())
+
+        // Modify the original mutable map
+        mutableAttributes["key1"] = Value.String("modified")
+        mutableAttributes["key3"] = Value.Boolean(true)
+
+        // Verify that the context is not affected by the modifications
+        Assert.assertEquals("value1", context.getValue("key1")?.asString())
+        Assert.assertEquals(42, context.getValue("key2")?.asInteger())
+        Assert.assertNull(context.getValue("key3"))
+    }
 }

--- a/android/src/test/java/dev/openfeature/sdk/ImmutableContextTest.kt
+++ b/android/src/test/java/dev/openfeature/sdk/ImmutableContextTest.kt
@@ -1,0 +1,77 @@
+package dev.openfeature.sdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ImmutableContextTest {
+
+    @Test
+    fun `should be immutable - modifications to input map should not affect context`() {
+        val mutableAttributes = mutableMapOf("key1" to Value.String("value1"), "key2" to Value.Integer(42))
+
+        val context = ImmutableContext("targetingKey", mutableAttributes)
+
+        assertEquals("value1", context.getValue("key1")?.asString())
+        assertEquals(42, context.getValue("key2")?.asInteger())
+
+        // Modify the original mutable map
+        mutableAttributes["key1"] = Value.String("modified")
+        mutableAttributes["key3"] = Value.Boolean(true)
+
+        // Verify that the context is not affected by the modifications
+        assertEquals("value1", context.getValue("key1")?.asString())
+        assertEquals(42, context.getValue("key2")?.asInteger())
+        assertNull(context.getValue("key3"))
+    }
+
+    @Test
+    fun `should be immutable - modifications to returned map should not affect context`() {
+        val attributes = mapOf("key1" to Value.String("value1"))
+        val context = ImmutableContext("targetingKey", attributes)
+
+        val returnedMap = context.asMap()
+        try {
+            if (returnedMap is MutableMap) {
+                returnedMap["key2"] = Value.String("newValue")
+                fail("Returned map should be immutable")
+            }
+        } catch (_: UnsupportedOperationException) {
+        }
+
+        assertEquals("value1", context.getValue("key1")?.asString())
+        assertNull(context.getValue("key2"))
+    }
+
+    @Test
+    fun `should be immutable - nested structures should be immutable`() {
+        val nestedMap = mutableMapOf("nestedKey" to Value.String("nestedValue"))
+        val attributes = mapOf("key1" to Value.Structure(nestedMap))
+        val context = ImmutableContext("targetingKey", attributes)
+
+        nestedMap["nestedKey"] = Value.String("modified")
+        nestedMap["newNestedKey"] = Value.String("newValue")
+
+        val contextNestedStructure = context.getValue("key1")?.asStructure()
+
+        assertEquals("nestedValue", contextNestedStructure?.get("nestedKey")?.asString())
+        assertNull(contextNestedStructure?.get("newNestedKey"))
+    }
+
+    @Test
+    fun `should be immutable - nested lists should be immutable`() {
+        val nestedList = mutableListOf(Value.String("item1"), Value.Integer(42))
+        val attributes = mapOf("key1" to Value.List(nestedList))
+        val context = ImmutableContext("targetingKey", attributes)
+
+        nestedList[0] = Value.String("modified")
+        nestedList.add(Value.Boolean(true))
+
+        val contextNestedList = context.getValue("key1")?.asList()
+
+        assertEquals("item1", contextNestedList?.get(0)?.asString())
+        assertEquals(42, contextNestedList?.get(1)?.asInteger())
+        assertEquals(2, contextNestedList?.size)
+    }
+}

--- a/android/src/test/java/dev/openfeature/sdk/StructureTests.kt
+++ b/android/src/test/java/dev/openfeature/sdk/StructureTests.kt
@@ -18,7 +18,12 @@ class StructureTests {
         val structure = ImmutableStructure(map)
 
         Assert.assertEquals("test", structure.getValue("key")?.asString())
-        Assert.assertEquals(map, structure.asMap())
+        // The structure should contain the same content as the input map, but not necessarily the same map reference
+        Assert.assertEquals(map.toMap(), structure.asMap())
+
+        // Verify that modifying the original map doesn't affect the structure
+        map["key"] = Value.String("modified")
+        Assert.assertEquals("test", structure.getValue("key")?.asString())
     }
 
     @Test
@@ -55,5 +60,13 @@ class StructureTests {
         val structure2 = ImmutableStructure(map2)
 
         Assert.assertEquals(structure1, structure2)
+
+        // Verify that modifying the original maps doesn't affect the structures
+        map["key"] = Value.String("modified1")
+        map2["key"] = Value.String("modified2")
+
+        Assert.assertEquals(structure1, structure2)
+        Assert.assertEquals("test", structure1.getValue("key")?.asString())
+        Assert.assertEquals("test", structure2.getValue("key")?.asString())
     }
 }

--- a/android/src/test/java/dev/openfeature/sdk/helpers/SpyProvider.kt
+++ b/android/src/test/java/dev/openfeature/sdk/helpers/SpyProvider.kt
@@ -1,0 +1,73 @@
+package dev.openfeature.sdk.helpers
+
+import dev.openfeature.sdk.EvaluationContext
+import dev.openfeature.sdk.FeatureProvider
+import dev.openfeature.sdk.Hook
+import dev.openfeature.sdk.ProviderEvaluation
+import dev.openfeature.sdk.ProviderMetadata
+import dev.openfeature.sdk.Value
+
+class SpyProvider : FeatureProvider {
+    override val hooks: List<Hook<*>>
+        get() = TODO("Not yet implemented")
+    override val metadata: ProviderMetadata
+        get() = TODO("Not yet implemented")
+
+    val initializeCalls = mutableListOf<EvaluationContext?>()
+    val onContextSetCalls = mutableListOf<Pair<EvaluationContext?, EvaluationContext>>()
+
+    override suspend fun initialize(initialContext: EvaluationContext?) {
+        initializeCalls.add(initialContext)
+    }
+
+    override fun shutdown() {
+        // no-op
+    }
+
+    override suspend fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) {
+        onContextSetCalls.add(Pair(oldContext, newContext))
+    }
+
+    override fun getBooleanEvaluation(
+        key: String,
+        defaultValue: Boolean,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Boolean> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStringEvaluation(
+        key: String,
+        defaultValue: String,
+        context: EvaluationContext?
+    ): ProviderEvaluation<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getIntegerEvaluation(
+        key: String,
+        defaultValue: Int,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Int> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDoubleEvaluation(
+        key: String,
+        defaultValue: Double,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Double> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getObjectEvaluation(
+        key: String,
+        defaultValue: Value,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Value> {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
### Problem
The ImmutableContext class was accepting mutable maps in its constructor, allowing callers to modify the original map after instantiation, which would affect the "immutable" context. This violated the immutability guarantee and could lead to unexpected behavior.

### Solution
Implemented comprehensive deep immutability through defensive copying at all levels

### Related Issues
Fixes #150

### Notes
This change is backwards compatible at the API level. However if an integration was performing collection mutation for collections used in a context object, the behavior might now change.