### PR TITLE
fix: fix publication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,11 @@ plugins {
     id("com.android.application").version("8.10.0").apply(false)
     id("org.jetbrains.kotlin.multiplatform").version("2.1.21").apply(false)
     id("org.jetbrains.kotlin.plugin.compose").version("2.1.0").apply(false)
+    id("org.jetbrains.dokka").version("2.0.0").apply(false)
     id("org.jlleitschuh.gradle.ktlint").version("11.6.1").apply(true)
     id("io.github.gradle-nexus.publish-plugin").version("2.0.0").apply(true)
     id("org.jetbrains.kotlinx.binary-compatibility-validator").version("0.17.0").apply(false)
+    id("com.vanniktech.maven.publish").version("0.34.0").apply(false)
 }
 allprojects {
     extra["groupId"] = "dev.openfeature"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Enable the v2 syntax of the Dokka Gradle Plugin
+# https://kotlinlang.org/docs/dokka-migration.html
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/kotlin-sdk/build.gradle.kts
+++ b/kotlin-sdk/build.gradle.kts
@@ -1,11 +1,16 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.dokka")
     id("maven-publish")
     id("signing")
     id("org.jlleitschuh.gradle.ktlint")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
+    id("com.vanniktech.maven.publish")
 }
 
 val releaseVersion = project.extra["version"].toString()
@@ -74,57 +79,73 @@ android {
     }
 }
 
-publishing {
-    publications {
-        withType(MavenPublication::class) {
-            pom {
-                name.set("OpenFeature Kotlin SDK")
-                description.set(
-                    "This is the Kotlin implementation of OpenFeature, a vendor-agnostic abstraction library for evaluating feature flags."
-                )
-                url.set("https://openfeature.dev")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("vahidlazio")
-                        name.set("Vahid Torkaman")
-                        email.set("vahidt@spotify.com")
-                    }
-                    developer {
-                        id.set("fabriziodemaria")
-                        name.set("Fabrizio Demaria")
-                        email.set("fdema@spotify.com")
-                    }
-                    developer {
-                        id.set("nicklasl")
-                        name.set("Nicklas Lundin")
-                        email.set("nicklasl@spotify.com")
-                    }
-                    developer {
-                        id.set("nickybondarenko")
-                        name.set("Nicky Bondarenko")
-                        email.set("nickyb@spotify.com")
-                    }
-                }
-                scm {
-                    connection.set(
-                        "scm:git:https://github.com/open-feature/kotlin-sdk.git"
-                    )
-                    developerConnection.set(
-                        "scm:git:ssh://open-feature/kotlin-sdk.git"
-                    )
-                    url.set("https://github.com/open-feature/kotlin-sdk")
-                }
-            }
+// Configure Dokka for documentation
+dokka {
+    dokkaPublications.html {
+        suppressInheritedMembers.set(true)
+        failOnWarning.set(true)
+    }
+    dokkaSourceSets.commonMain {
+        sourceLink {
+            localDirectory.set(file("src/"))
+            remoteUrl("https://github.com/open-feature/kotlin-sdk/tree/main/kotlin-sdk/src")
+            remoteLineSuffix.set("#L")
         }
     }
 }
 
-signing {
-    sign(publishing.publications)
+mavenPublishing {
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+            sourcesJar = true,
+            androidVariantsToPublish = listOf("release")
+        )
+    )
+    signAllPublications()
+
+    pom {
+        name.set("OpenFeature Kotlin SDK")
+        description.set(
+            "This is the Kotlin implementation of OpenFeature, a vendor-agnostic abstraction library for evaluating feature flags."
+        )
+        url.set("https://openfeature.dev")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                id.set("vahidlazio")
+                name.set("Vahid Torkaman")
+                email.set("vahidt@spotify.com")
+            }
+            developer {
+                id.set("fabriziodemaria")
+                name.set("Fabrizio Demaria")
+                email.set("fdema@spotify.com")
+            }
+            developer {
+                id.set("nicklasl")
+                name.set("Nicklas Lundin")
+                email.set("nicklasl@spotify.com")
+            }
+            developer {
+                id.set("nickybondarenko")
+                name.set("Nicky Bondarenko")
+                email.set("nickyb@spotify.com")
+            }
+        }
+        scm {
+            connection.set(
+                "scm:git:https://github.com/open-feature/kotlin-sdk.git"
+            )
+            developerConnection.set(
+                "scm:git:ssh://open-feature/kotlin-sdk.git"
+            )
+            url.set("https://github.com/open-feature/kotlin-sdk")
+        }
+    }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Fixes the publication errors:

