### PR TITLE
feat: In-memory provider (#208)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          submodules: true
 
       # For browser tests
       - uses: browser-actions/setup-chrome@v2
@@ -29,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          submodules: true
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec"]
+	path = spec
+	url = https://github.com/open-feature/spec.git

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -915,3 +915,68 @@ public abstract interface class dev/openfeature/kotlin/sdk/multiprovider/MultiPr
 	public abstract fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 }
 
+public abstract interface class dev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator {
+	public abstract fun evaluate (Ldev/openfeature/kotlin/sdk/providers/memory/Flag;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/Flag {
+	public static final field Companion Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Companion;
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;Z)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;
+	public final fun component4 ()Ldev/openfeature/kotlin/sdk/EvaluationMetadata;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;Z)Ldev/openfeature/kotlin/sdk/providers/memory/Flag;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/providers/memory/Flag;Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;ZILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContextEvaluator ()Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;
+	public final fun getDefaultVariant ()Ljava/lang/String;
+	public final fun getDisabled ()Z
+	public final fun getFlagMetadata ()Ldev/openfeature/kotlin/sdk/EvaluationMetadata;
+	public final fun getVariants ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/Flag$Builder {
+	public fun <init> ()V
+	public final fun build ()Ldev/openfeature/kotlin/sdk/providers/memory/Flag;
+	public final fun contextEvaluator (Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun defaultVariant (Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun disabled (Z)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun flagMetadata (Ldev/openfeature/kotlin/sdk/EvaluationMetadata;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun variant (Ljava/lang/String;Ljava/lang/Object;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun variants (Ljava/util/Map;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/Flag$Companion {
+	public final fun builder ()Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/InMemoryProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getHooks ()Ljava/util/List;
+	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
+	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun observe ()Lkotlinx/coroutines/flow/Flow;
+	public fun onContextSet (Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun shutdown ()V
+	public fun track (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
+	public final fun updateFlags (Ljava/util/Map;)V
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/InMemoryProvider$InMemoryProviderMetadata : dev/openfeature/kotlin/sdk/ProviderMetadata {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getOriginalMetadata ()Ljava/util/Map;
+}
+

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -915,3 +915,68 @@ public abstract interface class dev/openfeature/kotlin/sdk/multiprovider/MultiPr
 	public abstract fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 }
 
+public abstract interface class dev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator {
+	public abstract fun evaluate (Ldev/openfeature/kotlin/sdk/providers/memory/Flag;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/Flag {
+	public static final field Companion Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Companion;
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;Z)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;
+	public final fun component4 ()Ldev/openfeature/kotlin/sdk/EvaluationMetadata;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;Z)Ldev/openfeature/kotlin/sdk/providers/memory/Flag;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/providers/memory/Flag;Ljava/util/Map;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;Ldev/openfeature/kotlin/sdk/EvaluationMetadata;ZILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContextEvaluator ()Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;
+	public final fun getDefaultVariant ()Ljava/lang/String;
+	public final fun getDisabled ()Z
+	public final fun getFlagMetadata ()Ldev/openfeature/kotlin/sdk/EvaluationMetadata;
+	public final fun getVariants ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/Flag$Builder {
+	public fun <init> ()V
+	public final fun build ()Ldev/openfeature/kotlin/sdk/providers/memory/Flag;
+	public final fun contextEvaluator (Ldev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun defaultVariant (Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun disabled (Z)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun flagMetadata (Ldev/openfeature/kotlin/sdk/EvaluationMetadata;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun variant (Ljava/lang/String;Ljava/lang/Object;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+	public final fun variants (Ljava/util/Map;)Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/Flag$Companion {
+	public final fun builder ()Ldev/openfeature/kotlin/sdk/providers/memory/Flag$Builder;
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/InMemoryProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getHooks ()Ljava/util/List;
+	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
+	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun observe ()Lkotlinx/coroutines/flow/Flow;
+	public fun onContextSet (Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun shutdown ()V
+	public fun track (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
+	public final fun updateFlags (Ljava/util/Map;)V
+}
+
+public final class dev/openfeature/kotlin/sdk/providers/memory/InMemoryProvider$InMemoryProviderMetadata : dev/openfeature/kotlin/sdk/ProviderMetadata {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getOriginalMetadata ()Ljava/util/Map;
+}
+

--- a/kotlin-sdk/build.gradle.kts
+++ b/kotlin-sdk/build.gradle.kts
@@ -38,6 +38,9 @@ kotlin {
                 }
             }
         }
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+        }
     }
     linuxX64 {}
     iosArm64()
@@ -61,10 +64,18 @@ kotlin {
             implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0")
         }
         commonTest.dependencies {
-            implementation("org.jetbrains.kotlin:kotlin-test:2.2.10")
+            implementation(kotlin("test"))
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.7.3")
             implementation("org.jetbrains.kotlinx:atomicfu:0.29.0")
+        }
+        val jvmTest by getting {
+            resources.srcDir("../spec/specification/assets/gherkin")
+            dependencies {
+                implementation("org.junit.platform:junit-platform-suite:1.10.1")
+                implementation("io.cucumber:cucumber-java:7.15.0")
+                implementation("io.cucumber:cucumber-junit-platform-engine:7.15.0")
+            }
         }
     }
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Telemetry.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Telemetry.kt
@@ -51,7 +51,7 @@ fun <T> createEvaluationEvent(
         attributes[TELEMETRY_VARIANT] = variant
     }
 
-    if (flagEvaluationDetails.reason == Reason.ERROR.name) {
+    if (flagEvaluationDetails.reason.equals(Reason.ERROR.name, ignoreCase = true)) {
         attributes[TELEMETRY_ERROR_CODE] = flagEvaluationDetails.errorCode ?: ErrorCode.GENERAL
         flagEvaluationDetails.errorMessage?.let { attributes[TELEMETRY_ERROR_MSG] = it }
     }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/providers/memory/ContextEvaluator.kt
@@ -1,0 +1,18 @@
+package dev.openfeature.kotlin.sdk.providers.memory
+
+import dev.openfeature.kotlin.sdk.EvaluationContext
+
+/**
+ * Context evaluator - use for resolving flag according to evaluation context, for handling targeting.
+ */
+fun interface ContextEvaluator<T> {
+    /**
+     * Evaluates the flag's specific variant based on the provided evaluation context.
+     *
+     * @param flag the feature flag representation
+     * @param evaluationContext the context used for targeting
+     * @return the resolved variant key (a string matching a key in the flag's variants map),
+     *         or null if no match was found.
+     */
+    fun evaluate(flag: Flag<T>, evaluationContext: EvaluationContext?): String?
+}

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/providers/memory/Flag.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/providers/memory/Flag.kt
@@ -1,0 +1,43 @@
+package dev.openfeature.kotlin.sdk.providers.memory
+
+import dev.openfeature.kotlin.sdk.EvaluationMetadata
+
+/**
+ * Flag representation for the in-memory provider.
+ */
+data class Flag<T>(
+    val variants: Map<String, T>,
+    val defaultVariant: String? = null,
+    val contextEvaluator: ContextEvaluator<T>? = null,
+    val flagMetadata: EvaluationMetadata? = null,
+    val disabled: Boolean = false
+) {
+    init {
+        if (defaultVariant != null && !variants.containsKey(defaultVariant)) {
+            throw IllegalArgumentException("defaultVariant ($defaultVariant) is not present in variants map")
+        }
+    }
+
+    companion object {
+        fun <T> builder() = Builder<T>()
+    }
+
+    class Builder<T> {
+        private val variants = mutableMapOf<String, T>()
+        private var defaultVariant: String? = null
+        private var contextEvaluator: ContextEvaluator<T>? = null
+        private var flagMetadata: EvaluationMetadata? = null
+        private var disabled: Boolean = false
+
+        fun variant(name: String, value: T) = apply { this.variants[name] = value }
+        fun variants(variants: Map<String, T>) = apply { this.variants.putAll(variants) }
+        fun defaultVariant(defaultVariant: String?) = apply { this.defaultVariant = defaultVariant }
+        fun contextEvaluator(contextEvaluator: ContextEvaluator<T>) = apply { this.contextEvaluator = contextEvaluator }
+        fun flagMetadata(flagMetadata: EvaluationMetadata) = apply { this.flagMetadata = flagMetadata }
+        fun disabled(disabled: Boolean) = apply { this.disabled = disabled }
+
+        fun build(): Flag<T> {
+            return Flag(variants.toMap(), defaultVariant, contextEvaluator, flagMetadata, disabled)
+        }
+    }
+}

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/providers/memory/InMemoryProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/providers/memory/InMemoryProvider.kt
@@ -1,0 +1,198 @@
+package dev.openfeature.kotlin.sdk.providers.memory
+
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.EvaluationMetadata
+import dev.openfeature.kotlin.sdk.FeatureProvider
+import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
+import dev.openfeature.kotlin.sdk.ProviderEvaluation
+import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.EventDetails
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.ProviderConfigurationChanged
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.ProviderReady
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.FlagNotFoundError
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.ProviderNotReadyError
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.TypeMismatchError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.update
+import kotlin.concurrent.Volatile
+
+class InMemoryProvider(initialFlags: Map<String, Flag<*>> = emptyMap()) : FeatureProvider {
+
+    override val hooks: List<Hook<*>> = emptyList()
+    override val metadata: ProviderMetadata = InMemoryProviderMetadata("InMemoryProvider")
+
+    private val flagsState = MutableStateFlow<Map<String, Flag<*>>>(initialFlags.toMap())
+
+    @Volatile
+    private var state: OpenFeatureStatus = OpenFeatureStatus.NotReady
+
+    private val eventFlow = MutableSharedFlow<OpenFeatureProviderEvents>(extraBufferCapacity = 64)
+
+    override suspend fun initialize(initialContext: EvaluationContext?) {
+        state = OpenFeatureStatus.Ready
+        eventFlow.tryEmit(ProviderReady())
+    }
+
+    override fun shutdown() {
+        state = OpenFeatureStatus.NotReady
+    }
+
+    override suspend fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) {
+        // no-op for in-memory provider as flags aren't context-bound on fetch
+    }
+
+    fun updateFlags(newFlags: Map<String, Flag<*>>) {
+        val flagsChanged = newFlags.keys.toSet()
+        flagsState.update { currentFlags ->
+            currentFlags + newFlags
+        }
+        eventFlow.tryEmit(
+            ProviderConfigurationChanged(
+                EventDetails(flagsChanged = flagsChanged, message = "flags changed")
+            )
+        )
+    }
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = eventFlow.asSharedFlow()
+
+    override fun getBooleanEvaluation(
+        key: String,
+        defaultValue: Boolean,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Boolean> {
+        return getEvaluation(key, defaultValue, context, Boolean::class)
+    }
+
+    override fun getStringEvaluation(
+        key: String,
+        defaultValue: String,
+        context: EvaluationContext?
+    ): ProviderEvaluation<String> {
+        return getEvaluation(key, defaultValue, context, String::class)
+    }
+
+    override fun getIntegerEvaluation(
+        key: String,
+        defaultValue: Int,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Int> {
+        return getEvaluation(key, defaultValue, context, Int::class)
+    }
+
+    override fun getDoubleEvaluation(
+        key: String,
+        defaultValue: Double,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Double> {
+        return getEvaluation(key, defaultValue, context, Double::class)
+    }
+
+    override fun getObjectEvaluation(
+        key: String,
+        defaultValue: Value,
+        context: EvaluationContext?
+    ): ProviderEvaluation<Value> {
+        return getEvaluation(key, defaultValue, context, Value::class)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> getEvaluation(
+        key: String,
+        defaultValue: T,
+        context: EvaluationContext?,
+        expectedClass: kotlin.reflect.KClass<T>
+    ): ProviderEvaluation<T> {
+        when (val currentState = state) {
+            is OpenFeatureStatus.NotReady -> throw ProviderNotReadyError("provider not yet initialized")
+            is OpenFeatureStatus.Fatal -> throw currentState.error
+            is OpenFeatureStatus.Error -> throw currentState.error
+            else -> {
+                // fall through
+            }
+        }
+
+        val flag = flagsState.value[key] ?: throw FlagNotFoundError(key)
+
+        if (flag.disabled) {
+            return ProviderEvaluation(
+                value = defaultValue,
+                reason = Reason.DISABLED.toString(),
+                metadata = flag.flagMetadata
+                    ?: EvaluationMetadata.EMPTY
+            )
+        }
+
+        var value: Any? = null
+        var reason = Reason.STATIC
+        var errorCode: ErrorCode? = null
+        var errorMessage: String? = null
+        var variant: String? = flag.defaultVariant
+
+        if (flag.contextEvaluator != null) {
+            try {
+                @Suppress("UNCHECKED_CAST")
+                val evaluatedVariant =
+                    (flag.contextEvaluator as ContextEvaluator<T>).evaluate(
+                        flag as Flag<T>,
+                        context
+                    )
+                if (evaluatedVariant != null) {
+                    if (flag.variants.containsKey(evaluatedVariant)) {
+                        value = flag.variants[evaluatedVariant]
+                        variant = evaluatedVariant
+                        reason = Reason.TARGETING_MATCH
+                    } else {
+                        errorCode = ErrorCode.GENERAL
+                        errorMessage = "Evaluated variant '$evaluatedVariant' not found in variants"
+                    }
+                }
+            } catch (e: Exception) {
+                errorCode = ErrorCode.GENERAL
+                errorMessage = e.message ?: "Error evaluating context"
+            }
+            if (value == null) {
+                value = flag.defaultVariant?.let { flag.variants[it] }
+                variant = flag.defaultVariant
+                reason = if (errorCode != null) Reason.ERROR else Reason.DEFAULT
+            }
+        } else {
+            value = flag.defaultVariant?.let { flag.variants[it] }
+        }
+
+        if (value != null && !expectedClass.isInstance(value)) {
+            throw TypeMismatchError("flag $key evaluated to a type that does not match expected type")
+        }
+
+        if (value == null && errorMessage != null) {
+            // Provide the caller with the actual failure reason
+            value = defaultValue
+        } else if (value == null) {
+            // Check if expected class is actually instantiated by default, if we reach here there's
+            // a problem
+            throw TypeMismatchError("flag $key value could not be resolved or cast")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return ProviderEvaluation(
+            value = value as T,
+            variant = variant,
+            reason = reason.toString(),
+            errorCode = errorCode,
+            errorMessage = errorMessage,
+            metadata = flag.flagMetadata ?: EvaluationMetadata.EMPTY
+        )
+    }
+
+    class InMemoryProviderMetadata(override val name: String) : ProviderMetadata
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/providers/memory/InMemoryProviderTest.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/providers/memory/InMemoryProviderTest.kt
@@ -1,0 +1,362 @@
+package dev.openfeature.kotlin.sdk.providers.memory
+
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.FlagNotFoundError
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.ProviderNotReadyError
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.TypeMismatchError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InMemoryProviderTest {
+
+    private lateinit var provider: InMemoryProvider
+
+    @BeforeTest
+    fun setup() = runTest {
+        val flags = mapOf(
+            "boolean-flag" to Flag.builder<Boolean>()
+                .variant("on", true)
+                .variant("off", false)
+                .defaultVariant("on")
+                .build(),
+            "string-flag" to Flag.builder<String>()
+                .variant("greeting", "hi")
+                .defaultVariant("greeting")
+                .build(),
+            "integer-flag" to Flag.builder<Int>()
+                .variant("ten", 10)
+                .defaultVariant("ten")
+                .build(),
+            "object-flag" to Flag.builder<Value>()
+                .variant(
+                    "template",
+                    Value.Structure(
+                        mapOf(
+                            "showImages" to Value.Boolean(true),
+                            "title" to Value.String("Check out these pics!"),
+                            "imagesPerPage" to Value.Integer(100)
+                        )
+                    )
+                )
+                .defaultVariant("template")
+                .build()
+        )
+        provider = InMemoryProvider(flags)
+        OpenFeatureAPI.setProviderAndWait(provider)
+    }
+
+    @AfterTest
+    fun tearDown() = runTest {
+        OpenFeatureAPI.shutdown()
+    }
+
+    @Test
+    fun `getBooleanEvaluation returns correctly`() = runTest {
+        val client = OpenFeatureAPI.getClient()
+        assertEquals(true, client.getBooleanValue("boolean-flag", false))
+    }
+
+    @Test
+    fun `getStringEvaluation returns correctly`() = runTest {
+        val client = OpenFeatureAPI.getClient()
+        assertEquals("hi", client.getStringValue("string-flag", "dummy"))
+    }
+
+    @Test
+    fun `getIntegerEvaluation returns correctly`() = runTest {
+        val client = OpenFeatureAPI.getClient()
+        assertEquals(10, client.getIntegerValue("integer-flag", 999))
+    }
+
+    @Test
+    fun `getObjectEvaluation returns correctly`() = runTest {
+        val client = OpenFeatureAPI.getClient()
+        val defaultObj = Value.Structure(mapOf())
+        val obj = client.getObjectValue("object-flag", defaultObj) as Value.Structure
+        assertEquals(true, (obj.asStructure()!!["showImages"] as Value.Boolean).boolean)
+        assertEquals("Check out these pics!", (obj.asStructure()!!["title"] as Value.String).string)
+    }
+
+    @Test
+    fun `should throw FlagNotFoundError when flag is missing`() = runTest {
+        assertFailsWith<FlagNotFoundError> {
+            provider.getBooleanEvaluation("not-found-flag", false, null)
+        }
+    }
+
+    @Test
+    fun `should throw TypeMismatchError on wrong type cast`() = runTest {
+        assertFailsWith<TypeMismatchError> {
+            provider.getBooleanEvaluation("string-flag", false, null)
+        }
+    }
+
+    @Test
+    fun `should throw ProviderNotReadyError if not initialized`() = runTest {
+        val newProvider = InMemoryProvider()
+        assertFailsWith<ProviderNotReadyError> {
+            newProvider.getBooleanEvaluation("some_flag", false, null)
+        }
+    }
+
+    @Test
+    fun `disabled flag returns default value and reason DISABLED`() = runTest {
+        val disabledFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .variant("off", false)
+            .defaultVariant("on")
+            .disabled(true)
+            .build()
+
+        val localProvider = InMemoryProvider(mapOf("disabled-flag" to disabledFlag))
+        localProvider.initialize(null)
+
+        val eval = localProvider.getBooleanEvaluation("disabled-flag", false, null)
+        assertEquals(false, eval.value)
+        assertEquals(Reason.DISABLED.toString(), eval.reason)
+    }
+
+    @Test
+    fun `contextEvaluator returning null falls back to defaultVariant with Reason DEFAULT`() = runTest {
+        val evaluatorFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .variant("off", false)
+            .defaultVariant("on")
+            .contextEvaluator { _, _ -> null }
+            .build()
+
+        val localProvider = InMemoryProvider(mapOf("evaluator-flag" to evaluatorFlag))
+        localProvider.initialize(null)
+
+        val eval = localProvider.getBooleanEvaluation("evaluator-flag", false, null)
+        assertEquals(true, eval.value) // defaultVariant "on" has value true
+        assertEquals(Reason.DEFAULT.toString(), eval.reason)
+    }
+
+    @Test
+    fun `updateFlags fires ProviderConfigurationChanged event`() = runTest {
+        val newFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .defaultVariant("on")
+            .build()
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            val event = provider.observe()
+                .first { it is OpenFeatureProviderEvents.ProviderConfigurationChanged }
+                as OpenFeatureProviderEvents.ProviderConfigurationChanged
+            assertEquals(setOf("new-flag"), event.eventDetails?.flagsChanged)
+        }
+
+        provider.updateFlags(mapOf("new-flag" to newFlag))
+        job.join()
+
+        val multiFlags = mapOf(
+            "another-flag" to Flag.builder<Boolean>().variant("on", true).defaultVariant("on").build()
+        )
+        val job2 = launch(UnconfinedTestDispatcher(testScheduler)) {
+            val event = provider.observe()
+                .first { it is OpenFeatureProviderEvents.ProviderConfigurationChanged }
+                as OpenFeatureProviderEvents.ProviderConfigurationChanged
+            assertEquals(setOf("another-flag"), event.eventDetails?.flagsChanged)
+        }
+        provider.updateFlags(multiFlags)
+        job2.join()
+    }
+
+    @Test
+    fun `context evaluator exception defaults to fallback and Reason ERROR`() = runTest {
+        val evaluatorFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .variant("off", false)
+            .defaultVariant("on")
+            .contextEvaluator { _, _ -> throw Exception("Simulated evaluation error") }
+            .build()
+
+        val localProvider = InMemoryProvider(mapOf("evaluator-error-flag" to evaluatorFlag))
+        localProvider.initialize(null)
+
+        val eval = localProvider.getBooleanEvaluation("evaluator-error-flag", false, null)
+        assertEquals(true, eval.value) // defaultVariant "on" has value true
+        assertEquals(Reason.ERROR.toString(), eval.reason)
+        assertEquals(dev.openfeature.kotlin.sdk.exceptions.ErrorCode.GENERAL, eval.errorCode)
+        assertEquals("Simulated evaluation error", eval.errorMessage)
+    }
+
+    @Test
+    fun `variant resolution is correct for STATIC TARGETING_MATCH DEFAULT and ERROR reasons`() = runTest {
+        val staticFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .defaultVariant("on")
+            .build()
+
+        val targetingFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .variant("off", false)
+            .defaultVariant("on")
+            .contextEvaluator { _, _ -> "off" }
+            .build()
+
+        val defaultFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .defaultVariant("on")
+            .contextEvaluator { _, _ -> null }
+            .build()
+
+        val errorFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .defaultVariant("on")
+            .contextEvaluator { _, _ -> throw Exception("Simulated error") }
+            .build()
+
+        val flags = mapOf(
+            "static-flag" to staticFlag,
+            "targeting-flag" to targetingFlag,
+            "default-flag" to defaultFlag,
+            "error-flag" to errorFlag
+        )
+
+        val localProvider = InMemoryProvider(flags)
+        localProvider.initialize(null)
+
+        val staticEval = localProvider.getBooleanEvaluation("static-flag", false, null)
+        assertEquals(Reason.STATIC.toString(), staticEval.reason)
+        assertEquals("on", staticEval.variant)
+
+        val targetingEval = localProvider.getBooleanEvaluation("targeting-flag", false, null)
+        assertEquals(Reason.TARGETING_MATCH.toString(), targetingEval.reason)
+        assertEquals("off", targetingEval.variant)
+
+        val defaultEval = localProvider.getBooleanEvaluation("default-flag", false, null)
+        assertEquals(Reason.DEFAULT.toString(), defaultEval.reason)
+        assertEquals("on", defaultEval.variant)
+
+        val errorEval = localProvider.getBooleanEvaluation("error-flag", false, null)
+        assertEquals(Reason.ERROR.toString(), errorEval.reason)
+        assertEquals("on", errorEval.variant)
+    }
+
+    @Test
+    fun `updateFlags actually mutates the flag dictionary`() = runTest {
+        val newFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .defaultVariant("on")
+            .build()
+
+        provider.updateFlags(mapOf("my-new-flag" to newFlag))
+        val eval1 = provider.getBooleanEvaluation("my-new-flag", false, null)
+        assertEquals(true, eval1.value)
+
+        val multiFlags = mapOf(
+            "my-multi-flag" to Flag.builder<Boolean>().variant("off", false).defaultVariant("off").build()
+        )
+        provider.updateFlags(multiFlags)
+        val eval2 = provider.getBooleanEvaluation("my-multi-flag", true, null)
+        assertEquals(false, eval2.value)
+    }
+
+    @Test
+    fun `missing defaultVariant throws TypeMismatchError`() = runTest {
+        val nullDefaultFlag = Flag<Boolean>(
+            variants = mapOf("on" to true),
+            defaultVariant = null
+        )
+        val localProvider = InMemoryProvider(mapOf("no-default" to nullDefaultFlag))
+        localProvider.initialize(null)
+
+        val exception = assertFailsWith<TypeMismatchError> {
+            localProvider.getBooleanEvaluation("no-default", false, null)
+        }
+        assertEquals("flag no-default value could not be resolved or cast", exception.message)
+    }
+
+    @Test
+    fun `shutdown resets state to NotReady`() = runTest {
+        val localProvider = InMemoryProvider()
+        localProvider.initialize(null)
+
+        assertFailsWith<FlagNotFoundError> {
+            localProvider.getBooleanEvaluation("missing", false, null)
+        }
+
+        localProvider.shutdown()
+
+        assertFailsWith<ProviderNotReadyError> {
+            localProvider.getBooleanEvaluation("missing", false, null)
+        }
+    }
+
+    /* ktlint-disable max-line-length */
+    @Test
+    fun `no evaluation exception and Flag validation throws IllegalArgumentException if defaultVariant missing from variants`() = runTest {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            Flag<Boolean>(
+                variants = mapOf("on" to true),
+                defaultVariant = "off"
+            )
+        }
+        assertEquals("defaultVariant (off) is not present in variants map", exception.message)
+
+        // Assert no evaluation exception happens if it is valid
+        val validFlag = Flag<Boolean>(
+            variants = mapOf("on" to true),
+            defaultVariant = "on"
+        )
+        val provider = InMemoryProvider(mapOf("valid" to validFlag))
+        provider.initialize(null)
+        val eval = provider.getBooleanEvaluation("valid", false, null)
+        assertEquals(true, eval.value)
+    }
+    /* ktlint-enable max-line-length */
+
+    /* ktlint-disable max-line-length */
+    @Test
+    fun `evaluation exception without defaultVariant falls back to parameter defaultValue with Reason ERROR`() = runTest {
+        val flagWithoutDefaultVariant = Flag<Boolean>(
+            variants = mapOf("on" to true),
+            defaultVariant = null,
+            contextEvaluator = { _, _ -> throw Exception("Simulated error with no default variant") }
+        )
+
+        val localProvider = InMemoryProvider(mapOf("no-default-error" to flagWithoutDefaultVariant))
+        localProvider.initialize(null)
+
+        val eval = localProvider.getBooleanEvaluation("no-default-error", false, null)
+        assertEquals(false, eval.value) // Should fallback to `defaultValue` = false
+        assertEquals(Reason.ERROR.toString(), eval.reason)
+        assertEquals(ErrorCode.GENERAL, eval.errorCode)
+        assertEquals("Simulated error with no default variant", eval.errorMessage)
+    }
+
+    @Test
+    fun `contextEvaluator returning unknown variant falls back to defaultVariant with Reason ERROR`() = runTest {
+        val unknownVariantFlag = Flag.builder<Boolean>()
+            .variant("on", true)
+            .defaultVariant("on")
+            .contextEvaluator { _, _ -> "does-not-exist" }
+            .build()
+
+        val localProvider = InMemoryProvider(mapOf("unknown-variant" to unknownVariantFlag))
+        localProvider.initialize(null)
+
+        val eval = localProvider.getBooleanEvaluation("unknown-variant", false, null)
+        assertEquals(true, eval.value) // Should fallback to defaultVariant `on` = true
+        assertEquals(Reason.ERROR.toString(), eval.reason)
+        assertEquals(ErrorCode.GENERAL, eval.errorCode)
+        assertEquals("Evaluated variant 'does-not-exist' not found in variants", eval.errorMessage)
+        assertEquals("on", eval.variant)
+    }
+    /* ktlint-enable max-line-length */
+}

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/e2e/EvaluationSteps.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/e2e/EvaluationSteps.kt
@@ -1,0 +1,318 @@
+
+package dev.openfeature.kotlin.sdk.e2e
+
+import dev.openfeature.kotlin.sdk.Client
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.FlagEvaluationDetails
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.providers.memory.Flag
+import dev.openfeature.kotlin.sdk.providers.memory.InMemoryProvider
+import io.cucumber.java.en.Given
+import io.cucumber.java.en.Then
+import io.cucumber.java.en.When
+import kotlinx.coroutines.runBlocking
+import kotlin.test.assertEquals
+
+class EvaluationSteps {
+    private lateinit var client: Client
+
+    @Given("a stable provider")
+    fun setup(): Unit = runBlocking {
+        val flags = mapOf(
+            "boolean-flag" to
+                Flag.builder<Boolean>().variant("on", true)
+                    .variant("off", false).defaultVariant("on").build(),
+            "string-flag" to
+                Flag.builder<String>().variant("greeting", "hi").defaultVariant("greeting").build(),
+            "integer-flag" to Flag.builder<Int>().variant("ten", 10).defaultVariant("ten").build(),
+            "float-flag" to Flag.builder<Double>().variant("half", 0.5).defaultVariant("half").build(),
+            "object-flag" to Flag.builder<Value>().variant(
+                "template",
+                Value.Structure(
+                    mapOf(
+                        "showImages" to Value.Boolean(true),
+                        "title" to Value.String("Check out these pics!"),
+                        "imagesPerPage" to Value.Integer(100)
+                    )
+                )
+            ).defaultVariant("template").build(),
+            "context-aware" to Flag.builder<String>()
+                .variant("internal", "INTERNAL")
+                .variant("external", "EXTERNAL")
+                .defaultVariant("external")
+                .contextEvaluator { _, ctx ->
+                    if (ctx?.getValue("customer")?.asBoolean() == false) "INTERNAL" else "EXTERNAL"
+                }
+                .build(),
+            "wrong-flag" to Flag.builder<String>()
+                .variant("one", "uno")
+                .variant("two", "dos")
+                .defaultVariant("one")
+                .build()
+        )
+        val provider = InMemoryProvider(flags)
+        OpenFeatureAPI.setProviderAndWait(provider)
+        client = OpenFeatureAPI.getClient()
+    }
+
+    private var booleanFlagValue: Boolean = false
+    private var stringFlagValue: String = ""
+    private var intFlagValue: Int = 0
+    private var doubleFlagValue: Double = 0.0
+    private var objectFlagValue: Value? = null
+
+    private var booleanFlagDetails: FlagEvaluationDetails<Boolean>? = null
+    private var stringFlagDetails: FlagEvaluationDetails<String>? = null
+    private var intFlagDetails: FlagEvaluationDetails<Int>? = null
+    private var doubleFlagDetails: FlagEvaluationDetails<Double>? = null
+    private var objectFlagDetails: FlagEvaluationDetails<Value>? = null
+
+    private var contextAwareFlagKey: String = ""
+    private var contextAwareDefaultValue: String = ""
+    private var context: EvaluationContext? = null
+    private var contextAwareValue: String = ""
+
+    private var notFoundFlagKey: String = ""
+    private var notFoundDefaultValue: String = ""
+    private var notFoundDetails: FlagEvaluationDetails<String>? = null
+
+    private var typeErrorFlagKey: String = ""
+    private var typeErrorDefaultValue: Int = 0
+    private var typeErrorDetails: FlagEvaluationDetails<Int>? = null
+
+    @When("a boolean flag with key {string} is evaluated with default value {string}")
+    fun evaluate_boolean(flagKey: String, defaultValue: String) {
+        booleanFlagValue = client.getBooleanValue(flagKey, defaultValue.toBoolean())
+    }
+
+    @Then("the resolved boolean value should be {string}")
+    fun assert_boolean_value(expected: String) {
+        assertEquals(expected.toBoolean(), booleanFlagValue)
+    }
+
+    @When("a string flag with key {string} is evaluated with default value {string}")
+    fun evaluate_string(flagKey: String, defaultValue: String) {
+        stringFlagValue = client.getStringValue(flagKey, defaultValue)
+    }
+
+    @Then("the resolved string value should be {string}")
+    fun assert_string_value(expected: String) {
+        assertEquals(expected, stringFlagValue)
+    }
+
+    @When("an integer flag with key {string} is evaluated with default value {int}")
+    fun evaluate_integer(flagKey: String, defaultValue: Int) {
+        intFlagValue = client.getIntegerValue(flagKey, defaultValue)
+    }
+
+    @Then("the resolved integer value should be {int}")
+    fun assert_integer_value(expected: Int) {
+        assertEquals(expected, intFlagValue)
+    }
+
+    @When("a float flag with key {string} is evaluated with default value {double}")
+    fun evaluate_double(flagKey: String, defaultValue: Double) {
+        doubleFlagValue = client.getDoubleValue(flagKey, defaultValue)
+    }
+
+    @Then("the resolved float value should be {double}")
+    fun assert_float_value(expected: Double) {
+        assertEquals(expected, doubleFlagValue)
+    }
+
+    @When("an object flag with key {string} is evaluated with a null default value")
+    fun evaluate_object(flagKey: String) {
+        objectFlagValue = client.getObjectValue(flagKey, Value.Structure(emptyMap()))
+    }
+
+    @Then(
+        "the resolved object value should be contain fields {string}, {string}, and {string}, " +
+            "with values {string}, {string} and {int}, respectively"
+    )
+    fun assert_object_value(
+        boolField: String,
+        stringField: String,
+        numberField: String,
+        boolValue: String,
+        stringValue: String,
+        numberValue: Int
+    ) {
+        val structure = objectFlagValue?.asStructure()!!
+        assertEquals(boolValue.toBoolean(), (structure[boolField] as Value.Boolean).boolean)
+        assertEquals(stringValue, (structure[stringField] as Value.String).string)
+        assertEquals(numberValue, (structure[numberField] as Value.Integer).integer)
+    }
+
+    @When("a boolean flag with key {string} is evaluated with details and default value {string}")
+    fun evaluate_boolean_details(flagKey: String, defaultValue: String) {
+        booleanFlagDetails = client.getBooleanDetails(flagKey, defaultValue.toBoolean())
+    }
+
+    @Then(
+        "the resolved boolean details value should be {string}, " +
+            "the variant should be {string}, and the reason should be {string}"
+    )
+    fun assert_boolean_details(expectedValue: String, expectedVariant: String, expectedReason: String) {
+        assertEquals(expectedValue.toBoolean(), booleanFlagDetails?.value)
+        assertEquals(expectedVariant, booleanFlagDetails?.variant)
+        assertEquals(expectedReason, booleanFlagDetails?.reason)
+    }
+
+    @When("a string flag with key {string} is evaluated with details and default value {string}")
+    fun evaluate_string_details(flagKey: String, defaultValue: String) {
+        stringFlagDetails = client.getStringDetails(flagKey, defaultValue)
+    }
+
+    @Then(
+        "the resolved string details value should be {string}, the variant should be {string}, " +
+            "and the reason should be {string}"
+    )
+    fun assert_string_details(expectedValue: String, expectedVariant: String, expectedReason: String) {
+        assertEquals(expectedValue, stringFlagDetails?.value)
+        assertEquals(expectedVariant, stringFlagDetails?.variant)
+        assertEquals(expectedReason, stringFlagDetails?.reason)
+    }
+
+    @When("an integer flag with key {string} is evaluated with details and default value {int}")
+    fun evaluate_integer_details(flagKey: String, defaultValue: Int) {
+        intFlagDetails = client.getIntegerDetails(flagKey, defaultValue)
+    }
+
+    @Then(
+        "the resolved integer details value should be {int}, " +
+            "the variant should be {string}, and the reason should be {string}"
+    )
+    fun assert_integer_details(expectedValue: Int, expectedVariant: String, expectedReason: String) {
+        assertEquals(expectedValue, intFlagDetails?.value)
+        assertEquals(expectedVariant, intFlagDetails?.variant)
+        assertEquals(expectedReason, intFlagDetails?.reason)
+    }
+
+    @When("a float flag with key {string} is evaluated with details and default value {double}")
+    fun evaluate_double_details(flagKey: String, defaultValue: Double) {
+        doubleFlagDetails = client.getDoubleDetails(flagKey, defaultValue)
+    }
+
+    @Then(
+        "the resolved float details value should be {double}, the variant should be {string}, " +
+            "and the reason should be {string}"
+    )
+    fun assert_double_details(expectedValue: Double, expectedVariant: String, expectedReason: String) {
+        assertEquals(expectedValue, doubleFlagDetails?.value)
+        assertEquals(expectedVariant, doubleFlagDetails?.variant)
+        assertEquals(expectedReason, doubleFlagDetails?.reason)
+    }
+
+    @When("an object flag with key {string} is evaluated with details and a null default value")
+    fun evaluate_object_details(flagKey: String) {
+        objectFlagDetails = client.getObjectDetails(flagKey, Value.Structure(emptyMap()))
+    }
+
+    @Then(
+        "the resolved object details value should be contain fields {string}, {string}, and {string}, " +
+            "with values {string}, {string} and {int}, respectively"
+    )
+    fun assert_object_details(
+        boolField: String,
+        stringField: String,
+        numberField: String,
+        boolValue: String,
+        stringValue: String,
+        numberValue: Int
+    ) {
+        val structure = objectFlagDetails?.value?.asStructure()!!
+        assertEquals(boolValue.toBoolean(), (structure[boolField] as Value.Boolean).boolean)
+        assertEquals(stringValue, (structure[stringField] as Value.String).string)
+        assertEquals(numberValue, (structure[numberField] as Value.Integer).integer)
+    }
+
+    @Then("the variant should be {string}, and the reason should be {string}")
+    fun assert_object_details_variant(expectedVariant: String, expectedReason: String) {
+        assertEquals(expectedVariant, objectFlagDetails?.variant)
+        assertEquals(expectedReason, objectFlagDetails?.reason)
+    }
+
+    @When(
+        "context contains keys {string}, {string}, {string}, {string} with values {string}, {string}, {int}, {string}"
+    )
+    fun context_contains(
+        field1: String,
+        field2: String,
+        field3: String,
+        field4: String,
+        value1: String,
+        value2: String,
+        value3: Int,
+        value4: String
+    ) {
+        val attributes = mapOf(
+            field1 to Value.String(value1),
+            field2 to Value.String(value2),
+            field3 to Value.Integer(value3),
+            field4 to Value.Boolean(value4.toBoolean())
+        )
+        context = dev.openfeature.kotlin.sdk.ImmutableContext(attributes = attributes)
+        runBlocking {
+            OpenFeatureAPI.setEvaluationContextAndWait(context!!)
+        }
+    }
+
+    @When("a flag with key {string} is evaluated with default value {string}")
+    fun evaluate_context_aware(flagKey: String, defaultValue: String) {
+        contextAwareFlagKey = flagKey
+        contextAwareDefaultValue = defaultValue
+        contextAwareValue = client.getStringValue(flagKey, defaultValue)
+    }
+
+    @Then("the resolved string response should be {string}")
+    fun assert_context_aware_response(expected: String) {
+        assertEquals(expected, contextAwareValue)
+    }
+
+    @Then("the resolved flag value is {string} when the context is empty")
+    fun assert_context_empty_response(expected: String) {
+        runBlocking {
+            OpenFeatureAPI.setEvaluationContextAndWait(dev.openfeature.kotlin.sdk.ImmutableContext())
+        }
+        val emptyValue = client.getStringValue(contextAwareFlagKey, contextAwareDefaultValue)
+        assertEquals(expected, emptyValue)
+    }
+
+    @When("a non-existent string flag with key {string} is evaluated with details and a fallback value {string}")
+    fun evaluate_not_found(flagKey: String, defaultValue: String) {
+        notFoundFlagKey = flagKey
+        notFoundDefaultValue = defaultValue
+        notFoundDetails = client.getStringDetails(flagKey, defaultValue)
+    }
+
+    @Then("the default string value should be returned")
+    fun assert_not_found_value() {
+        assertEquals(notFoundDefaultValue, notFoundDetails?.value)
+    }
+
+    @Then("the reason should indicate an error and the error code should indicate a missing flag with {string}")
+    fun assert_not_found_reason(errorCode: String) {
+        assertEquals(Reason.ERROR.toString(), notFoundDetails?.reason)
+        assertEquals(errorCode, notFoundDetails?.errorCode?.name)
+    }
+
+    @When("a string flag with key {string} is evaluated as an integer, with details and a fallback value {int}")
+    fun evaluate_type_mismatch(flagKey: String, defaultValue: Int) {
+        typeErrorFlagKey = flagKey
+        typeErrorDefaultValue = defaultValue
+        typeErrorDetails = client.getIntegerDetails(flagKey, defaultValue)
+    }
+
+    @Then("the default integer value should be returned")
+    fun assert_type_mismatch_value() {
+        assertEquals(typeErrorDefaultValue, typeErrorDetails?.value)
+    }
+
+    @Then("the reason should indicate an error and the error code should indicate a type mismatch with {string}")
+    fun assert_type_mismatch_reason(errorCode: String) {
+        assertEquals(Reason.ERROR.toString(), typeErrorDetails?.reason)
+        assertEquals(errorCode, typeErrorDetails?.errorCode?.name)
+    }
+}

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/e2e/EvaluationSteps.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/e2e/EvaluationSteps.kt
@@ -43,7 +43,7 @@ class EvaluationSteps {
                 .variant("external", "EXTERNAL")
                 .defaultVariant("external")
                 .contextEvaluator { _, ctx ->
-                    if (ctx?.getValue("customer")?.asBoolean() == false) "INTERNAL" else "EXTERNAL"
+                    if (ctx?.getValue("customer")?.asBoolean() == false) "internal" else "external"
                 }
                 .build(),
             "wrong-flag" to Flag.builder<String>()

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/e2e/GherkinSpecTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/e2e/GherkinSpecTest.kt
@@ -1,0 +1,24 @@
+package dev.openfeature.kotlin.sdk.e2e
+
+import io.cucumber.junit.platform.engine.Constants.FILTER_NAME_PROPERTY_NAME
+import io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME
+import io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME
+import org.junit.platform.suite.api.ConfigurationParameter
+import org.junit.platform.suite.api.ExcludeTags
+import org.junit.platform.suite.api.IncludeEngines
+import org.junit.platform.suite.api.SelectDirectories
+import org.junit.platform.suite.api.Suite
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectDirectories("../spec/specification/assets/gherkin")
+/**
+ * tells the JUnit platform to parse all the Gherkin files in the submodules but strictly run only
+ * the scenarios originating under the feature named exact match Flag evaluation (which uniquely
+ * targets evaluation.feature and ignores evaluation_v2.feature and the rest)
+ */
+@ConfigurationParameter(key = FILTER_NAME_PROPERTY_NAME, value = "^Flag evaluation\$")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "dev.openfeature.kotlin.sdk.e2e")
+@ExcludeTags("reason-codes-cached", "async", "immutability", "evaluation-options", "providers")
+class GherkinSpecTest


### PR DESCRIPTION
## InMemoryProvider, Gherkin based tests
This PR introduces the `InMemoryProvider` for the OpenFeature Kotlin SDK and validates its implementation using the official OpenFeature specification.
- Adds the `InMemoryProvider` for managing and evaluating flags entirely in memory, including `ContextEvaluator` and `Flag` models.
- Links the `open-feature/spec` repository as a Git submodule to utilize the official cross-platform test suite.
- Adds End-to-End (E2E) testing suite (`EvaluationSteps`, `GherkinSpecTest`) using Cucumber to verify the new provider adheres to the OpenFeature Gherkin specification. Evaluation targets evaluation.feature file and ignores evaluation_v2.feature.
- Updates the GitHub Actions `ci.yaml` workflow to ensure Git submodules are checked out during CI test runs.

### Related Issues
Fixes #208 

### Notes
Because this PR introduces the `open-feature/spec` as a Git submodule, developers pulling or checking out this branch locally may need to initialize submodules by running:
```bash
git submodule update --init --recursive