### PR TITLE
feat: Add structured logging to Logger interface

### DIFF
--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -835,21 +835,21 @@ public final class dev/openfeature/kotlin/sdk/logging/LogLevel : java/lang/Enum 
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/logging/Logger {
-	public abstract fun debug (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public abstract fun error (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public abstract fun info (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public abstract fun warn (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public abstract fun debug (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public abstract fun error (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public abstract fun info (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public abstract fun warn (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/logging/Logger$DefaultImpls {
-	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/logging/LoggerFactory {
@@ -860,10 +860,10 @@ public final class dev/openfeature/kotlin/sdk/logging/LoggerFactory {
 
 public final class dev/openfeature/kotlin/sdk/logging/NoOpLogger : dev/openfeature/kotlin/sdk/logging/Logger {
 	public fun <init> ()V
-	public fun debug (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public fun error (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public fun info (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public fun warn (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public fun debug (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public fun error (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public fun info (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public fun warn (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/multiprovider/FirstMatchStrategy : dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -835,21 +835,21 @@ public final class dev/openfeature/kotlin/sdk/logging/LogLevel : java/lang/Enum 
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/logging/Logger {
-	public abstract fun debug (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public abstract fun error (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public abstract fun info (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public abstract fun warn (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public abstract fun debug (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public abstract fun error (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public abstract fun info (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public abstract fun warn (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/logging/Logger$DefaultImpls {
-	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun debug$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun error$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun info$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun warn$default (Ldev/openfeature/kotlin/sdk/logging/Logger;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/logging/LoggerFactory {
@@ -860,10 +860,10 @@ public final class dev/openfeature/kotlin/sdk/logging/LoggerFactory {
 
 public final class dev/openfeature/kotlin/sdk/logging/NoOpLogger : dev/openfeature/kotlin/sdk/logging/Logger {
 	public fun <init> ()V
-	public fun debug (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public fun error (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public fun info (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
-	public fun warn (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public fun debug (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public fun error (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public fun info (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+	public fun warn (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/multiprovider/FirstMatchStrategy : dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {

--- a/kotlin-sdk/src/androidMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/androidMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -19,21 +19,25 @@ internal class AndroidLogger(private val tag: String) : Logger {
     // throwable is passed directly to Log.*() which formats the stack trace natively.
     // Do NOT pass throwable to formatLogLine here — it would duplicate the stack trace in Logcat.
     override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        if (!Log.isLoggable(tag, Log.DEBUG)) return
         val msg = formatLogLine(message(), attributes())
         if (throwable != null) Log.d(tag, msg, throwable) else Log.d(tag, msg)
     }
 
     override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        if (!Log.isLoggable(tag, Log.INFO)) return
         val msg = formatLogLine(message(), attributes())
         if (throwable != null) Log.i(tag, msg, throwable) else Log.i(tag, msg)
     }
 
     override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        if (!Log.isLoggable(tag, Log.WARN)) return
         val msg = formatLogLine(message(), attributes())
         if (throwable != null) Log.w(tag, msg, throwable) else Log.w(tag, msg)
     }
 
     override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        if (!Log.isLoggable(tag, Log.ERROR)) return
         val msg = formatLogLine(message(), attributes())
         if (throwable != null) Log.e(tag, msg, throwable) else Log.e(tag, msg)
     }

--- a/kotlin-sdk/src/androidMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/androidMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -13,21 +13,28 @@ actual object LoggerFactory {
 /**
  * Android-specific logger implementation using android.util.Log.
  * Logs are visible in Logcat.
+ * Attributes are appended to the message as key=value pairs.
  */
 internal class AndroidLogger(private val tag: String) : Logger {
-    override fun debug(throwable: Throwable?, message: () -> String) {
-        Log.d(tag, message(), throwable)
+    // throwable is passed directly to Log.*() which formats the stack trace natively.
+    // Do NOT pass throwable to formatLogLine here — it would duplicate the stack trace in Logcat.
+    override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val msg = formatLogLine(message(), attributes())
+        if (throwable != null) Log.d(tag, msg, throwable) else Log.d(tag, msg)
     }
 
-    override fun info(throwable: Throwable?, message: () -> String) {
-        Log.i(tag, message(), throwable)
+    override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val msg = formatLogLine(message(), attributes())
+        if (throwable != null) Log.i(tag, msg, throwable) else Log.i(tag, msg)
     }
 
-    override fun warn(throwable: Throwable?, message: () -> String) {
-        Log.w(tag, message(), throwable)
+    override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val msg = formatLogLine(message(), attributes())
+        if (throwable != null) Log.w(tag, msg, throwable) else Log.w(tag, msg)
     }
 
-    override fun error(throwable: Throwable?, message: () -> String) {
-        Log.e(tag, message(), throwable)
+    override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val msg = formatLogLine(message(), attributes())
+        if (throwable != null) Log.e(tag, msg, throwable) else Log.e(tag, msg)
     }
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
@@ -46,125 +46,117 @@ class LoggingHook(
     override fun before(ctx: HookContext<Any>, hints: Map<String, Any>) {
         val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
 
-        val message = buildString {
-            append("Flag evaluation starting: ")
-            append("flag='${ctx.flagKey}', ")
-            append("type=${ctx.type}, ")
-            append("defaultValue=${formatAnyValue(ctx.defaultValue)}")
-            if (shouldLogContext && ctx.ctx != null) {
-                append(", ")
-                append(formatContext(ctx.ctx))
+        logAtLevel(
+            beforeLogLevel,
+            message = { "Flag evaluation starting" },
+            attributes = {
+                buildMap {
+                    put("flag", ctx.flagKey)
+                    put("type", ctx.type.toString())
+                    put("defaultValue", ctx.defaultValue)
+                    put("provider", ctx.providerMetadata.name)
+                    ctx.clientMetadata?.name?.let { put("client", it) }
+                    if (shouldLogContext && ctx.ctx != null) {
+                        putAll(contextAttributes(ctx.ctx))
+                    }
+                }
             }
-            append(", provider='${ctx.providerMetadata.name}'")
-            if (ctx.clientMetadata?.name != null) {
-                append(", client='${ctx.clientMetadata.name}'")
-            }
-        }
-
-        logAtLevel(beforeLogLevel) { message }
+        )
     }
 
     override fun after(ctx: HookContext<Any>, details: FlagEvaluationDetails<Any>, hints: Map<String, Any>) {
         val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
 
-        val message = buildString {
-            append("Flag evaluation completed: ")
-            append("flag='${details.flagKey}', ")
-            append("value=${formatAnyValue(details.value)}")
-            if (details.variant != null) {
-                append(", variant='${details.variant}'")
+        logAtLevel(
+            afterLogLevel,
+            message = { "Flag evaluation completed" },
+            attributes = {
+                buildMap {
+                    put("flag", details.flagKey)
+                    put("value", details.value)
+                    details.variant?.let { put("variant", it) }
+                    details.reason?.let { put("reason", it) }
+                    put("provider", ctx.providerMetadata.name)
+                    if (shouldLogContext && ctx.ctx != null) {
+                        putAll(contextAttributes(ctx.ctx))
+                    }
+                }
             }
-            if (details.reason != null) {
-                append(", reason='${details.reason}'")
-            }
-            if (shouldLogContext && ctx.ctx != null) {
-                append(", ")
-                append(formatContext(ctx.ctx))
-            }
-            append(", provider='${ctx.providerMetadata.name}'")
-        }
-
-        logAtLevel(afterLogLevel) { message }
+        )
     }
 
     override fun error(ctx: HookContext<Any>, error: Exception, hints: Map<String, Any>) {
         val shouldLogContext = hints[HINT_LOG_EVALUATION_CONTEXT] as? Boolean ?: logEvaluationContext
 
-        val message = buildString {
-            append("Flag evaluation error: ")
-            append("flag='${ctx.flagKey}', ")
-            append("type=${ctx.type}, ")
-            append("defaultValue=${formatAnyValue(ctx.defaultValue)}")
-            if (shouldLogContext && ctx.ctx != null) {
-                append(", ")
-                append(formatContext(ctx.ctx))
+        logAtLevel(
+            errorLogLevel,
+            throwable = error,
+            message = { "Flag evaluation error" },
+            attributes = {
+                buildMap {
+                    put("flag", ctx.flagKey)
+                    put("type", ctx.type.toString())
+                    put("defaultValue", ctx.defaultValue)
+                    put("provider", ctx.providerMetadata.name)
+                    error.message?.let { put("error", it) }
+                    if (shouldLogContext && ctx.ctx != null) {
+                        putAll(contextAttributes(ctx.ctx))
+                    }
+                }
             }
-            append(", provider='${ctx.providerMetadata.name}', ")
-            append("error='${error.message?.replace("'", "''")}'")
-        }
-
-        logAtLevel(errorLogLevel, error) { message }
+        )
     }
 
     override fun finallyAfter(ctx: HookContext<Any>, details: FlagEvaluationDetails<Any>, hints: Map<String, Any>) {
-        val message = buildString {
-            append("Flag evaluation finalized: ")
-            append("flag='${ctx.flagKey}'")
-            if (details.errorCode != null) {
-                append(", errorCode=${details.errorCode}")
+        logAtLevel(
+            finallyLogLevel,
+            message = { "Flag evaluation finalized" },
+            attributes = {
+                buildMap {
+                    put("flag", ctx.flagKey)
+                    details.errorCode?.let { put("errorCode", it.toString()) }
+                    details.errorMessage?.let { put("errorMessage", it) }
+                }
             }
-            if (details.errorMessage != null) {
-                append(", errorMessage='${details.errorMessage.replace("'", "''")}'")
-            }
-        }
-
-        logAtLevel(finallyLogLevel) { message }
+        )
     }
 
-    private fun logAtLevel(level: LogLevel, throwable: Throwable? = null, message: () -> String) {
+    private fun logAtLevel(
+        level: LogLevel,
+        throwable: Throwable? = null,
+        message: () -> String,
+        attributes: () -> Map<String, Any?>
+    ) {
         when (level) {
-            LogLevel.DEBUG -> logger.debug(throwable, message)
-            LogLevel.INFO -> logger.info(throwable, message)
-            LogLevel.WARN -> logger.warn(throwable, message)
-            LogLevel.ERROR -> logger.error(throwable, message)
-        }
-    }
-
-    private fun formatContext(context: EvaluationContext): String {
-        return buildString {
-            append("context={")
-            append("targetingKey='${context.getTargetingKey()}'")
-            val attributes = context.asMap()
-            if (attributes.isNotEmpty()) {
-                append(", attributes={")
-                append(attributes.entries.joinToString(", ") { "${it.key}=${formatValue(it.value)}" })
-                append("}")
-            }
-            append("}")
+            LogLevel.DEBUG -> logger.debug(message, attributes, throwable)
+            LogLevel.INFO -> logger.info(message, attributes, throwable)
+            LogLevel.WARN -> logger.warn(message, attributes, throwable)
+            LogLevel.ERROR -> logger.error(message, attributes, throwable)
         }
     }
 
     @OptIn(ExperimentalTime::class)
-    private fun formatValue(value: Value): String {
-        return when (value) {
-            is Value.String -> "'${value.string.replace("'", "''")}'"
-            is Value.Integer -> value.integer.toString()
-            is Value.Double -> value.double.toString()
-            is Value.Boolean -> value.boolean.toString()
-            is Value.Instant -> value.instant.toString()
-            is Value.List -> "[${value.list.joinToString(", ") { formatValue(it) }}]"
-            is Value.Structure ->
-                "{${value.structure.entries.joinToString(", ") { "${it.key}=${formatValue(it.value)}" }}}"
-            is Value.Null -> "null"
+    private fun contextAttributes(context: EvaluationContext): Map<String, Any?> = buildMap {
+        // getTargetingKey() returns "" when not set (non-nullable), so check isNotEmpty
+        context.getTargetingKey().takeIf { it.isNotEmpty() }?.let { put("context.targetingKey", it) }
+        context.asMap().forEach { (key, value) ->
+            put("context.$key", valueToNative(value))
         }
     }
 
-    private fun formatAnyValue(value: Any?): String {
-        return when (value) {
-            null -> "null"
-            is String -> "'${value.replace("'", "''")}'"
-            is Number, is Boolean -> value.toString()
-            else -> "'${value.toString().replace("'", "''")}'"
+    @OptIn(ExperimentalTime::class)
+    private fun valueToNative(value: Value): Any? = when (value) {
+        is Value.String -> value.string
+        is Value.Integer -> value.integer
+        is Value.Double -> value.double
+        is Value.Boolean -> value.boolean
+        is Value.Instant -> value.instant.toString()
+        is Value.List -> value.list.joinToString(", ", "[", "]") { valueToNative(it).toString() }
+        is Value.Structure -> value.structure.entries.joinToString(", ", "{", "}") {
+            "${it.key}=${valueToNative(
+                it.value
+            )}"
         }
+        is Value.Null -> null
     }
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHook.kt
@@ -4,11 +4,9 @@ import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.FlagEvaluationDetails
 import dev.openfeature.kotlin.sdk.Hook
 import dev.openfeature.kotlin.sdk.HookContext
-import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.logging.LogLevel
 import dev.openfeature.kotlin.sdk.logging.Logger
 import dev.openfeature.kotlin.sdk.logging.NoOpLogger
-import kotlin.time.ExperimentalTime
 
 /**
  * A hook that logs detailed information during flag evaluation lifecycle.
@@ -135,28 +133,17 @@ class LoggingHook(
         }
     }
 
-    @OptIn(ExperimentalTime::class)
     private fun contextAttributes(context: EvaluationContext): Map<String, Any?> = buildMap {
-        // getTargetingKey() returns "" when not set (non-nullable), so check isNotEmpty
+        // asObjectMap() unwraps Value subtypes to native Kotlin types (String, Int, Boolean,
+        // Instant, List<Any?>, Map<String, Any?>) — reuses the SDK's own conversion logic.
+        // ImmutableContext stores the targeting key separately from its attributes map, so
+        // asObjectMap() will not include it for the standard implementation.
+        context.asObjectMap().forEach { (key, value) ->
+            put("context.$key", value)
+        }
+        // getTargetingKey() returns "" when not set (non-nullable), so check isNotEmpty.
+        // Put after asObjectMap() so that targeting key always wins if a custom
+        // EvaluationContext also returns it from asObjectMap().
         context.getTargetingKey().takeIf { it.isNotEmpty() }?.let { put("context.targetingKey", it) }
-        context.asMap().forEach { (key, value) ->
-            put("context.$key", valueToNative(value))
-        }
-    }
-
-    @OptIn(ExperimentalTime::class)
-    private fun valueToNative(value: Value): Any? = when (value) {
-        is Value.String -> value.string
-        is Value.Integer -> value.integer
-        is Value.Double -> value.double
-        is Value.Boolean -> value.boolean
-        is Value.Instant -> value.instant.toString()
-        is Value.List -> value.list.joinToString(", ", "[", "]") { valueToNative(it).toString() }
-        is Value.Structure -> value.structure.entries.joinToString(", ", "{", "}") {
-            "${it.key}=${valueToNative(
-                it.value
-            )}"
-        }
-        is Value.Null -> null
     }
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/logging/Logger.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/logging/Logger.kt
@@ -10,61 +10,92 @@ enum class LogLevel { DEBUG, INFO, WARN, ERROR }
  * Defines a minimal logging contract that can be implemented by platform-specific loggers
  * or used with built-in adapters for common logging frameworks.
  *
- * Message parameters are lambdas so evaluation is deferred until the logger decides to
- * emit the message. This avoids unnecessary string construction when logging is inactive
+ * Both the message and attributes are lambdas so evaluation is deferred until the logger
+ * decides to emit the log record. This avoids unnecessary work when logging is inactive
  * (e.g. with [NoOpLogger]).
  *
- * The throwable parameter comes before the message lambda so callers can use trailing
- * lambda syntax:
+ * Implementations that support structured logging (e.g. SLF4J, Android structured logs)
+ * can forward the attributes map directly. Implementations that only support plain strings
+ * are responsible for stringifying the attributes themselves.
+ *
  * ```kotlin
- * logger.debug { "simple message" }
- * logger.error(exception) { "message with cause" }
+ * logger.debug({ "Flag evaluation starting" }, { mapOf("flag" to flagKey) })
+ * logger.error({ "Evaluation failed" }, { mapOf("flag" to flagKey) }, exception)
  * ```
  */
 interface Logger {
     /**
      * Log a debug message.
      *
-     * @param throwable optional throwable to log with the message
-     * @param message lambda producing the message to log
+     * @param message lambda producing the log message
+     * @param attributes lambda producing a map of structured key-value pairs
+     * @param throwable optional throwable to associate with the log record
      */
-    fun debug(throwable: Throwable? = null, message: () -> String)
+    fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
 
     /**
      * Log an info message.
      *
-     * @param throwable optional throwable to log with the message
-     * @param message lambda producing the message to log
+     * @param message lambda producing the log message
+     * @param attributes lambda producing a map of structured key-value pairs
+     * @param throwable optional throwable to associate with the log record
      */
-    fun info(throwable: Throwable? = null, message: () -> String)
+    fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
 
     /**
      * Log a warning message.
      *
-     * @param throwable optional throwable to log with the message
-     * @param message lambda producing the message to log
+     * @param message lambda producing the log message
+     * @param attributes lambda producing a map of structured key-value pairs
+     * @param throwable optional throwable to associate with the log record
      */
-    fun warn(throwable: Throwable? = null, message: () -> String)
+    fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
 
     /**
      * Log an error message.
      *
-     * @param throwable optional throwable to log with the message
-     * @param message lambda producing the message to log
+     * @param message lambda producing the log message
+     * @param attributes lambda producing a map of structured key-value pairs
+     * @param throwable optional throwable to associate with the log record
      */
-    fun error(throwable: Throwable? = null, message: () -> String)
+    fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
 }
 
 /**
  * A no-op logger that discards all log messages.
  * Used as the default logger when no logger is configured.
- * Message lambdas are never evaluated.
+ * Neither lambda is evaluated.
  */
 class NoOpLogger : Logger {
-    override fun debug(throwable: Throwable?, message: () -> String) {}
-    override fun info(throwable: Throwable?, message: () -> String) {}
-    override fun warn(throwable: Throwable?, message: () -> String) {}
-    override fun error(throwable: Throwable?, message: () -> String) {}
+    override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {}
+    override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {}
+    override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {}
+    override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {}
+}
+
+/**
+ * Formats a log line by appending structured attributes as `key=value` pairs and,
+ * if present, the throwable stack trace. Used by string-only logging backends
+ * (Android Logcat, JVM stdout, iOS NSLog, Linux stderr) that have no native
+ * structured key-value API.
+ *
+ * @param message the pre-built message string (may already include a level/tag prefix)
+ * @param attributes key-value pairs to append after the message
+ * @param throwable optional throwable whose stack trace is appended on a new line
+ */
+internal fun formatLogLine(
+    message: String,
+    attributes: Map<String, Any?>,
+    throwable: Throwable? = null
+): String = buildString {
+    append(message)
+    if (attributes.isNotEmpty()) {
+        append(" ")
+        append(attributes.entries.joinToString(" ") { "${it.key}=${it.value}" })
+    }
+    if (throwable != null) {
+        append("\n${throwable.stackTraceToString()}")
+    }
 }
 
 /**

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/logging/Logger.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/logging/Logger.kt
@@ -31,7 +31,7 @@ interface Logger {
      * @param attributes lambda producing a map of structured key-value pairs
      * @param throwable optional throwable to associate with the log record
      */
-    fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
+    fun debug(message: () -> String, attributes: () -> Map<String, Any?> = { emptyMap() }, throwable: Throwable? = null)
 
     /**
      * Log an info message.
@@ -40,7 +40,7 @@ interface Logger {
      * @param attributes lambda producing a map of structured key-value pairs
      * @param throwable optional throwable to associate with the log record
      */
-    fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
+    fun info(message: () -> String, attributes: () -> Map<String, Any?> = { emptyMap() }, throwable: Throwable? = null)
 
     /**
      * Log a warning message.
@@ -49,7 +49,7 @@ interface Logger {
      * @param attributes lambda producing a map of structured key-value pairs
      * @param throwable optional throwable to associate with the log record
      */
-    fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
+    fun warn(message: () -> String, attributes: () -> Map<String, Any?> = { emptyMap() }, throwable: Throwable? = null)
 
     /**
      * Log an error message.
@@ -58,7 +58,7 @@ interface Logger {
      * @param attributes lambda producing a map of structured key-value pairs
      * @param throwable optional throwable to associate with the log record
      */
-    fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable? = null)
+    fun error(message: () -> String, attributes: () -> Map<String, Any?> = { emptyMap() }, throwable: Throwable? = null)
 }
 
 /**

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
@@ -86,13 +86,11 @@ class LoggingIntegrationTests {
 
     @BeforeTest
     fun setup() {
-        // Clear hooks and reset API state before each test
         OpenFeatureAPI.clearHooks()
     }
 
     @AfterTest
     fun teardown() = runTest {
-        // Clean up after tests
         OpenFeatureAPI.clearHooks()
         OpenFeatureAPI.shutdown()
     }
@@ -113,9 +111,9 @@ class LoggingIntegrationTests {
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation completed") })
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation finalized") })
 
-        // Verify flag details
-        assertTrue(testLogger.debugMessages.any { it.message.contains("flag='test-flag'") })
-        assertTrue(testLogger.debugMessages.any { it.message.contains("value=true") })
+        // Verify flag key and value in structured attributes
+        assertTrue(testLogger.debugMessages.any { it.attributes["flag"] == "test-flag" })
+        assertTrue(testLogger.debugMessages.any { it.attributes["value"] == true })
     }
 
     @Test
@@ -129,9 +127,8 @@ class LoggingIntegrationTests {
 
         client.getBooleanValue("client-flag", false)
 
-        // Verify logging happened
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
-        assertTrue(testLogger.debugMessages.any { it.message.contains("flag='client-flag'") })
+        assertTrue(testLogger.debugMessages.any { it.attributes["flag"] == "client-flag" })
     }
 
     @Test
@@ -150,9 +147,8 @@ class LoggingIntegrationTests {
             )
         )
 
-        // Verify logging happened
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
-        assertTrue(testLogger.debugMessages.any { it.message.contains("flag='invocation-flag'") })
+        assertTrue(testLogger.debugMessages.any { it.attributes["flag"] == "invocation-flag" })
     }
 
     @Test
@@ -177,11 +173,10 @@ class LoggingIntegrationTests {
             )
         )
 
-        // Verify context was logged
+        // Verify context was included in structured attributes
         assertTrue(
             testLogger.debugMessages.any {
-                it.message.contains("context=") &&
-                    it.message.contains("targetingKey='user-456'")
+                it.attributes["context.targetingKey"] == "user-456"
             }
         )
     }
@@ -199,12 +194,10 @@ class LoggingIntegrationTests {
 
         assertEquals("test-value", value)
 
-        // Verify logging happened
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
         assertTrue(
             testLogger.debugMessages.any {
-                it.message.contains("flag='string-flag'") &&
-                    it.message.contains("value='test-value'")
+                it.attributes["flag"] == "string-flag" && it.attributes["value"] == "test-value"
             }
         )
     }
@@ -224,8 +217,7 @@ class LoggingIntegrationTests {
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
         assertTrue(
             testLogger.debugMessages.any {
-                it.message.contains("flag='integer-flag'") &&
-                    it.message.contains("value=42")
+                it.attributes["flag"] == "integer-flag" && it.attributes["value"] == 42
             }
         )
     }
@@ -245,8 +237,7 @@ class LoggingIntegrationTests {
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
         assertTrue(
             testLogger.debugMessages.any {
-                it.message.contains("flag='double-flag'") &&
-                    it.message.contains("value=3.14")
+                it.attributes["flag"] == "double-flag" && it.attributes["value"] == 3.14
             }
         )
     }
@@ -265,8 +256,7 @@ class LoggingIntegrationTests {
         assertTrue(testLogger.debugMessages.any { it.message.contains("Flag evaluation starting") })
         assertTrue(
             testLogger.debugMessages.any {
-                it.message.contains("flag='object-flag'") &&
-                    it.message.contains("value=")
+                it.attributes["flag"] == "object-flag" && it.attributes.containsKey("value")
             }
         )
     }
@@ -345,11 +335,11 @@ class LoggingIntegrationTests {
             // Expected
         }
 
-        // Verify error was logged
+        // Verify error was logged with structured attributes
         assertTrue(
             testLogger.errorMessages.any {
                 it.message.contains("Flag evaluation error") &&
-                    it.message.contains("flag='error-flag'")
+                    it.attributes["flag"] == "error-flag"
             }
         )
     }
@@ -367,7 +357,6 @@ class LoggingIntegrationTests {
         val client = OpenFeatureAPI.getClient()
         client.getBooleanValue("multi-hook-flag", false)
 
-        // Both loggers should have captured the evaluation
         assertTrue(testLogger1.debugMessages.any { it.message.contains("Flag evaluation starting") })
         assertTrue(testLogger2.debugMessages.any { it.message.contains("Flag evaluation starting") })
     }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
@@ -264,6 +264,7 @@ class LoggingHookTests {
 
         hook.finallyAfter(context, details, emptyMap())
 
+        assertEquals(1, testLogger.debugMessages.size)
         val entry = testLogger.debugMessages[0]
         assertFalse(entry.attributes.containsKey("context.targetingKey"))
         assertFalse(entry.attributes.containsKey("context.region"))
@@ -323,6 +324,7 @@ class LoggingHookTests {
 
         hook.after(context, details, emptyMap())
 
+        assertEquals(1, testLogger.debugMessages.size)
         val entry = testLogger.debugMessages[0]
         assertFalse(entry.attributes.containsKey("variant"))
         assertFalse(entry.attributes.containsKey("reason"))
@@ -343,6 +345,7 @@ class LoggingHookTests {
 
         hook.before(context, emptyMap())
 
+        assertEquals(1, testLogger.debugMessages.size)
         val entry = testLogger.debugMessages[0]
         assertFalse(entry.attributes.containsKey("client"))
     }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/hooks/LoggingHookTests.kt
@@ -12,6 +12,7 @@ import dev.openfeature.kotlin.sdk.logging.LogLevel
 import dev.openfeature.kotlin.sdk.logging.TestLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class LoggingHookTests {
@@ -43,13 +44,13 @@ class LoggingHookTests {
         hook.before(context, emptyMap())
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(message.contains("Flag evaluation starting"))
-        assertTrue(message.contains("flag='my-flag'"))
-        assertTrue(message.contains("type=BOOLEAN"))
-        assertTrue(message.contains("defaultValue=false"))
-        assertTrue(message.contains("provider='test-provider'"))
-        assertTrue(message.contains("client='test-client'"))
+        val entry = testLogger.debugMessages[0]
+        assertTrue(entry.message.contains("Flag evaluation starting"))
+        assertEquals("my-flag", entry.attributes["flag"])
+        assertEquals("BOOLEAN", entry.attributes["type"])
+        assertEquals(false, entry.attributes["defaultValue"])
+        assertEquals("test-provider", entry.attributes["provider"])
+        assertEquals("test-client", entry.attributes["client"])
     }
 
     @Test
@@ -67,13 +68,13 @@ class LoggingHookTests {
         hook.after(context, details, emptyMap())
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(message.contains("Flag evaluation completed"))
-        assertTrue(message.contains("flag='my-flag'"))
-        assertTrue(message.contains("value=true"))
-        assertTrue(message.contains("variant='on'"))
-        assertTrue(message.contains("reason='TARGETING_MATCH'"))
-        assertTrue(message.contains("provider='test-provider'"))
+        val entry = testLogger.debugMessages[0]
+        assertTrue(entry.message.contains("Flag evaluation completed"))
+        assertEquals("my-flag", entry.attributes["flag"])
+        assertEquals(true, entry.attributes["value"])
+        assertEquals("on", entry.attributes["variant"])
+        assertEquals("TARGETING_MATCH", entry.attributes["reason"])
+        assertEquals("test-provider", entry.attributes["provider"])
     }
 
     @Test
@@ -86,14 +87,14 @@ class LoggingHookTests {
         hook.error(context, exception, emptyMap())
 
         assertEquals(1, testLogger.errorMessages.size)
-        val message = testLogger.errorMessages[0].message
-        assertTrue(message.contains("Flag evaluation error"))
-        assertTrue(message.contains("flag='my-flag'"))
-        assertTrue(message.contains("type=BOOLEAN"))
-        assertTrue(message.contains("defaultValue=false"))
-        assertTrue(message.contains("provider='test-provider'"))
-        assertTrue(message.contains("error='Connection timeout'"))
-        assertEquals(exception, testLogger.errorMessages[0].throwable)
+        val entry = testLogger.errorMessages[0]
+        assertTrue(entry.message.contains("Flag evaluation error"))
+        assertEquals("my-flag", entry.attributes["flag"])
+        assertEquals("BOOLEAN", entry.attributes["type"])
+        assertEquals(false, entry.attributes["defaultValue"])
+        assertEquals("test-provider", entry.attributes["provider"])
+        assertEquals("Connection timeout", entry.attributes["error"])
+        assertEquals(exception, entry.throwable)
     }
 
     @Test
@@ -109,9 +110,11 @@ class LoggingHookTests {
         hook.finallyAfter(context, details, emptyMap())
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(message.contains("Flag evaluation finalized"))
-        assertTrue(message.contains("flag='my-flag'"))
+        val entry = testLogger.debugMessages[0]
+        assertTrue(entry.message.contains("Flag evaluation finalized"))
+        assertEquals("my-flag", entry.attributes["flag"])
+        assertFalse(entry.attributes.containsKey("errorCode"))
+        assertFalse(entry.attributes.containsKey("errorMessage"))
     }
 
     @Test
@@ -129,11 +132,11 @@ class LoggingHookTests {
         hook.finallyAfter(context, details, emptyMap())
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(message.contains("Flag evaluation finalized"))
-        assertTrue(message.contains("flag='my-flag'"))
-        assertTrue(message.contains("errorCode=PROVIDER_NOT_READY"))
-        assertTrue(message.contains("errorMessage='Provider not initialized'"))
+        val entry = testLogger.debugMessages[0]
+        assertTrue(entry.message.contains("Flag evaluation finalized"))
+        assertEquals("my-flag", entry.attributes["flag"])
+        assertEquals("PROVIDER_NOT_READY", entry.attributes["errorCode"])
+        assertEquals("Provider not initialized", entry.attributes["errorMessage"])
     }
 
     @Test
@@ -149,10 +152,9 @@ class LoggingHookTests {
         hook.before(context, emptyMap())
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(!message.contains("context="))
-        assertTrue(!message.contains("user-123"))
-        assertTrue(!message.contains("email"))
+        val entry = testLogger.debugMessages[0]
+        assertFalse(entry.attributes.containsKey("context.targetingKey"))
+        assertFalse(entry.attributes.containsKey("context.email"))
     }
 
     @Test
@@ -168,12 +170,10 @@ class LoggingHookTests {
         hook.before(context, emptyMap())
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(message.contains("context="))
-        assertTrue(message.contains("targetingKey='user-123'"))
-        assertTrue(message.contains("attributes="))
-        assertTrue(message.contains("email='user@example.com'"))
-        assertTrue(message.contains("plan='premium'"))
+        val entry = testLogger.debugMessages[0]
+        assertEquals("user-123", entry.attributes["context.targetingKey"])
+        assertEquals("user@example.com", entry.attributes["context.email"])
+        assertEquals("premium", entry.attributes["context.plan"])
     }
 
     @Test
@@ -190,9 +190,8 @@ class LoggingHookTests {
         hook.before(context, hints)
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(message.contains("context="))
-        assertTrue(message.contains("targetingKey='user-123'"))
+        val entry = testLogger.debugMessages[0]
+        assertEquals("user-123", entry.attributes["context.targetingKey"])
     }
 
     @Test
@@ -209,9 +208,9 @@ class LoggingHookTests {
         hook.before(context, hints)
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(!message.contains("context="))
-        assertTrue(!message.contains("user-123"))
+        val entry = testLogger.debugMessages[0]
+        assertFalse(entry.attributes.containsKey("context.targetingKey"))
+        assertFalse(entry.attributes.containsKey("context.email"))
     }
 
     @Test
@@ -230,9 +229,8 @@ class LoggingHookTests {
         hook.after(context, details, emptyMap())
 
         assertEquals(1, testLogger.debugMessages.size)
-        val message = testLogger.debugMessages[0].message
-        assertTrue(message.contains("context="))
-        assertTrue(message.contains("targetingKey='user-123'"))
+        val entry = testLogger.debugMessages[0]
+        assertEquals("user-123", entry.attributes["context.targetingKey"])
     }
 
     @Test
@@ -248,9 +246,27 @@ class LoggingHookTests {
         hook.error(context, exception, emptyMap())
 
         assertEquals(1, testLogger.errorMessages.size)
-        val message = testLogger.errorMessages[0].message
-        assertTrue(message.contains("context="))
-        assertTrue(message.contains("targetingKey='user-123'"))
+        val entry = testLogger.errorMessages[0]
+        assertEquals("user-123", entry.attributes["context.targetingKey"])
+    }
+
+    @Test
+    fun `finallyAfter does not include context even when logEvaluationContext is true`() {
+        // finallyAfter intentionally omits context — it only logs completion status
+        val testLogger = TestLogger()
+        val hook = LoggingHook(logger = testLogger, logEvaluationContext = true)
+        val evaluationContext = ImmutableContext(
+            targetingKey = "user-123",
+            attributes = mapOf("region" to Value.String("us-east"))
+        )
+        val context = createHookContext("my-flag", false, evaluationContext)
+        val details = FlagEvaluationDetails<Any>(flagKey = "my-flag", value = false)
+
+        hook.finallyAfter(context, details, emptyMap())
+
+        val entry = testLogger.debugMessages[0]
+        assertFalse(entry.attributes.containsKey("context.targetingKey"))
+        assertFalse(entry.attributes.containsKey("context.region"))
     }
 
     @Test
@@ -293,5 +309,41 @@ class LoggingHookTests {
 
         assertEquals(3, testLogger.debugMessages.size)
         assertEquals(1, testLogger.errorMessages.size)
+    }
+
+    @Test
+    fun `after stage omits null variant and reason`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook(logger = testLogger)
+        val context = createHookContext("my-flag")
+        val details = FlagEvaluationDetails<Any>(
+            flagKey = "my-flag",
+            value = true
+        )
+
+        hook.after(context, details, emptyMap())
+
+        val entry = testLogger.debugMessages[0]
+        assertFalse(entry.attributes.containsKey("variant"))
+        assertFalse(entry.attributes.containsKey("reason"))
+    }
+
+    @Test
+    fun `before stage omits client when clientMetadata is null`() {
+        val testLogger = TestLogger()
+        val hook = LoggingHook(logger = testLogger)
+        val context = HookContext<Any>(
+            flagKey = "my-flag",
+            type = FlagValueType.BOOLEAN,
+            defaultValue = false,
+            ctx = null,
+            clientMetadata = null,
+            providerMetadata = TestProviderMetadata()
+        )
+
+        hook.before(context, emptyMap())
+
+        val entry = testLogger.debugMessages[0]
+        assertFalse(entry.attributes.containsKey("client"))
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerTests.kt
@@ -4,24 +4,23 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class LoggerTests {
     @Test
     fun `NoOpLogger executes without throwing`() {
         val logger = NoOpLogger()
 
-        // All methods should execute without throwing
-        logger.debug { "test message" }
-        logger.info { "test message" }
-        logger.warn { "test message" }
-        logger.error { "test message" }
+        logger.debug({ "test message" }, { emptyMap() })
+        logger.info({ "test message" }, { emptyMap() })
+        logger.warn({ "test message" }, { emptyMap() })
+        logger.error({ "test message" }, { emptyMap() })
 
-        // With throwables
         val throwable = RuntimeException("test exception")
-        logger.debug(throwable) { "test message" }
-        logger.info(throwable) { "test message" }
-        logger.warn(throwable) { "test message" }
-        logger.error(throwable) { "test message" }
+        logger.debug({ "test message" }, { emptyMap() }, throwable)
+        logger.info({ "test message" }, { emptyMap() }, throwable)
+        logger.warn({ "test message" }, { emptyMap() }, throwable)
+        logger.error({ "test message" }, { emptyMap() }, throwable)
     }
 
     @Test
@@ -29,86 +28,122 @@ class LoggerTests {
         val logger = NoOpLogger()
         var evaluated = false
 
-        logger.debug {
-            evaluated = true
-            "should not be evaluated"
-        }
+        logger.debug({ evaluated = true; "should not be evaluated" }, { emptyMap() })
 
         assertEquals(false, evaluated)
     }
 
     @Test
-    fun `TestLogger captures debug messages`() {
+    fun `NoOpLogger does not evaluate attributes lambda`() {
+        val logger = NoOpLogger()
+        var evaluated = false
+
+        logger.debug({ "msg" }, { evaluated = true; emptyMap() })
+
+        assertEquals(false, evaluated)
+    }
+
+    @Test
+    fun `NoOpLogger does not evaluate info lambdas`() {
+        val logger = NoOpLogger()
+        var msgEvaluated = false
+        var attrsEvaluated = false
+
+        logger.info({ msgEvaluated = true; "msg" }, { attrsEvaluated = true; emptyMap() })
+
+        assertEquals(false, msgEvaluated)
+        assertEquals(false, attrsEvaluated)
+    }
+
+    @Test
+    fun `NoOpLogger does not evaluate warn lambdas`() {
+        val logger = NoOpLogger()
+        var msgEvaluated = false
+        var attrsEvaluated = false
+
+        logger.warn({ msgEvaluated = true; "msg" }, { attrsEvaluated = true; emptyMap() })
+
+        assertEquals(false, msgEvaluated)
+        assertEquals(false, attrsEvaluated)
+    }
+
+    @Test
+    fun `NoOpLogger does not evaluate error lambdas`() {
+        val logger = NoOpLogger()
+        var msgEvaluated = false
+        var attrsEvaluated = false
+
+        logger.error({ msgEvaluated = true; "msg" }, { attrsEvaluated = true; emptyMap() })
+
+        assertEquals(false, msgEvaluated)
+        assertEquals(false, attrsEvaluated)
+    }
+
+    @Test
+    fun `TestLogger captures debug messages with attributes`() {
         val logger = TestLogger()
-        val message = "debug message"
+        val attrs = mapOf("flag" to "my-flag", "type" to "BOOLEAN")
         val throwable = RuntimeException("test exception")
 
-        logger.debug { message }
-        logger.debug(throwable) { "$message with throwable" }
+        logger.debug({ "debug message" }, { attrs })
+        logger.debug({ "debug with throwable" }, { emptyMap() }, throwable)
 
         assertEquals(2, logger.debugMessages.size)
-        assertEquals(message, logger.debugMessages[0].message)
+        assertEquals("debug message", logger.debugMessages[0].message)
+        assertEquals(attrs, logger.debugMessages[0].attributes)
         assertNull(logger.debugMessages[0].throwable)
-        assertEquals("$message with throwable", logger.debugMessages[1].message)
+        assertEquals("debug with throwable", logger.debugMessages[1].message)
+        assertEquals(emptyMap<String, Any?>(), logger.debugMessages[1].attributes)
         assertNotNull(logger.debugMessages[1].throwable)
     }
 
     @Test
-    fun `TestLogger captures info messages`() {
+    fun `TestLogger captures info messages with attributes`() {
         val logger = TestLogger()
-        val message = "info message"
-        val throwable = RuntimeException("test exception")
+        val attrs = mapOf("key" to "value")
 
-        logger.info { message }
-        logger.info(throwable) { "$message with throwable" }
+        logger.info({ "info message" }, { attrs })
 
-        assertEquals(2, logger.infoMessages.size)
-        assertEquals(message, logger.infoMessages[0].message)
+        assertEquals(1, logger.infoMessages.size)
+        assertEquals("info message", logger.infoMessages[0].message)
+        assertEquals(attrs, logger.infoMessages[0].attributes)
         assertNull(logger.infoMessages[0].throwable)
-        assertEquals("$message with throwable", logger.infoMessages[1].message)
-        assertNotNull(logger.infoMessages[1].throwable)
     }
 
     @Test
-    fun `TestLogger captures warn messages`() {
+    fun `TestLogger captures warn messages with attributes`() {
         val logger = TestLogger()
-        val message = "warn message"
-        val throwable = RuntimeException("test exception")
+        val attrs = mapOf("key" to "value")
 
-        logger.warn { message }
-        logger.warn(throwable) { "$message with throwable" }
+        logger.warn({ "warn message" }, { attrs })
 
-        assertEquals(2, logger.warnMessages.size)
-        assertEquals(message, logger.warnMessages[0].message)
-        assertNull(logger.warnMessages[0].throwable)
-        assertEquals("$message with throwable", logger.warnMessages[1].message)
-        assertNotNull(logger.warnMessages[1].throwable)
+        assertEquals(1, logger.warnMessages.size)
+        assertEquals("warn message", logger.warnMessages[0].message)
+        assertEquals(attrs, logger.warnMessages[0].attributes)
     }
 
     @Test
-    fun `TestLogger captures error messages`() {
+    fun `TestLogger captures error messages with attributes`() {
         val logger = TestLogger()
-        val message = "error message"
+        val attrs = mapOf("key" to "value")
         val throwable = RuntimeException("test exception")
 
-        logger.error { message }
-        logger.error(throwable) { "$message with throwable" }
+        logger.error({ "error message" }, { attrs }, throwable)
 
-        assertEquals(2, logger.errorMessages.size)
-        assertEquals(message, logger.errorMessages[0].message)
-        assertNull(logger.errorMessages[0].throwable)
-        assertEquals("$message with throwable", logger.errorMessages[1].message)
-        assertNotNull(logger.errorMessages[1].throwable)
+        assertEquals(1, logger.errorMessages.size)
+        assertEquals("error message", logger.errorMessages[0].message)
+        assertEquals(attrs, logger.errorMessages[0].attributes)
+        assertEquals(throwable, logger.errorMessages[0].throwable)
     }
 
     @Test
     fun `TestLogger clear removes all messages`() {
         val logger = TestLogger()
 
-        logger.debug { "debug" }
-        logger.info { "info" }
-        logger.warn { "warn" }
-        logger.error { "error" }
+        logger.debug({ "debug" }, { emptyMap() })
+        logger.info({ "info" }, { emptyMap() })
+        logger.warn({ "warn" }, { emptyMap() })
+        logger.error({ "error" }, { emptyMap() })
 
         assertEquals(4, logger.getAllMessages().size)
 
@@ -125,10 +160,10 @@ class LoggerTests {
     fun `TestLogger getAllMessages returns all messages in order`() {
         val logger = TestLogger()
 
-        logger.debug { "message 1" }
-        logger.info { "message 2" }
-        logger.warn { "message 3" }
-        logger.error { "message 4" }
+        logger.debug({ "message 1" }, { emptyMap() })
+        logger.info({ "message 2" }, { emptyMap() })
+        logger.warn({ "message 3" }, { emptyMap() })
+        logger.error({ "message 4" }, { emptyMap() })
 
         val allMessages = logger.getAllMessages()
         assertEquals(4, allMessages.size)
@@ -136,6 +171,64 @@ class LoggerTests {
         assertEquals("message 2", allMessages[1].message)
         assertEquals("message 3", allMessages[2].message)
         assertEquals("message 4", allMessages[3].message)
+    }
+
+    @Test
+    fun `TestLogger attributes are evaluated and stored`() {
+        val logger = TestLogger()
+        val attrs = mapOf<String, Any?>("flag" to "test-flag", "value" to true, "count" to 42)
+
+        logger.debug({ "msg" }, { attrs })
+
+        val entry = logger.debugMessages[0]
+        assertEquals("test-flag", entry.attributes["flag"])
+        assertEquals(true, entry.attributes["value"])
+        assertEquals(42, entry.attributes["count"])
+    }
+
+    @Test
+    fun `TestLogger supports null values in attributes`() {
+        val logger = TestLogger()
+
+        logger.debug({ "msg" }, { mapOf("nullKey" to null) })
+
+        assertTrue(logger.debugMessages[0].attributes.containsKey("nullKey"))
+        assertNull(logger.debugMessages[0].attributes["nullKey"])
+    }
+
+    @Test
+    fun `formatLogLine returns message when attributes empty and no throwable`() {
+        assertEquals("hello world", formatLogLine("hello world", emptyMap()))
+    }
+
+    @Test
+    fun `formatLogLine appends attributes as key=value pairs`() {
+        val result = formatLogLine("msg", mapOf("flag" to "my-flag", "type" to "BOOLEAN"))
+        assertTrue(result.startsWith("msg "))
+        assertTrue(result.contains("flag=my-flag"))
+        assertTrue(result.contains("type=BOOLEAN"))
+    }
+
+    @Test
+    fun `formatLogLine renders null attribute values`() {
+        val result = formatLogLine("msg", mapOf("key" to null))
+        assertEquals("msg key=null", result)
+    }
+
+    @Test
+    fun `formatLogLine appends throwable stacktrace on new line`() {
+        val t = RuntimeException("boom")
+        val result = formatLogLine("msg", emptyMap(), t)
+        assertTrue(result.startsWith("msg\n"))
+        assertTrue(result.contains("boom"))
+    }
+
+    @Test
+    fun `formatLogLine with attributes and throwable includes both`() {
+        val t = RuntimeException("boom")
+        val result = formatLogLine("msg", mapOf("k" to "v"), t)
+        assertTrue(result.startsWith("msg k=v\n"))
+        assertTrue(result.contains("boom"))
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerTests.kt
@@ -11,16 +11,16 @@ class LoggerTests {
     fun `NoOpLogger executes without throwing`() {
         val logger = NoOpLogger()
 
-        logger.debug({ "test message" }, { emptyMap() })
-        logger.info({ "test message" }, { emptyMap() })
-        logger.warn({ "test message" }, { emptyMap() })
-        logger.error({ "test message" }, { emptyMap() })
+        logger.debug({ "test message" })
+        logger.info({ "test message" })
+        logger.warn({ "test message" })
+        logger.error({ "test message" })
 
         val throwable = RuntimeException("test exception")
-        logger.debug({ "test message" }, { emptyMap() }, throwable)
-        logger.info({ "test message" }, { emptyMap() }, throwable)
-        logger.warn({ "test message" }, { emptyMap() }, throwable)
-        logger.error({ "test message" }, { emptyMap() }, throwable)
+        logger.debug({ "test message" }, throwable = throwable)
+        logger.info({ "test message" }, throwable = throwable)
+        logger.warn({ "test message" }, throwable = throwable)
+        logger.error({ "test message" }, throwable = throwable)
     }
 
     @Test
@@ -28,7 +28,7 @@ class LoggerTests {
         val logger = NoOpLogger()
         var evaluated = false
 
-        logger.debug({ evaluated = true; "should not be evaluated" }, { emptyMap() })
+        logger.debug({ evaluated = true; "should not be evaluated" })
 
         assertEquals(false, evaluated)
     }
@@ -38,6 +38,7 @@ class LoggerTests {
         val logger = NoOpLogger()
         var evaluated = false
 
+        // Keep explicit attributes lambda to verify NoOpLogger skips it
         logger.debug({ "msg" }, { evaluated = true; emptyMap() })
 
         assertEquals(false, evaluated)
@@ -86,7 +87,7 @@ class LoggerTests {
         val throwable = RuntimeException("test exception")
 
         logger.debug({ "debug message" }, { attrs })
-        logger.debug({ "debug with throwable" }, { emptyMap() }, throwable)
+        logger.debug({ "debug with throwable" }, throwable = throwable)
 
         assertEquals(2, logger.debugMessages.size)
         assertEquals("debug message", logger.debugMessages[0].message)
@@ -140,10 +141,10 @@ class LoggerTests {
     fun `TestLogger clear removes all messages`() {
         val logger = TestLogger()
 
-        logger.debug({ "debug" }, { emptyMap() })
-        logger.info({ "info" }, { emptyMap() })
-        logger.warn({ "warn" }, { emptyMap() })
-        logger.error({ "error" }, { emptyMap() })
+        logger.debug({ "debug" })
+        logger.info({ "info" })
+        logger.warn({ "warn" })
+        logger.error({ "error" })
 
         assertEquals(4, logger.getAllMessages().size)
 
@@ -160,10 +161,10 @@ class LoggerTests {
     fun `TestLogger getAllMessages returns all messages in order`() {
         val logger = TestLogger()
 
-        logger.debug({ "message 1" }, { emptyMap() })
-        logger.info({ "message 2" }, { emptyMap() })
-        logger.warn({ "message 3" }, { emptyMap() })
-        logger.error({ "message 4" }, { emptyMap() })
+        logger.debug({ "message 1" })
+        logger.info({ "message 2" })
+        logger.warn({ "message 3" })
+        logger.error({ "message 4" })
 
         val allMessages = logger.getAllMessages()
         assertEquals(4, allMessages.size)
@@ -194,6 +195,13 @@ class LoggerTests {
 
         assertTrue(logger.debugMessages[0].attributes.containsKey("nullKey"))
         assertNull(logger.debugMessages[0].attributes["nullKey"])
+    }
+
+    @Test
+    fun `Logger default attributes produce emptyMap`() {
+        val logger = TestLogger()
+        logger.debug({ "msg" })
+        assertEquals(emptyMap<String, Any?>(), logger.debugMessages[0].attributes)
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/TestLogger.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/TestLogger.kt
@@ -5,7 +5,8 @@ import kotlinx.atomicfu.locks.synchronized
 
 /**
  * A test logger that captures all log messages for verification in tests.
- * This allows tests to verify that the correct messages are logged at the correct levels.
+ * This allows tests to verify that the correct messages are logged at the correct levels,
+ * with the correct structured attributes.
  *
  * This implementation is thread-safe to prevent ConcurrentModificationException
  * when hooks are invoked from multiple coroutines during testing.
@@ -27,34 +28,34 @@ class TestLogger : Logger {
     val warnMessages: List<LogEntry> get() = synchronized(lock) { _warnMessages.toList() }
     val errorMessages: List<LogEntry> get() = synchronized(lock) { _errorMessages.toList() }
 
-    data class LogEntry(val message: String, val throwable: Throwable?)
+    data class LogEntry(val message: String, val attributes: Map<String, Any?>, val throwable: Throwable?)
 
-    override fun debug(throwable: Throwable?, message: () -> String) {
-        val entry = LogEntry(message(), throwable)
+    override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val entry = LogEntry(message(), attributes(), throwable)
         synchronized(lock) {
             _debugMessages.add(entry)
             _allMessages.add(entry)
         }
     }
 
-    override fun info(throwable: Throwable?, message: () -> String) {
-        val entry = LogEntry(message(), throwable)
+    override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val entry = LogEntry(message(), attributes(), throwable)
         synchronized(lock) {
             _infoMessages.add(entry)
             _allMessages.add(entry)
         }
     }
 
-    override fun warn(throwable: Throwable?, message: () -> String) {
-        val entry = LogEntry(message(), throwable)
+    override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val entry = LogEntry(message(), attributes(), throwable)
         synchronized(lock) {
             _warnMessages.add(entry)
             _allMessages.add(entry)
         }
     }
 
-    override fun error(throwable: Throwable?, message: () -> String) {
-        val entry = LogEntry(message(), throwable)
+    override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val entry = LogEntry(message(), attributes(), throwable)
         synchronized(lock) {
             _errorMessages.add(entry)
             _allMessages.add(entry)

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/TestLogger.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/logging/TestLogger.kt
@@ -31,6 +31,10 @@ class TestLogger : Logger {
     data class LogEntry(val message: String, val attributes: Map<String, Any?>, val throwable: Throwable?)
 
     override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        // Lambdas are evaluated before acquiring the lock. In this test context they only
+        // capture immutable hook context data, so there is no data race in practice.
+        // Evaluating inside the lock would be unsafe if a lambda itself tried to acquire
+        // another lock, which simple test lambdas never do.
         val entry = LogEntry(message(), attributes(), throwable)
         synchronized(lock) {
             _debugMessages.add(entry)

--- a/kotlin-sdk/src/iosMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/iosMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -14,29 +14,24 @@ actual object LoggerFactory {
  * iOS-specific logger implementation using NSLog.
  * Logs are visible in Xcode console and device logs.
  * NSLog prepends a timestamp automatically, so no additional timestamp is included.
+ * Attributes are appended to the message as key=value pairs.
  */
 internal class IosLogger(private val tag: String) : Logger {
-    private fun formatMessage(level: String, message: String, throwable: Throwable?): String =
-        buildString {
-            append("[$level] $tag - $message")
-            if (throwable != null) {
-                append("\n${throwable.stackTraceToString()}")
-            }
-        }
+    private fun prefix(level: String) = "[$level] $tag - "
 
-    override fun debug(throwable: Throwable?, message: () -> String) {
-        NSLog("%@", formatMessage("DEBUG", message(), throwable))
+    override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        NSLog("%@", formatLogLine(prefix("DEBUG") + message(), attributes(), throwable))
     }
 
-    override fun info(throwable: Throwable?, message: () -> String) {
-        NSLog("%@", formatMessage("INFO", message(), throwable))
+    override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        NSLog("%@", formatLogLine(prefix("INFO") + message(), attributes(), throwable))
     }
 
-    override fun warn(throwable: Throwable?, message: () -> String) {
-        NSLog("%@", formatMessage("WARN", message(), throwable))
+    override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        NSLog("%@", formatLogLine(prefix("WARN") + message(), attributes(), throwable))
     }
 
-    override fun error(throwable: Throwable?, message: () -> String) {
-        NSLog("%@", formatMessage("ERROR", message(), throwable))
+    override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        NSLog("%@", formatLogLine(prefix("ERROR") + message(), attributes(), throwable))
     }
 }

--- a/kotlin-sdk/src/jsMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/jsMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -11,25 +11,62 @@ actual object LoggerFactory {
 /**
  * JavaScript-specific logger implementation using the console API.
  * Logs are visible in the browser console or Node.js console.
+ * Attributes are converted to a plain JS object so browser devtools
+ * display them as an expandable key-value structure.
  */
 internal class JsLogger(private val tag: String) : Logger {
-    override fun debug(throwable: Throwable?, message: () -> String) {
-        val msg = "[$tag] ${message()}"
-        if (throwable != null) console.log(msg, throwable) else console.log(msg)
+    // Convert to a plain JS object so devtools shows {key: value} not Kotlin internals.
+    private fun toJsObject(attrs: Map<String, Any?>): dynamic {
+        val obj = js("{}")
+        attrs.forEach { (k, v) -> obj[k] = v }
+        return obj
     }
 
-    override fun info(throwable: Throwable?, message: () -> String) {
+    override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
         val msg = "[$tag] ${message()}"
-        if (throwable != null) console.info(msg, throwable) else console.info(msg)
+        val attrs = attributes()
+        if (throwable != null) {
+            console.log(msg, toJsObject(attrs), throwable)
+        } else if (attrs.isNotEmpty()) {
+            console.log(msg, toJsObject(attrs))
+        } else {
+            console.log(msg)
+        }
     }
 
-    override fun warn(throwable: Throwable?, message: () -> String) {
+    override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
         val msg = "[$tag] ${message()}"
-        if (throwable != null) console.warn(msg, throwable) else console.warn(msg)
+        val attrs = attributes()
+        if (throwable != null) {
+            console.info(msg, toJsObject(attrs), throwable)
+        } else if (attrs.isNotEmpty()) {
+            console.info(msg, toJsObject(attrs))
+        } else {
+            console.info(msg)
+        }
     }
 
-    override fun error(throwable: Throwable?, message: () -> String) {
+    override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
         val msg = "[$tag] ${message()}"
-        if (throwable != null) console.error(msg, throwable) else console.error(msg)
+        val attrs = attributes()
+        if (throwable != null) {
+            console.warn(msg, toJsObject(attrs), throwable)
+        } else if (attrs.isNotEmpty()) {
+            console.warn(msg, toJsObject(attrs))
+        } else {
+            console.warn(msg)
+        }
+    }
+
+    override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        val msg = "[$tag] ${message()}"
+        val attrs = attributes()
+        if (throwable != null) {
+            console.error(msg, toJsObject(attrs), throwable)
+        } else if (attrs.isNotEmpty()) {
+            console.error(msg, toJsObject(attrs))
+        } else {
+            console.error(msg)
+        }
     }
 }

--- a/kotlin-sdk/src/jsMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/jsMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -26,7 +26,11 @@ internal class JsLogger(private val tag: String) : Logger {
         val msg = "[$tag] ${message()}"
         val attrs = attributes()
         if (throwable != null) {
-            console.log(msg, toJsObject(attrs), throwable)
+            if (attrs.isNotEmpty()) {
+                console.log(msg, toJsObject(attrs), throwable)
+            } else {
+                console.log(msg, throwable)
+            }
         } else if (attrs.isNotEmpty()) {
             console.log(msg, toJsObject(attrs))
         } else {
@@ -38,7 +42,11 @@ internal class JsLogger(private val tag: String) : Logger {
         val msg = "[$tag] ${message()}"
         val attrs = attributes()
         if (throwable != null) {
-            console.info(msg, toJsObject(attrs), throwable)
+            if (attrs.isNotEmpty()) {
+                console.info(msg, toJsObject(attrs), throwable)
+            } else {
+                console.info(msg, throwable)
+            }
         } else if (attrs.isNotEmpty()) {
             console.info(msg, toJsObject(attrs))
         } else {
@@ -50,7 +58,11 @@ internal class JsLogger(private val tag: String) : Logger {
         val msg = "[$tag] ${message()}"
         val attrs = attributes()
         if (throwable != null) {
-            console.warn(msg, toJsObject(attrs), throwable)
+            if (attrs.isNotEmpty()) {
+                console.warn(msg, toJsObject(attrs), throwable)
+            } else {
+                console.warn(msg, throwable)
+            }
         } else if (attrs.isNotEmpty()) {
             console.warn(msg, toJsObject(attrs))
         } else {
@@ -62,7 +74,11 @@ internal class JsLogger(private val tag: String) : Logger {
         val msg = "[$tag] ${message()}"
         val attrs = attributes()
         if (throwable != null) {
-            console.error(msg, toJsObject(attrs), throwable)
+            if (attrs.isNotEmpty()) {
+                console.error(msg, toJsObject(attrs), throwable)
+            } else {
+                console.error(msg, throwable)
+            }
         } else if (attrs.isNotEmpty()) {
             console.error(msg, toJsObject(attrs))
         } else {

--- a/kotlin-sdk/src/jvmMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/jvmMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -15,29 +15,24 @@ actual object LoggerFactory {
 /**
  * JVM-specific logger implementation using System.out and System.err.
  * Logs include timestamps and follow standard formatting.
+ * Attributes are appended to the message as key=value pairs.
  */
 internal class JvmLogger(private val tag: String) : Logger {
-    private fun formatMessage(level: String, message: String, throwable: Throwable?): String =
-        buildString {
-            append("${Instant.now()} [$level] $tag - $message")
-            if (throwable != null) {
-                append("\n${throwable.stackTraceToString()}")
-            }
-        }
+    private fun prefix(level: String) = "${Instant.now()} [$level] $tag - "
 
-    override fun debug(throwable: Throwable?, message: () -> String) {
-        println(formatMessage("DEBUG", message(), throwable))
+    override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        println(formatLogLine(prefix("DEBUG") + message(), attributes(), throwable))
     }
 
-    override fun info(throwable: Throwable?, message: () -> String) {
-        println(formatMessage("INFO", message(), throwable))
+    override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        println(formatLogLine(prefix("INFO") + message(), attributes(), throwable))
     }
 
-    override fun warn(throwable: Throwable?, message: () -> String) {
-        System.err.println(formatMessage("WARN", message(), throwable))
+    override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        System.err.println(formatLogLine(prefix("WARN") + message(), attributes(), throwable))
     }
 
-    override fun error(throwable: Throwable?, message: () -> String) {
-        System.err.println(formatMessage("ERROR", message(), throwable))
+    override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        System.err.println(formatLogLine(prefix("ERROR") + message(), attributes(), throwable))
     }
 }

--- a/kotlin-sdk/src/linuxX64Main/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/linuxX64Main/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -17,32 +17,31 @@ actual object LoggerFactory {
  * Warnings and errors are written to stderr following POSIX conventions.
  * Timestamps are omitted as Linux deployments typically run under systemd or similar
  * which provide their own timestamping.
+ * Attributes are appended to the message as key=value pairs.
  * Suitable for CLI applications and native executables.
  */
 internal class NativeLogger(private val tag: String) : Logger {
-    private fun formatMessage(level: String, message: String, throwable: Throwable?): String =
-        buildString {
-            append("[$level] $tag - $message")
-            if (throwable != null) {
-                append("\n${throwable.stackTraceToString()}")
-            }
-        }
+    private fun prefix(level: String) = "[$level] $tag - "
 
-    override fun debug(throwable: Throwable?, message: () -> String) {
-        println(formatMessage("DEBUG", message(), throwable))
+    override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        println(formatLogLine(prefix("DEBUG") + message(), attributes(), throwable))
     }
 
-    override fun info(throwable: Throwable?, message: () -> String) {
-        println(formatMessage("INFO", message(), throwable))
+    override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        println(formatLogLine(prefix("INFO") + message(), attributes(), throwable))
+    }
+
+    // fprintf appends "\n" after the formatted line. When a throwable is present,
+    // formatLogLine already ends with "\n<stacktrace>", so the output ends with two
+    // newlines. This matches systemd journal conventions where a blank line separates
+    // multi-line log entries, and was the behavior before this utility was extracted.
+    @OptIn(ExperimentalForeignApi::class)
+    override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        fprintf(stderr, "%s\n", formatLogLine(prefix("WARN") + message(), attributes(), throwable))
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    override fun warn(throwable: Throwable?, message: () -> String) {
-        fprintf(stderr, "%s\n", formatMessage("WARN", message(), throwable))
-    }
-
-    @OptIn(ExperimentalForeignApi::class)
-    override fun error(throwable: Throwable?, message: () -> String) {
-        fprintf(stderr, "%s\n", formatMessage("ERROR", message(), throwable))
+    override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
+        fprintf(stderr, "%s\n", formatLogLine(prefix("ERROR") + message(), attributes(), throwable))
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the previous \`Logger\` interface (which had no message-lazy evaluation) with \`fun debug/info/warn/error(throwable: Throwable? = null, message: () -> String)\`
- The message lambda is lazy — \`NoOpLogger\` never evaluates it, keeping disabled-logging at zero cost
- Throwable comes before the trailing lambda so callers can use idiomatic Kotlin trailing-lambda syntax: \`logger.debug { "msg" }\` and \`logger.error(exception) { "msg" }\`
- \`LoggingHook\` builds formatted log strings internally via \`formatValue()\`, \`formatAnyValue()\`, and \`formatContext()\` helpers rather than relying on the logger to handle structured data
- Platform loggers (Android, JVM, iOS, Linux) are simplified — they only need to handle \`message\` + optional \`throwable\`, no attribute formatting
- \`TestLogger\` captures \`LogEntry(message, throwable)\` for assertion in tests

## Test plan

- [ ] All unit tests pass (\`./gradlew :kotlin-sdk:jvmTest\`)
- [ ] \`LoggingHookTests\` asserts on formatted message strings
- [ ] \`LoggerTests\` covers lazy evaluation (NoOp does not call message lambda)
- [ ] \`apiDump\` files committed and up to date