```
> Task :kotlin-sdk:publishReleasePublicationToSonatypeRepository
Multiple publications with coordinates 'dev.openfeature:kotlin-sdk:0.6.1' are published to repository 'sonatype'. The publications 'kotlinMultiplatform' in project ':kotlin-sdk' and 'release' in project ':kotlin-sdk' will overwrite each other!
> Task :kotlin-sdk:publishToSonatype
FAILURE: Build failed with an exception.
> Task :closeSonatypeStagingRepository FAILED
* What went wrong:
Execution failed for task ':closeSonatypeStagingRepository'.
> Failed to close staging repository, server at https://ossrh-staging-api.central.sonatype.com/service/local/ responded with status code 400, body: Failed to process request: Deployment reached an unexpected status: Failed
  pkg:maven/dev.openfeature/kotlin-sdk-jvm@0.6.1
  - Javadocs must be provided but not found in entries
  - Missing signature for file: kotlin-sdk-jvm-0.6.1.module
  - Missing signature for file: kotlin-sdk-jvm-0.6.1.pom
  - Missing signature for file: kotlin-sdk-jvm-0.6.1-sources.jar
  - Missing signature for file: kotlin-sdk-jvm-0.6.1.jar
  - Project name is missing
  - Project description is missing
  - Project URL is not defined
  - License information is missing
  - SCM URL is not defined
  - Developers information is missing
  pkg:maven/dev.openfeature/kotlin-sdk-js@0.6.1?type=klib
  - Missing signature for file: kotlin-sdk-js-0.6.1.module
  - Missing signature for file: kotlin-sdk-js-0.6.1-sources.jar
  - Missing signature for file: kotlin-sdk-js-0.6.1.klib
  - Missing signature for file: kotlin-sdk-js-0.6.1.pom
  pkg:maven/dev.openfeature/kotlin-sdk-js@0.6.1
  - Project name is missing
  - Project description is missing
  - Project URL is not defined
  - License information is missing
  - SCM URL is not defined
  - Developers information is missing
  pkg:maven/dev.openfeature/kotlin-sdk@0.6.1?type=aar
  - Missing signature for file: kotlin-sdk-0.6.1.jar
  - Missing signature for file: kotlin-sdk-0.6.1-kotlin-tooling-metadata.json
  pkg:maven/dev.openfeature/kotlin-sdk-linuxx64@0.6.1?type=klib
  - Missing signature for file: kotlin-sdk-linuxx64-0.6.1.klib
  - Missing signature for file: kotlin-sdk-linuxx64-0.6.1-sources.jar
  - Missing signature for file: kotlin-sdk-linuxx64-0.6.1.module
  - Missing signature for file: kotlin-sdk-linuxx64-0.6.1.pom
  pkg:maven/dev.openfeature/kotlin-sdk-linuxx64@0.6.1
  - Project name is missing
  - Project description is missing
  - Project URL is not defined
  - License information is missing
  - SCM URL is not defined
  - Developers information is missing
* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org/.
* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':closeSonatypeStagingRepository'.
```

### Notes

I have set up [Dokka](https://kotlinlang.org/docs/dokka-introduction.html) to generate docs in the typical Kotlin template. I've decided to adopt the recently released alpha [v2 config syntax](https://kotlinlang.org/docs/dokka-migration.html), because v1 will eventually be deprecated.

For packaging the Dokka HTML output as an old-school javadoc jar I've made use of the popular [Gradle Maven Publish Plugin by vanniktech](https://vanniktech.github.io/gradle-maven-publish-plugin/), which is used by [Ktor](https://github.com/ktorio/ktor/pull/4942/files) and [OkHttp](https://github.com/square/okhttp/blob/363d3e788f497dbee0a2bb9762e69f85c4f79d16/okhttp/build.gradle.kts#L15) just two mention two popular ones.

### How to test

#### Dokka

Execute

```bash
./gradlew dokkaGeneratePublicationHtml
```

It will place the generated docs in `kotlin-sdk/build/dokka`. You can also double check that the `(source)` links point to the right GitHub URLs.

#### Local publication

If you have the code signing locally configured, you can execute `./gradlew publishToMavenLocal`. This will place the generated files under `/home/bence/.m2/repository/dev/openfeature/`.

(If you don't have code signing, comment out `signAllPublications()` in `kotlin-sdk/build.gradle.kts`)

For me it generated the following files, hopefully everything that is required by the Sonatype repository:

```
./kotlin-sdk
./kotlin-sdk/0.6.1
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1.pom.asc
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1.jar.asc
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1.pom
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1.module
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1.jar
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1-sources.jar
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1-javadoc.jar.asc
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1.module.asc
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1-sources.jar.asc
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1-kotlin-tooling-metadata.json
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1-javadoc.jar
./kotlin-sdk/0.6.1/kotlin-sdk-0.6.1-kotlin-tooling-metadata.json.asc
./kotlin-sdk/maven-metadata-local.xml
./kotlin-sdk-js
./kotlin-sdk-js/0.6.1
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1.pom.asc
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1.klib
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1-javadoc.jar
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1.module.asc
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1-sources.jar.asc
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1.module
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1.pom
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1-sources.jar
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1.klib.asc
./kotlin-sdk-js/0.6.1/kotlin-sdk-js-0.6.1-javadoc.jar.asc
./kotlin-sdk-js/maven-metadata-local.xml
./kotlin-sdk-linuxx64
./kotlin-sdk-linuxx64/0.6.1
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1.module.asc
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1.module
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1.pom.asc
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1-sources.jar
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1.pom
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1-sources.jar.asc
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1.klib.asc
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1.klib
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1-javadoc.jar
./kotlin-sdk-linuxx64/0.6.1/kotlin-sdk-linuxx64-0.6.1-javadoc.jar.asc
./kotlin-sdk-linuxx64/maven-metadata-local.xml
./kotlin-sdk-android
./kotlin-sdk-android/0.6.1
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1-javadoc.jar.asc
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1.pom.asc
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1-sources.jar.asc
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1-sources.jar
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1-javadoc.jar
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1.module
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1.aar.asc
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1.pom
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1.module.asc
./kotlin-sdk-android/0.6.1/kotlin-sdk-android-0.6.1.aar
./kotlin-sdk-android/maven-metadata-local.xml
./kotlin-sdk-jvm
./kotlin-sdk-jvm/0.6.1
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1.module
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1.jar.asc
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1-javadoc.jar.asc
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1.jar
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1.pom
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1-javadoc.jar
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1-sources.jar
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1.module.asc
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1.pom.asc
./kotlin-sdk-jvm/0.6.1/kotlin-sdk-jvm-0.6.1-sources.jar.asc
./kotlin-sdk-jvm/maven-metadata-local.xml
```

If you extract the javadoc jars, they should contain the html docs.