### PR TITLE
feat: Add LoggingHook for evaluation logging

### DIFF
--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -276,7 +276,6 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public static synthetic fun getClient$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/Client;
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
-	public final fun getLogger ()Ldev/openfeature/kotlin/sdk/logging/Logger;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
@@ -285,7 +284,6 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun setLogger (Ldev/openfeature/kotlin/sdk/logging/Logger;)V
 	public final fun setProvider (Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public static synthetic fun setProvider$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;ILjava/lang/Object;)V
 	public final fun setProviderAndWait (Ldev/openfeature/kotlin/sdk/FeatureProvider;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -814,8 +812,8 @@ public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook : dev/openfeatur
 	public static final field Companion Ldev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion;
 	public static final field HINT_LOG_EVALUATION_CONTEXT Ljava/lang/String;
 	public fun <init> ()V
-	public fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;Z)V
-	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZLdev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZLdev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun after (Ldev/openfeature/kotlin/sdk/HookContext;Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
 	public fun before (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/util/Map;)V
 	public fun error (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/lang/Exception;Ljava/util/Map;)V
@@ -824,6 +822,16 @@ public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook : dev/openfeatur
 }
 
 public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion {
+}
+
+public final class dev/openfeature/kotlin/sdk/logging/LogLevel : java/lang/Enum {
+	public static final field DEBUG Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static final field ERROR Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static final field INFO Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static final field WARN Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static fun values ()[Ldev/openfeature/kotlin/sdk/logging/LogLevel;
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/logging/Logger {

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -276,6 +276,7 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public static synthetic fun getClient$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/Client;
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
+	public final fun getLogger ()Ldev/openfeature/kotlin/sdk/logging/Logger;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
@@ -284,6 +285,7 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setLogger (Ldev/openfeature/kotlin/sdk/logging/Logger;)V
 	public final fun setProvider (Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public static synthetic fun setProvider$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;ILjava/lang/Object;)V
 	public final fun setProviderAndWait (Ldev/openfeature/kotlin/sdk/FeatureProvider;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -806,6 +808,22 @@ public final class dev/openfeature/kotlin/sdk/exceptions/OpenFeatureError$TypeMi
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun errorCode ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook : dev/openfeature/kotlin/sdk/Hook {
+	public static final field Companion Ldev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion;
+	public static final field HINT_LOG_EVALUATION_CONTEXT Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;Z)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun after (Ldev/openfeature/kotlin/sdk/HookContext;Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
+	public fun before (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/util/Map;)V
+	public fun error (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/lang/Exception;Ljava/util/Map;)V
+	public fun finallyAfter (Ldev/openfeature/kotlin/sdk/HookContext;Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
+	public fun supportsFlagValueType (Ldev/openfeature/kotlin/sdk/FlagValueType;)Z
+}
+
+public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion {
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/logging/Logger {

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -276,7 +276,6 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public static synthetic fun getClient$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/Client;
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
-	public final fun getLogger ()Ldev/openfeature/kotlin/sdk/logging/Logger;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
@@ -285,7 +284,6 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun setLogger (Ldev/openfeature/kotlin/sdk/logging/Logger;)V
 	public final fun setProvider (Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public static synthetic fun setProvider$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;ILjava/lang/Object;)V
 	public final fun setProviderAndWait (Ldev/openfeature/kotlin/sdk/FeatureProvider;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -814,8 +812,8 @@ public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook : dev/openfeatur
 	public static final field Companion Ldev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion;
 	public static final field HINT_LOG_EVALUATION_CONTEXT Ljava/lang/String;
 	public fun <init> ()V
-	public fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;Z)V
-	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZLdev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZLdev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;Ldev/openfeature/kotlin/sdk/logging/LogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun after (Ldev/openfeature/kotlin/sdk/HookContext;Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
 	public fun before (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/util/Map;)V
 	public fun error (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/lang/Exception;Ljava/util/Map;)V
@@ -824,6 +822,16 @@ public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook : dev/openfeatur
 }
 
 public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion {
+}
+
+public final class dev/openfeature/kotlin/sdk/logging/LogLevel : java/lang/Enum {
+	public static final field DEBUG Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static final field ERROR Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static final field INFO Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static final field WARN Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/logging/LogLevel;
+	public static fun values ()[Ldev/openfeature/kotlin/sdk/logging/LogLevel;
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/logging/Logger {

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -276,6 +276,7 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public static synthetic fun getClient$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/Client;
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
+	public final fun getLogger ()Ldev/openfeature/kotlin/sdk/logging/Logger;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
@@ -284,6 +285,7 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureAPI {
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setLogger (Ldev/openfeature/kotlin/sdk/logging/Logger;)V
 	public final fun setProvider (Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public static synthetic fun setProvider$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPI;Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;ILjava/lang/Object;)V
 	public final fun setProviderAndWait (Ldev/openfeature/kotlin/sdk/FeatureProvider;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -806,6 +808,22 @@ public final class dev/openfeature/kotlin/sdk/exceptions/OpenFeatureError$TypeMi
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun errorCode ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook : dev/openfeature/kotlin/sdk/Hook {
+	public static final field Companion Ldev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion;
+	public static final field HINT_LOG_EVALUATION_CONTEXT Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;Z)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/logging/Logger;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun after (Ldev/openfeature/kotlin/sdk/HookContext;Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
+	public fun before (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/util/Map;)V
+	public fun error (Ldev/openfeature/kotlin/sdk/HookContext;Ljava/lang/Exception;Ljava/util/Map;)V
+	public fun finallyAfter (Ldev/openfeature/kotlin/sdk/HookContext;Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;Ljava/util/Map;)V
+	public fun supportsFlagValueType (Ldev/openfeature/kotlin/sdk/FlagValueType;)Z
+}
+
+public final class dev/openfeature/kotlin/sdk/hooks/LoggingHook$Companion {
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/logging/Logger {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPI.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPI.kt
@@ -3,6 +3,8 @@ package dev.openfeature.kotlin.sdk
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.logging.Logger
+import dev.openfeature.kotlin.sdk.logging.NoOpLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -43,6 +45,24 @@ object OpenFeatureAPI {
 
     var hooks: List<Hook<*>> = listOf()
         private set
+
+    /**
+     * The logger used by the SDK. Can be set to customize logging behavior.
+     * Defaults to NoOpLogger which discards all log messages.
+     * Access with OpenFeatureAPI.logger, set with OpenFeatureAPI.setLogger().
+     */
+    var logger: Logger = NoOpLogger()
+        private set
+
+    /**
+     * Set the logger for the SDK.
+     * This logger will be used for internal SDK logging and can be accessed by custom hooks.
+     *
+     * @param logger the logger to set
+     */
+    fun setLogger(logger: Logger) {
+        this.logger = logger
+    }
 
     /**
      * Set the [FeatureProvider] for the SDK. This method will return immediately and initialize the provider in a coroutine scope

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPI.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPI.kt
@@ -3,8 +3,6 @@ package dev.openfeature.kotlin.sdk
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
-import dev.openfeature.kotlin.sdk.logging.Logger
-import dev.openfeature.kotlin.sdk.logging.NoOpLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -45,24 +43,6 @@ object OpenFeatureAPI {
 
     var hooks: List<Hook<*>> = listOf()
         private set
-
-    /**
-     * The logger used by the SDK. Can be set to customize logging behavior.
-     * Defaults to NoOpLogger which discards all log messages.
-     * Access with OpenFeatureAPI.logger, set with OpenFeatureAPI.setLogger().
-     */
-    var logger: Logger = NoOpLogger()
-        private set
-
-    /**
-     * Set the logger for the SDK.
-     * This logger will be used for internal SDK logging and can be accessed by custom hooks.
-     *
-     * @param logger the logger to set
-     */
-    fun setLogger(logger: Logger) {
-        this.logger = logger
-    }
 
     /**
      * Set the [FeatureProvider] for the SDK. This method will return immediately and initialize the provider in a coroutine scope

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
@@ -7,6 +7,7 @@ import dev.openfeature.kotlin.sdk.FlagEvaluationDetails
 import dev.openfeature.kotlin.sdk.Hook
 import dev.openfeature.kotlin.sdk.HookContext
 import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.logging.LogLevel
 import dev.openfeature.kotlin.sdk.logging.Logger
 import dev.openfeature.kotlin.sdk.logging.NoOpLogger
 import kotlin.time.ExperimentalTime
@@ -15,17 +16,25 @@ import kotlin.time.ExperimentalTime
  * A hook that logs detailed information during flag evaluation lifecycle.
  *
  * Logs at different stages:
- * - Before: Flag evaluation request (debug level)
- * - After: Successful evaluation with result (debug level)
- * - Error: Errors during evaluation (error level)
- * - Finally: Completion status (debug level)
+ * - Before: Flag evaluation request
+ * - After: Successful evaluation with result
+ * - Error: Errors during evaluation
+ * - Finally: Completion status
  *
  * @param logger The logger to use. Defaults to NoOpLogger.
  * @param logEvaluationContext If true, includes evaluation context in logs (default: false for privacy)
+ * @param beforeLogLevel Log level for the before stage (default: DEBUG)
+ * @param afterLogLevel Log level for the after stage (default: DEBUG)
+ * @param errorLogLevel Log level for the error stage (default: ERROR)
+ * @param finallyLogLevel Log level for the finallyAfter stage (default: DEBUG)
  */
 class LoggingHook<T>(
     private val logger: Logger = NoOpLogger(),
-    private val logEvaluationContext: Boolean = false
+    private val logEvaluationContext: Boolean = false,
+    private val beforeLogLevel: LogLevel = LogLevel.DEBUG,
+    private val afterLogLevel: LogLevel = LogLevel.DEBUG,
+    private val errorLogLevel: LogLevel = LogLevel.ERROR,
+    private val finallyLogLevel: LogLevel = LogLevel.DEBUG
 ) : Hook<T> {
 
     companion object {
@@ -54,7 +63,7 @@ class LoggingHook<T>(
             }
         }
 
-        logger.debug { message }
+        logAtLevel(beforeLogLevel) { message }
     }
 
     override fun after(ctx: HookContext<T>, details: FlagEvaluationDetails<T>, hints: Map<String, Any>) {
@@ -77,7 +86,7 @@ class LoggingHook<T>(
             append(", provider='${ctx.providerMetadata.name}'")
         }
 
-        logger.debug { message }
+        logAtLevel(afterLogLevel) { message }
     }
 
     override fun error(ctx: HookContext<T>, error: Exception, hints: Map<String, Any>) {
@@ -96,7 +105,7 @@ class LoggingHook<T>(
             append("error='${error.message?.replace("'", "''")}'")
         }
 
-        logger.error(error) { message }
+        logAtLevel(errorLogLevel, error) { message }
     }
 
     override fun finallyAfter(ctx: HookContext<T>, details: FlagEvaluationDetails<T>, hints: Map<String, Any>) {
@@ -111,7 +120,16 @@ class LoggingHook<T>(
             }
         }
 
-        logger.debug { message }
+        logAtLevel(finallyLogLevel) { message }
+    }
+
+    private fun logAtLevel(level: LogLevel, throwable: Throwable? = null, message: () -> String) {
+        when (level) {
+            LogLevel.DEBUG -> logger.debug(throwable, message)
+            LogLevel.INFO -> logger.info(throwable, message)
+            LogLevel.WARN -> logger.warn(throwable, message)
+            LogLevel.ERROR -> logger.error(throwable, message)
+        }
     }
 
     private fun formatContext(context: EvaluationContext): String {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalTime::class)
-
 package dev.openfeature.kotlin.sdk.hooks
 
 import dev.openfeature.kotlin.sdk.EvaluationContext
@@ -28,14 +26,14 @@ import kotlin.time.ExperimentalTime
  * @param errorLogLevel Log level for the error stage (default: ERROR)
  * @param finallyLogLevel Log level for the finallyAfter stage (default: DEBUG)
  */
-class LoggingHook<T>(
+class LoggingHook(
     private val logger: Logger = NoOpLogger(),
     private val logEvaluationContext: Boolean = false,
     private val beforeLogLevel: LogLevel = LogLevel.DEBUG,
     private val afterLogLevel: LogLevel = LogLevel.DEBUG,
     private val errorLogLevel: LogLevel = LogLevel.ERROR,
     private val finallyLogLevel: LogLevel = LogLevel.DEBUG
-) : Hook<T> {
+) : Hook<Any> {
 
     companion object {
         /**
@@ -45,7 +43,7 @@ class LoggingHook<T>(
         const val HINT_LOG_EVALUATION_CONTEXT = "logEvaluationContext"
     }
 
-    override fun before(ctx: HookContext<T>, hints: Map<String, Any>) {
+    override fun before(ctx: HookContext<Any>, hints: Map<String, Any>) {
         val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
 
         val message = buildString {
@@ -66,7 +64,7 @@ class LoggingHook<T>(
         logAtLevel(beforeLogLevel) { message }
     }
 
-    override fun after(ctx: HookContext<T>, details: FlagEvaluationDetails<T>, hints: Map<String, Any>) {
+    override fun after(ctx: HookContext<Any>, details: FlagEvaluationDetails<Any>, hints: Map<String, Any>) {
         val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
 
         val message = buildString {
@@ -89,7 +87,7 @@ class LoggingHook<T>(
         logAtLevel(afterLogLevel) { message }
     }
 
-    override fun error(ctx: HookContext<T>, error: Exception, hints: Map<String, Any>) {
+    override fun error(ctx: HookContext<Any>, error: Exception, hints: Map<String, Any>) {
         val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
 
         val message = buildString {
@@ -108,7 +106,7 @@ class LoggingHook<T>(
         logAtLevel(errorLogLevel, error) { message }
     }
 
-    override fun finallyAfter(ctx: HookContext<T>, details: FlagEvaluationDetails<T>, hints: Map<String, Any>) {
+    override fun finallyAfter(ctx: HookContext<Any>, details: FlagEvaluationDetails<Any>, hints: Map<String, Any>) {
         val message = buildString {
             append("Flag evaluation finalized: ")
             append("flag='${ctx.flagKey}'")
@@ -146,6 +144,7 @@ class LoggingHook<T>(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
     private fun formatValue(value: Value): String {
         return when (value) {
             is Value.String -> "'${value.string.replace("'", "''")}'"

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
@@ -1,0 +1,153 @@
+@file:OptIn(ExperimentalTime::class)
+
+package dev.openfeature.kotlin.sdk.hooks
+
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.FlagEvaluationDetails
+import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.HookContext
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.logging.Logger
+import dev.openfeature.kotlin.sdk.logging.NoOpLogger
+import kotlin.time.ExperimentalTime
+
+/**
+ * A hook that logs detailed information during flag evaluation lifecycle.
+ *
+ * Logs at different stages:
+ * - Before: Flag evaluation request (debug level)
+ * - After: Successful evaluation with result (debug level)
+ * - Error: Errors during evaluation (error level)
+ * - Finally: Completion status (debug level)
+ *
+ * @param logger The logger to use. Defaults to NoOpLogger.
+ * @param logEvaluationContext If true, includes evaluation context in logs (default: false for privacy)
+ */
+class LoggingHook<T>(
+    private val logger: Logger = NoOpLogger(),
+    private val logEvaluationContext: Boolean = false
+) : Hook<T> {
+
+    companion object {
+        /**
+         * Hook hint key to enable/disable context logging for a specific evaluation.
+         * Pass this key in hookHints with a Boolean value to override the hook's default behavior.
+         */
+        const val HINT_LOG_EVALUATION_CONTEXT = "logEvaluationContext"
+    }
+
+    override fun before(ctx: HookContext<T>, hints: Map<String, Any>) {
+        val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
+
+        val message = buildString {
+            append("Flag evaluation starting: ")
+            append("flag='${ctx.flagKey}', ")
+            append("type=${ctx.type}, ")
+            append("defaultValue=${formatAnyValue(ctx.defaultValue)}")
+            if (shouldLogContext && ctx.ctx != null) {
+                append(", ")
+                append(formatContext(ctx.ctx))
+            }
+            append(", provider='${ctx.providerMetadata.name}'")
+            if (ctx.clientMetadata?.name != null) {
+                append(", client='${ctx.clientMetadata.name}'")
+            }
+        }
+
+        logger.debug { message }
+    }
+
+    override fun after(ctx: HookContext<T>, details: FlagEvaluationDetails<T>, hints: Map<String, Any>) {
+        val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
+
+        val message = buildString {
+            append("Flag evaluation completed: ")
+            append("flag='${details.flagKey}', ")
+            append("value=${formatAnyValue(details.value)}")
+            if (details.variant != null) {
+                append(", variant='${details.variant}'")
+            }
+            if (details.reason != null) {
+                append(", reason='${details.reason}'")
+            }
+            if (shouldLogContext && ctx.ctx != null) {
+                append(", ")
+                append(formatContext(ctx.ctx))
+            }
+            append(", provider='${ctx.providerMetadata.name}'")
+        }
+
+        logger.debug { message }
+    }
+
+    override fun error(ctx: HookContext<T>, error: Exception, hints: Map<String, Any>) {
+        val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
+
+        val message = buildString {
+            append("Flag evaluation error: ")
+            append("flag='${ctx.flagKey}', ")
+            append("type=${ctx.type}, ")
+            append("defaultValue=${formatAnyValue(ctx.defaultValue)}")
+            if (shouldLogContext && ctx.ctx != null) {
+                append(", ")
+                append(formatContext(ctx.ctx))
+            }
+            append(", provider='${ctx.providerMetadata.name}', ")
+            append("error='${error.message?.replace("'", "''")}'")
+        }
+
+        logger.error(error) { message }
+    }
+
+    override fun finallyAfter(ctx: HookContext<T>, details: FlagEvaluationDetails<T>, hints: Map<String, Any>) {
+        val message = buildString {
+            append("Flag evaluation finalized: ")
+            append("flag='${ctx.flagKey}'")
+            if (details.errorCode != null) {
+                append(", errorCode=${details.errorCode}")
+            }
+            if (details.errorMessage != null) {
+                append(", errorMessage='${details.errorMessage.replace("'", "''")}'")
+            }
+        }
+
+        logger.debug { message }
+    }
+
+    private fun formatContext(context: EvaluationContext): String {
+        return buildString {
+            append("context={")
+            append("targetingKey='${context.getTargetingKey()}'")
+            val attributes = context.asMap()
+            if (attributes.isNotEmpty()) {
+                append(", attributes={")
+                append(attributes.entries.joinToString(", ") { "${it.key}=${formatValue(it.value)}" })
+                append("}")
+            }
+            append("}")
+        }
+    }
+
+    private fun formatValue(value: Value): String {
+        return when (value) {
+            is Value.String -> "'${value.string.replace("'", "''")}'"
+            is Value.Integer -> value.integer.toString()
+            is Value.Double -> value.double.toString()
+            is Value.Boolean -> value.boolean.toString()
+            is Value.Instant -> value.instant.toString()
+            is Value.List -> "[${value.list.joinToString(", ") { formatValue(it) }}]"
+            is Value.Structure ->
+                "{${value.structure.entries.joinToString(", ") { "${it.key}=${formatValue(it.value)}" }}}"
+            is Value.Null -> "null"
+        }
+    }
+
+    private fun formatAnyValue(value: Any?): String {
+        return when (value) {
+            null -> "null"
+            is String -> "'${value.replace("'", "''")}'"
+            is Number, is Boolean -> value.toString()
+            else -> "'${value.toString().replace("'", "''")}'"
+        }
+    }
+}

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/logging/Logger.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/logging/Logger.kt
@@ -1,6 +1,11 @@
 package dev.openfeature.kotlin.sdk.logging
 
 /**
+ * Log levels supported by the [Logger] interface.
+ */
+enum class LogLevel { DEBUG, INFO, WARN, ERROR }
+
+/**
  * Logger interface for OpenFeature SDK logging.
  * Defines a minimal logging contract that can be implemented by platform-specific loggers
  * or used with built-in adapters for common logging frameworks.

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
@@ -1,0 +1,323 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.hooks.LoggingHook
+import dev.openfeature.kotlin.sdk.logging.TestLogger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LoggingIntegrationTests {
+
+    private class TestProviderMetadata(override val name: String = "test-provider") : ProviderMetadata
+
+    private val testProvider = object : FeatureProvider {
+        override val metadata: ProviderMetadata = TestProviderMetadata()
+        override val hooks: List<Hook<*>> = listOf()
+        private val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
+
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            events.emit(OpenFeatureProviderEvents.ProviderReady())
+        }
+
+        override fun shutdown() {}
+
+        override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+            events.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        }
+
+        override fun getBooleanEvaluation(
+            key: String,
+            defaultValue: Boolean,
+            context: EvaluationContext?
+        ): ProviderEvaluation<Boolean> {
+            return ProviderEvaluation(
+                value = true,
+                variant = "enabled",
+                reason = "STATIC"
+            )
+        }
+
+        override fun getStringEvaluation(
+            key: String,
+            defaultValue: String,
+            context: EvaluationContext?
+        ): ProviderEvaluation<String> {
+            return ProviderEvaluation(
+                value = "test-value",
+                variant = "variant-a",
+                reason = "TARGETING_MATCH"
+            )
+        }
+
+        override fun getIntegerEvaluation(
+            key: String,
+            defaultValue: Int,
+            context: EvaluationContext?
+        ): ProviderEvaluation<Int> {
+            return ProviderEvaluation(value = defaultValue)
+        }
+
+        override fun getDoubleEvaluation(
+            key: String,
+            defaultValue: Double,
+            context: EvaluationContext?
+        ): ProviderEvaluation<Double> {
+            return ProviderEvaluation(value = defaultValue)
+        }
+
+        override fun getObjectEvaluation(
+            key: String,
+            defaultValue: Value,
+            context: EvaluationContext?
+        ): ProviderEvaluation<Value> {
+            return ProviderEvaluation(value = defaultValue)
+        }
+
+        override fun observe(): Flow<OpenFeatureProviderEvents> {
+            return events
+        }
+    }
+
+    @BeforeTest
+    fun setup() {
+        // Clear hooks and reset API state before each test
+        OpenFeatureAPI.clearHooks()
+        OpenFeatureAPI.setLogger(dev.openfeature.kotlin.sdk.logging.NoOpLogger())
+    }
+
+    @AfterTest
+    fun teardown() = runTest {
+        // Clean up after tests
+        OpenFeatureAPI.clearHooks()
+        OpenFeatureAPI.shutdown()
+    }
+
+    @Test
+    fun `logging hook at API level logs flag evaluations`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Any>(logger = testLogger)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        OpenFeatureAPI.addHooks(listOf(hook))
+
+        val client = OpenFeatureAPI.getClient()
+        client.getBooleanValue("test-flag", false)
+
+        // Verify all lifecycle stages were logged
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation completed") })
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation finalized") })
+
+        // Verify flag details
+        assertTrue(testLogger.debugMessages.any { it.message.contains("flag='test-flag'") })
+        assertTrue(testLogger.debugMessages.any { it.message.contains("value=true") })
+    }
+
+    @Test
+    fun `logging hook at client level logs flag evaluations`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Any>(logger = testLogger)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        val client = OpenFeatureAPI.getClient()
+        client.addHooks(listOf(hook))
+
+        client.getBooleanValue("client-flag", false)
+
+        // Verify logging happened
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(testLogger.debugMessages.any { it.message.contains("flag='client-flag'") })
+    }
+
+    @Test
+    fun `logging hook at invocation level logs flag evaluations`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        val client = OpenFeatureAPI.getClient()
+
+        client.getBooleanValue(
+            "invocation-flag",
+            false,
+            FlagEvaluationOptions(
+                hooks = listOf(hook)
+            )
+        )
+
+        // Verify logging happened
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(testLogger.debugMessages.any { it.message.contains("flag='invocation-flag'") })
+    }
+
+    @Test
+    fun `logging hook logs context when enabled at invocation level`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-456",
+            attributes = mapOf("email" to Value.String("test@example.com"))
+        )
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        OpenFeatureAPI.setEvaluationContextAndWait(evaluationContext)
+
+        val client = OpenFeatureAPI.getClient()
+        client.getBooleanValue(
+            "context-flag",
+            false,
+            FlagEvaluationOptions(
+                hooks = listOf(hook)
+            )
+        )
+
+        // Verify context was logged
+        assertTrue(
+            testLogger.debugMessages.any {
+                it.message.contains("context=") &&
+                    it.message.contains("targetingKey='user-456'")
+            }
+        )
+    }
+
+    @Test
+    fun `logger can be set and retrieved from API`() {
+        val testLogger = TestLogger()
+
+        OpenFeatureAPI.setLogger(testLogger)
+        val retrievedLogger = OpenFeatureAPI.logger
+
+        assertEquals(testLogger, retrievedLogger)
+    }
+
+    @Test
+    fun `logging hook with string evaluation`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Any>(logger = testLogger)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        OpenFeatureAPI.addHooks(listOf(hook))
+
+        val client = OpenFeatureAPI.getClient()
+        val value = client.getStringValue("string-flag", "default")
+
+        assertEquals("test-value", value)
+
+        // Verify logging happened
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(
+            testLogger.debugMessages.any {
+                it.message.contains("flag='string-flag'") &&
+                    it.message.contains("value='test-value'")
+            }
+        )
+    }
+
+    @Test
+    fun `logging hook captures error when provider throws`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Any>(logger = testLogger)
+
+        val errorProvider = object : FeatureProvider {
+            override val metadata: ProviderMetadata = TestProviderMetadata("error-provider")
+            override val hooks: List<Hook<*>> = listOf()
+            private val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
+
+            override suspend fun initialize(initialContext: EvaluationContext?) {
+                events.emit(OpenFeatureProviderEvents.ProviderReady())
+            }
+
+            override fun shutdown() {}
+
+            override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {}
+
+            override fun getBooleanEvaluation(
+                key: String,
+                defaultValue: Boolean,
+                context: EvaluationContext?
+            ): ProviderEvaluation<Boolean> {
+                throw RuntimeException("Provider error")
+            }
+
+            override fun getStringEvaluation(
+                key: String,
+                defaultValue: String,
+                context: EvaluationContext?
+            ): ProviderEvaluation<String> {
+                return ProviderEvaluation(value = defaultValue)
+            }
+
+            override fun getIntegerEvaluation(
+                key: String,
+                defaultValue: Int,
+                context: EvaluationContext?
+            ): ProviderEvaluation<Int> {
+                return ProviderEvaluation(value = defaultValue)
+            }
+
+            override fun getDoubleEvaluation(
+                key: String,
+                defaultValue: Double,
+                context: EvaluationContext?
+            ): ProviderEvaluation<Double> {
+                return ProviderEvaluation(value = defaultValue)
+            }
+
+            override fun getObjectEvaluation(
+                key: String,
+                defaultValue: Value,
+                context: EvaluationContext?
+            ): ProviderEvaluation<Value> {
+                return ProviderEvaluation(value = defaultValue)
+            }
+
+            override fun observe(): Flow<OpenFeatureProviderEvents> {
+                return events
+            }
+        }
+
+        OpenFeatureAPI.setProviderAndWait(errorProvider)
+        OpenFeatureAPI.addHooks(listOf(hook))
+
+        val client = OpenFeatureAPI.getClient()
+
+        try {
+            client.getBooleanValue("error-flag", false)
+        } catch (e: Exception) {
+            // Expected
+        }
+
+        // Verify error was logged
+        assertTrue(
+            testLogger.errorMessages.any {
+                it.message.contains("Flag evaluation error") &&
+                    it.message.contains("flag='error-flag'")
+            }
+        )
+    }
+
+    @Test
+    fun `multiple hooks execute in order`() = runTest {
+        val testLogger1 = TestLogger()
+        val testLogger2 = TestLogger()
+        val hook1 = LoggingHook<Any>(logger = testLogger1)
+        val hook2 = LoggingHook<Any>(logger = testLogger2)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        OpenFeatureAPI.addHooks(listOf(hook1, hook2))
+
+        val client = OpenFeatureAPI.getClient()
+        client.getBooleanValue("multi-hook-flag", false)
+
+        // Both loggers should have captured the evaluation
+        assertTrue(testLogger1.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(testLogger2.debugMessages.any { it.message.contains("Flag evaluation starting") })
+    }
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
@@ -88,7 +88,6 @@ class LoggingIntegrationTests {
     fun setup() {
         // Clear hooks and reset API state before each test
         OpenFeatureAPI.clearHooks()
-        OpenFeatureAPI.setLogger(dev.openfeature.kotlin.sdk.logging.NoOpLogger())
     }
 
     @AfterTest
@@ -185,16 +184,6 @@ class LoggingIntegrationTests {
                     it.message.contains("targetingKey='user-456'")
             }
         )
-    }
-
-    @Test
-    fun `logger can be set and retrieved from API`() {
-        val testLogger = TestLogger()
-
-        OpenFeatureAPI.setLogger(testLogger)
-        val retrievedLogger = OpenFeatureAPI.logger
-
-        assertEquals(testLogger, retrievedLogger)
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
@@ -100,7 +100,7 @@ class LoggingIntegrationTests {
     @Test
     fun `logging hook at API level logs flag evaluations`() = runTest {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Any>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
 
         OpenFeatureAPI.setProviderAndWait(testProvider)
         OpenFeatureAPI.addHooks(listOf(hook))
@@ -121,7 +121,7 @@ class LoggingIntegrationTests {
     @Test
     fun `logging hook at client level logs flag evaluations`() = runTest {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Any>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
 
         OpenFeatureAPI.setProviderAndWait(testProvider)
         val client = OpenFeatureAPI.getClient()
@@ -137,7 +137,7 @@ class LoggingIntegrationTests {
     @Test
     fun `logging hook at invocation level logs flag evaluations`() = runTest {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
 
         OpenFeatureAPI.setProviderAndWait(testProvider)
         val client = OpenFeatureAPI.getClient()
@@ -158,7 +158,7 @@ class LoggingIntegrationTests {
     @Test
     fun `logging hook logs context when enabled at invocation level`() = runTest {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val hook = LoggingHook(logger = testLogger, logEvaluationContext = true)
 
         val evaluationContext = ImmutableContext(
             targetingKey = "user-456",
@@ -189,7 +189,7 @@ class LoggingIntegrationTests {
     @Test
     fun `logging hook with string evaluation`() = runTest {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Any>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
 
         OpenFeatureAPI.setProviderAndWait(testProvider)
         OpenFeatureAPI.addHooks(listOf(hook))
@@ -210,9 +210,71 @@ class LoggingIntegrationTests {
     }
 
     @Test
+    fun `logging hook with integer evaluation`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook(logger = testLogger)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        OpenFeatureAPI.addHooks(listOf(hook))
+
+        val client = OpenFeatureAPI.getClient()
+        val value = client.getIntegerValue("integer-flag", 42)
+
+        assertEquals(42, value)
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(
+            testLogger.debugMessages.any {
+                it.message.contains("flag='integer-flag'") &&
+                    it.message.contains("value=42")
+            }
+        )
+    }
+
+    @Test
+    fun `logging hook with double evaluation`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook(logger = testLogger)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        OpenFeatureAPI.addHooks(listOf(hook))
+
+        val client = OpenFeatureAPI.getClient()
+        val value = client.getDoubleValue("double-flag", 3.14)
+
+        assertEquals(3.14, value)
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(
+            testLogger.debugMessages.any {
+                it.message.contains("flag='double-flag'") &&
+                    it.message.contains("value=3.14")
+            }
+        )
+    }
+
+    @Test
+    fun `logging hook with object evaluation`() = runTest {
+        val testLogger = TestLogger()
+        val hook = LoggingHook(logger = testLogger)
+
+        OpenFeatureAPI.setProviderAndWait(testProvider)
+        OpenFeatureAPI.addHooks(listOf(hook))
+
+        val client = OpenFeatureAPI.getClient()
+        client.getObjectValue("object-flag", Value.String("default-object"))
+
+        assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
+        assertTrue(
+            testLogger.debugMessages.any {
+                it.message.contains("flag='object-flag'") &&
+                    it.message.contains("value=")
+            }
+        )
+    }
+
+    @Test
     fun `logging hook captures error when provider throws`() = runTest {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Any>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
 
         val errorProvider = object : FeatureProvider {
             override val metadata: ProviderMetadata = TestProviderMetadata("error-provider")
@@ -296,8 +358,8 @@ class LoggingIntegrationTests {
     fun `multiple hooks execute in order`() = runTest {
         val testLogger1 = TestLogger()
         val testLogger2 = TestLogger()
-        val hook1 = LoggingHook<Any>(logger = testLogger1)
-        val hook2 = LoggingHook<Any>(logger = testLogger2)
+        val hook1 = LoggingHook(logger = testLogger1)
+        val hook2 = LoggingHook(logger = testLogger2)
 
         OpenFeatureAPI.setProviderAndWait(testProvider)
         OpenFeatureAPI.addHooks(listOf(hook1, hook2))

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
@@ -21,9 +21,9 @@ class LoggingHookTests {
 
     private fun createHookContext(
         flagKey: String = "test-flag",
-        defaultValue: Boolean = false,
+        defaultValue: Any = false,
         evaluationContext: EvaluationContext? = null
-    ): HookContext<Boolean> {
+    ): HookContext<Any> {
         return HookContext(
             flagKey = flagKey,
             type = FlagValueType.BOOLEAN,
@@ -37,7 +37,7 @@ class LoggingHookTests {
     @Test
     fun `before stage logs flag evaluation starting`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
         val context = createHookContext("my-flag", false)
 
         hook.before(context, emptyMap())
@@ -55,9 +55,9 @@ class LoggingHookTests {
     @Test
     fun `after stage logs flag evaluation completed`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
         val context = createHookContext("my-flag")
-        val details = FlagEvaluationDetails(
+        val details = FlagEvaluationDetails<Any>(
             flagKey = "my-flag",
             value = true,
             variant = "on",
@@ -79,7 +79,7 @@ class LoggingHookTests {
     @Test
     fun `error stage logs flag evaluation error`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
         val context = createHookContext("my-flag", false)
         val exception = RuntimeException("Connection timeout")
 
@@ -99,9 +99,9 @@ class LoggingHookTests {
     @Test
     fun `finally stage logs flag evaluation finalized`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
         val context = createHookContext("my-flag")
-        val details = FlagEvaluationDetails(
+        val details = FlagEvaluationDetails<Any>(
             flagKey = "my-flag",
             value = false
         )
@@ -117,9 +117,9 @@ class LoggingHookTests {
     @Test
     fun `finally stage includes error details when present`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
         val context = createHookContext("my-flag")
-        val details = FlagEvaluationDetails(
+        val details = FlagEvaluationDetails<Any>(
             flagKey = "my-flag",
             value = false,
             errorCode = dev.openfeature.kotlin.sdk.exceptions.ErrorCode.PROVIDER_NOT_READY,
@@ -139,7 +139,7 @@ class LoggingHookTests {
     @Test
     fun `context logging is disabled by default`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
         val evaluationContext = ImmutableContext(
             targetingKey = "user-123",
             attributes = mapOf("email" to Value.String("user@example.com"))
@@ -158,7 +158,7 @@ class LoggingHookTests {
     @Test
     fun `context logging works when enabled`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val hook = LoggingHook(logger = testLogger, logEvaluationContext = true)
         val evaluationContext = ImmutableContext(
             targetingKey = "user-123",
             attributes = mapOf("email" to Value.String("user@example.com"), "plan" to Value.String("premium"))
@@ -179,7 +179,7 @@ class LoggingHookTests {
     @Test
     fun `hint override enables context logging`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = false)
+        val hook = LoggingHook(logger = testLogger, logEvaluationContext = false)
         val evaluationContext = ImmutableContext(
             targetingKey = "user-123",
             attributes = mapOf("email" to Value.String("user@example.com"))
@@ -198,7 +198,7 @@ class LoggingHookTests {
     @Test
     fun `hint override disables context logging`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val hook = LoggingHook(logger = testLogger, logEvaluationContext = true)
         val evaluationContext = ImmutableContext(
             targetingKey = "user-123",
             attributes = mapOf("email" to Value.String("user@example.com"))
@@ -217,12 +217,12 @@ class LoggingHookTests {
     @Test
     fun `context logging works in after stage`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val hook = LoggingHook(logger = testLogger, logEvaluationContext = true)
         val evaluationContext = ImmutableContext(
             targetingKey = "user-123"
         )
         val context = createHookContext("my-flag", false, evaluationContext)
-        val details = FlagEvaluationDetails(
+        val details = FlagEvaluationDetails<Any>(
             flagKey = "my-flag",
             value = true
         )
@@ -238,7 +238,7 @@ class LoggingHookTests {
     @Test
     fun `context logging works in error stage`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val hook = LoggingHook(logger = testLogger, logEvaluationContext = true)
         val evaluationContext = ImmutableContext(
             targetingKey = "user-123"
         )
@@ -256,7 +256,7 @@ class LoggingHookTests {
     @Test
     fun `configurable log levels route messages to correct level`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(
+        val hook = LoggingHook(
             logger = testLogger,
             beforeLogLevel = LogLevel.INFO,
             afterLogLevel = LogLevel.INFO,
@@ -264,7 +264,7 @@ class LoggingHookTests {
             finallyLogLevel = LogLevel.INFO
         )
         val context = createHookContext("my-flag")
-        val details = FlagEvaluationDetails(flagKey = "my-flag", value = true)
+        val details = FlagEvaluationDetails<Any>(flagKey = "my-flag", value = true)
         val exception = RuntimeException("err")
 
         hook.before(context, emptyMap())
@@ -281,9 +281,9 @@ class LoggingHookTests {
     @Test
     fun `default log levels use debug for before after finally and error for error stage`() {
         val testLogger = TestLogger()
-        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val hook = LoggingHook(logger = testLogger)
         val context = createHookContext("my-flag")
-        val details = FlagEvaluationDetails(flagKey = "my-flag", value = true)
+        val details = FlagEvaluationDetails<Any>(flagKey = "my-flag", value = true)
         val exception = RuntimeException("err")
 
         hook.before(context, emptyMap())

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
@@ -1,0 +1,254 @@
+package dev.openfeature.kotlin.sdk.hooks
+
+import dev.openfeature.kotlin.sdk.ClientMetadata
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.FlagEvaluationDetails
+import dev.openfeature.kotlin.sdk.FlagValueType
+import dev.openfeature.kotlin.sdk.HookContext
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.logging.TestLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LoggingHookTests {
+
+    private class TestProviderMetadata(override val name: String = "test-provider") : ProviderMetadata
+    private class TestClientMetadata(override val name: String = "test-client") : ClientMetadata
+
+    private fun createHookContext(
+        flagKey: String = "test-flag",
+        defaultValue: Boolean = false,
+        evaluationContext: EvaluationContext? = null
+    ): HookContext<Boolean> {
+        return HookContext(
+            flagKey = flagKey,
+            type = FlagValueType.BOOLEAN,
+            defaultValue = defaultValue,
+            ctx = evaluationContext,
+            clientMetadata = TestClientMetadata(),
+            providerMetadata = TestProviderMetadata()
+        )
+    }
+
+    @Test
+    fun `before stage logs flag evaluation starting`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val context = createHookContext("my-flag", false)
+
+        hook.before(context, emptyMap())
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(message.contains("Flag evaluation starting"))
+        assertTrue(message.contains("flag='my-flag'"))
+        assertTrue(message.contains("type=BOOLEAN"))
+        assertTrue(message.contains("defaultValue=false"))
+        assertTrue(message.contains("provider='test-provider'"))
+        assertTrue(message.contains("client='test-client'"))
+    }
+
+    @Test
+    fun `after stage logs flag evaluation completed`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val context = createHookContext("my-flag")
+        val details = FlagEvaluationDetails(
+            flagKey = "my-flag",
+            value = true,
+            variant = "on",
+            reason = "TARGETING_MATCH"
+        )
+
+        hook.after(context, details, emptyMap())
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(message.contains("Flag evaluation completed"))
+        assertTrue(message.contains("flag='my-flag'"))
+        assertTrue(message.contains("value=true"))
+        assertTrue(message.contains("variant='on'"))
+        assertTrue(message.contains("reason='TARGETING_MATCH'"))
+        assertTrue(message.contains("provider='test-provider'"))
+    }
+
+    @Test
+    fun `error stage logs flag evaluation error`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val context = createHookContext("my-flag", false)
+        val exception = RuntimeException("Connection timeout")
+
+        hook.error(context, exception, emptyMap())
+
+        assertEquals(1, testLogger.errorMessages.size)
+        val message = testLogger.errorMessages[0].message
+        assertTrue(message.contains("Flag evaluation error"))
+        assertTrue(message.contains("flag='my-flag'"))
+        assertTrue(message.contains("type=BOOLEAN"))
+        assertTrue(message.contains("defaultValue=false"))
+        assertTrue(message.contains("provider='test-provider'"))
+        assertTrue(message.contains("error='Connection timeout'"))
+        assertEquals(exception, testLogger.errorMessages[0].throwable)
+    }
+
+    @Test
+    fun `finally stage logs flag evaluation finalized`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val context = createHookContext("my-flag")
+        val details = FlagEvaluationDetails(
+            flagKey = "my-flag",
+            value = false
+        )
+
+        hook.finallyAfter(context, details, emptyMap())
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(message.contains("Flag evaluation finalized"))
+        assertTrue(message.contains("flag='my-flag'"))
+    }
+
+    @Test
+    fun `finally stage includes error details when present`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val context = createHookContext("my-flag")
+        val details = FlagEvaluationDetails(
+            flagKey = "my-flag",
+            value = false,
+            errorCode = dev.openfeature.kotlin.sdk.exceptions.ErrorCode.PROVIDER_NOT_READY,
+            errorMessage = "Provider not initialized"
+        )
+
+        hook.finallyAfter(context, details, emptyMap())
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(message.contains("Flag evaluation finalized"))
+        assertTrue(message.contains("flag='my-flag'"))
+        assertTrue(message.contains("errorCode=PROVIDER_NOT_READY"))
+        assertTrue(message.contains("errorMessage='Provider not initialized'"))
+    }
+
+    @Test
+    fun `context logging is disabled by default`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-123",
+            attributes = mapOf("email" to Value.String("user@example.com"))
+        )
+        val context = createHookContext("my-flag", false, evaluationContext)
+
+        hook.before(context, emptyMap())
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(!message.contains("context="))
+        assertTrue(!message.contains("user-123"))
+        assertTrue(!message.contains("email"))
+    }
+
+    @Test
+    fun `context logging works when enabled`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-123",
+            attributes = mapOf("email" to Value.String("user@example.com"), "plan" to Value.String("premium"))
+        )
+        val context = createHookContext("my-flag", false, evaluationContext)
+
+        hook.before(context, emptyMap())
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(message.contains("context="))
+        assertTrue(message.contains("targetingKey='user-123'"))
+        assertTrue(message.contains("attributes="))
+        assertTrue(message.contains("email='user@example.com'"))
+        assertTrue(message.contains("plan='premium'"))
+    }
+
+    @Test
+    fun `hint override enables context logging`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = false)
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-123",
+            attributes = mapOf("email" to Value.String("user@example.com"))
+        )
+        val context = createHookContext("my-flag", false, evaluationContext)
+        val hints = mapOf("logEvaluationContext" to true)
+
+        hook.before(context, hints)
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(message.contains("context="))
+        assertTrue(message.contains("targetingKey='user-123'"))
+    }
+
+    @Test
+    fun `hint override disables context logging`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-123",
+            attributes = mapOf("email" to Value.String("user@example.com"))
+        )
+        val context = createHookContext("my-flag", false, evaluationContext)
+        val hints = mapOf("logEvaluationContext" to false)
+
+        hook.before(context, hints)
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(!message.contains("context="))
+        assertTrue(!message.contains("user-123"))
+    }
+
+    @Test
+    fun `context logging works in after stage`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-123"
+        )
+        val context = createHookContext("my-flag", false, evaluationContext)
+        val details = FlagEvaluationDetails(
+            flagKey = "my-flag",
+            value = true
+        )
+
+        hook.after(context, details, emptyMap())
+
+        assertEquals(1, testLogger.debugMessages.size)
+        val message = testLogger.debugMessages[0].message
+        assertTrue(message.contains("context="))
+        assertTrue(message.contains("targetingKey='user-123'"))
+    }
+
+    @Test
+    fun `context logging works in error stage`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger, logEvaluationContext = true)
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-123"
+        )
+        val context = createHookContext("my-flag", false, evaluationContext)
+        val exception = RuntimeException("Test error")
+
+        hook.error(context, exception, emptyMap())
+
+        assertEquals(1, testLogger.errorMessages.size)
+        val message = testLogger.errorMessages[0].message
+        assertTrue(message.contains("context="))
+        assertTrue(message.contains("targetingKey='user-123'"))
+    }
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
@@ -8,6 +8,7 @@ import dev.openfeature.kotlin.sdk.HookContext
 import dev.openfeature.kotlin.sdk.ImmutableContext
 import dev.openfeature.kotlin.sdk.ProviderMetadata
 import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.logging.LogLevel
 import dev.openfeature.kotlin.sdk.logging.TestLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -250,5 +251,47 @@ class LoggingHookTests {
         val message = testLogger.errorMessages[0].message
         assertTrue(message.contains("context="))
         assertTrue(message.contains("targetingKey='user-123'"))
+    }
+
+    @Test
+    fun `configurable log levels route messages to correct level`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(
+            logger = testLogger,
+            beforeLogLevel = LogLevel.INFO,
+            afterLogLevel = LogLevel.INFO,
+            errorLogLevel = LogLevel.WARN,
+            finallyLogLevel = LogLevel.INFO
+        )
+        val context = createHookContext("my-flag")
+        val details = FlagEvaluationDetails(flagKey = "my-flag", value = true)
+        val exception = RuntimeException("err")
+
+        hook.before(context, emptyMap())
+        hook.after(context, details, emptyMap())
+        hook.error(context, exception, emptyMap())
+        hook.finallyAfter(context, details, emptyMap())
+
+        assertEquals(0, testLogger.debugMessages.size)
+        assertEquals(3, testLogger.infoMessages.size)
+        assertEquals(1, testLogger.warnMessages.size)
+        assertEquals(0, testLogger.errorMessages.size)
+    }
+
+    @Test
+    fun `default log levels use debug for before after finally and error for error stage`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook<Boolean>(logger = testLogger)
+        val context = createHookContext("my-flag")
+        val details = FlagEvaluationDetails(flagKey = "my-flag", value = true)
+        val exception = RuntimeException("err")
+
+        hook.before(context, emptyMap())
+        hook.after(context, details, emptyMap())
+        hook.error(context, exception, emptyMap())
+        hook.finallyAfter(context, details, emptyMap())
+
+        assertEquals(3, testLogger.debugMessages.size)
+        assertEquals(1, testLogger.errorMessages.size)
     }
 }

--- a/kotlin-sdk/src/jvmMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/jvmMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -4,12 +4,14 @@ import java.time.Instant
 
 /**
  * JVM platform implementation of LoggerFactory.
- * Automatically detects and uses SLF4J if available on the classpath,
- * otherwise falls back to simple JvmLogger that uses System.out/err.
+ * Currently uses JvmLogger that writes to System.out/err.
+ *
+ * Note: SLF4J integration is planned for a future enhancement.
+ * This will enable automatic detection and use of SLF4J when available
+ * on the classpath, with fallback to JvmLogger.
  */
 actual object LoggerFactory {
     actual fun getLogger(tag: String): Logger {
-        // TODO: SLF4J detection will be added in a future PR
         return JvmLogger(tag)
     }
 }

--- a/kotlin-sdk/src/jvmMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/jvmMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -4,11 +4,7 @@ import java.time.Instant
 
 /**
  * JVM platform implementation of LoggerFactory.
- * Currently uses JvmLogger that writes to System.out/err.
- *
- * Note: SLF4J integration is planned for a future enhancement.
- * This will enable automatic detection and use of SLF4J when available
- * on the classpath, with fallback to JvmLogger.
+ * Uses JvmLogger that writes to System.out/err.
  */
 actual object LoggerFactory {
     actual fun getLogger(tag: String): Logger {


### PR DESCRIPTION
## Intent

Add automatic logging of flag evaluations through the Hook system to provide visibility into the evaluation lifecycle for debugging and auditing.

## Motivation

Developers need visibility into flag evaluations for:
- **Debugging** - Understanding why a flag returned a specific value
- **Auditing** - Tracking which flags are evaluated and when
- **Troubleshooting** - Diagnosing provider or configuration issues
- **Development** - Verifying flag behavior during development

## Changes

### LoggingHook Implementation
- Implements the Hook interface
- Logs at 4 lifecycle stages: Before, After, Error, Finally
- Configurable log level per stage via `beforeLogLevel`, `afterLogLevel`, `errorLogLevel`, `finallyLogLevel` (all default to existing behaviour: debug/debug/error/debug)
- `LogLevel` enum added to the logging package (DEBUG, INFO, WARN, ERROR)
- Structured logging with evaluation context (opt-in, default off for privacy)
- Provider and client metadata in logs
- Consistent value formatting with single-quote escaping for log parsers

### Changes to OpenFeatureAPI
- Adds `logger` property and `setLogger()` removed — hook-level logger injection is the correct mechanism; `LoggingHook(logger = myLogger)` is the API

### Usage Examples

**API Level** (logs all evaluations globally):
```kotlin
val logger = LoggerFactory.getLogger("FeatureFlags")
OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))
```

**Client Level** (logs all evaluations from this client):
```kotlin
val client = OpenFeatureAPI.getClient()
client.addHooks(listOf(LoggingHook<Any>(logger = logger)))
```

**Invocation Level** (logs only this specific evaluation):
```kotlin
client.getBooleanValue(
    "my-flag",
    false,
    FlagEvaluationOptions(hooks = listOf(LoggingHook<Boolean>(logger = logger)))
)
```

**Custom log levels:**
```kotlin
LoggingHook<Any>(
    logger = logger,
    beforeLogLevel = LogLevel.INFO,
    afterLogLevel = LogLevel.INFO,
    errorLogLevel = LogLevel.ERROR
)
```

## Testing

- Unit tests covering all 4 hook stages
- Tests for custom log level routing
- Integration tests against a real provider

## Breaking Changes

None - LoggingHook is optional and additive.