### PR TITLE
feat: add provider status to client (#205)

### DIFF
--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -19,6 +19,7 @@ public abstract interface class dev/openfeature/kotlin/sdk/Client : dev/openfeat
 	public abstract fun addHooks (Ljava/util/List;)V
 	public abstract fun getHooks ()Ljava/util/List;
 	public abstract fun getMetadata ()Ldev/openfeature/kotlin/sdk/ClientMetadata;
+	public abstract fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public abstract fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
 }
 
@@ -313,6 +314,7 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureClient : dev/openfeatur
 	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;)Ldev/openfeature/kotlin/sdk/Value;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/Value;
+	public fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -19,8 +19,12 @@ public abstract interface class dev/openfeature/kotlin/sdk/Client : dev/openfeat
 	public abstract fun addHooks (Ljava/util/List;)V
 	public abstract fun getHooks ()Ljava/util/List;
 	public abstract fun getMetadata ()Ldev/openfeature/kotlin/sdk/ClientMetadata;
-	public abstract fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
+	public fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public abstract fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class dev/openfeature/kotlin/sdk/Client$DefaultImpls {
+	public static fun getProviderStatus (Ldev/openfeature/kotlin/sdk/Client;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/ClientMetadata {

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -19,6 +19,7 @@ public abstract interface class dev/openfeature/kotlin/sdk/Client : dev/openfeat
 	public abstract fun addHooks (Ljava/util/List;)V
 	public abstract fun getHooks ()Ljava/util/List;
 	public abstract fun getMetadata ()Ldev/openfeature/kotlin/sdk/ClientMetadata;
+	public abstract fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public abstract fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
 }
 
@@ -313,6 +314,7 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureClient : dev/openfeatur
 	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;)Ldev/openfeature/kotlin/sdk/Value;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/Value;
+	public fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -19,8 +19,12 @@ public abstract interface class dev/openfeature/kotlin/sdk/Client : dev/openfeat
 	public abstract fun addHooks (Ljava/util/List;)V
 	public abstract fun getHooks ()Ljava/util/List;
 	public abstract fun getMetadata ()Ldev/openfeature/kotlin/sdk/ClientMetadata;
-	public abstract fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
+	public fun getProviderStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public abstract fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class dev/openfeature/kotlin/sdk/Client$DefaultImpls {
+	public static fun getProviderStatus (Ldev/openfeature/kotlin/sdk/Client;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 
 public abstract interface class dev/openfeature/kotlin/sdk/ClientMetadata {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
@@ -10,7 +10,7 @@ interface Client : Features, Tracking {
     fun addHooks(hooks: List<Hook<*>>)
 
     /**
-     * Get the current [OpenFeatureStatus] of the Provider handling this client's evaluations.
+     * Get the current [OpenFeatureStatus] of the Provider handling this client's evaluations, or [OpenFeatureStatus.NotReady] if no Provider has been initialized.
      */
-    fun getProviderStatus(): OpenFeatureStatus
+    fun getProviderStatus(): OpenFeatureStatus = OpenFeatureStatus.NotReady
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
@@ -8,4 +8,9 @@ interface Client : Features, Tracking {
     val statusFlow: Flow<OpenFeatureStatus>
 
     fun addHooks(hooks: List<Hook<*>>)
+
+    /**
+     * Get the current [OpenFeatureStatus] of the Provider handling this client's evaluations.
+     */
+    fun getProviderStatus(): OpenFeatureStatus
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
@@ -5,6 +5,11 @@ import kotlinx.coroutines.flow.Flow
 interface Client : Features, Tracking {
     val metadata: ClientMetadata
     val hooks: List<Hook<*>>
+    /**
+     * A [Flow] that emits the initial [OpenFeatureStatus] and all subsequent state transitions
+     * of the Provider handling this client's evaluations. This enables reactive observation
+     * of the provider's lifecycle.
+     */
     val statusFlow: Flow<OpenFeatureStatus>
 
     fun addHooks(hooks: List<Hook<*>>)
@@ -12,5 +17,6 @@ interface Client : Features, Tracking {
     /**
      * Get the current [OpenFeatureStatus] of the Provider handling this client's evaluations, or [OpenFeatureStatus.NotReady] if no Provider has been initialized.
      */
-    fun getProviderStatus(): OpenFeatureStatus = OpenFeatureStatus.NotReady
+    val providerStatus: OpenFeatureStatus
+        get() = OpenFeatureStatus.NotReady
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface Client : Features, Tracking {
     val metadata: ClientMetadata
     val hooks: List<Hook<*>>
+
     /**
      * A [Flow] that emits the initial [OpenFeatureStatus] and all subsequent state transitions
      * of the Provider handling this client's evaluations. This enables reactive observation

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPI.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPI.kt
@@ -192,7 +192,11 @@ object OpenFeatureAPI {
         } catch (e: CancellationException) {
             // This happens by design and shouldn't be treated as an error
         } catch (e: OpenFeatureError) {
-            _statusFlow.emit(OpenFeatureStatus.Error(e))
+            if (e is OpenFeatureError.ProviderFatalError) {
+                _statusFlow.emit(OpenFeatureStatus.Fatal(e))
+            } else {
+                _statusFlow.emit(OpenFeatureStatus.Error(e))
+            }
         } catch (e: Throwable) {
             _statusFlow.emit(
                 OpenFeatureStatus.Error(

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
@@ -26,9 +26,8 @@ class OpenFeatureClient(
 
     override val statusFlow = openFeatureAPI.statusFlow
 
-    override fun getProviderStatus(): OpenFeatureStatus {
-        return openFeatureAPI.getStatus()
-    }
+    override val providerStatus: OpenFeatureStatus
+        get() = openFeatureAPI.getStatus()
 
     override fun getBooleanValue(key: String, defaultValue: Boolean): Boolean {
         return getBooleanDetails(key, defaultValue).value
@@ -223,7 +222,7 @@ class OpenFeatureClient(
     }
 
     private fun shortCircuitIfNotReady() {
-        val providerStatus = getProviderStatus()
+        val providerStatus = this.providerStatus
         if (providerStatus == OpenFeatureStatus.NotReady) {
             throw OpenFeatureError.ProviderNotReadyError()
         } else if (providerStatus is OpenFeatureStatus.Fatal) {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
@@ -26,6 +26,10 @@ class OpenFeatureClient(
 
     override val statusFlow = openFeatureAPI.statusFlow
 
+    override fun getProviderStatus(): OpenFeatureStatus {
+        return openFeatureAPI.getStatus()
+    }
+
     override fun getBooleanValue(key: String, defaultValue: Boolean): Boolean {
         return getBooleanDetails(key, defaultValue).value
     }
@@ -219,7 +223,7 @@ class OpenFeatureClient(
     }
 
     private fun shortCircuitIfNotReady() {
-        val providerStatus = openFeatureAPI.getStatus()
+        val providerStatus = getProviderStatus()
         if (providerStatus == OpenFeatureStatus.NotReady) {
             throw OpenFeatureError.ProviderNotReadyError()
         } else if (providerStatus is OpenFeatureStatus.Fatal) {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Telemetry.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Telemetry.kt
@@ -32,11 +32,18 @@ fun <T> createEvaluationEvent(
 ): EvaluationEvent {
     val attributes = mutableMapOf<String, Any?>()
     val body = mutableMapOf<String, Any?>()
+
+    // In OpenTelemetry (and observability in general), if a piece of telemetry data isn't available,
+    // the best practice is to omit the attribute entirely rather than sending it with an empty string ("") or a null value.
     attributes[TELEMETRY_KEY] = hookContext.flagKey
-    attributes[TELEMETRY_PROVIDER] = hookContext.providerMetadata.name ?: ""
+    hookContext.providerMetadata.name?.takeIf { it.isNotEmpty() }?.let { attributes[TELEMETRY_PROVIDER] = it }
     attributes[TELEMETRY_REASON] = flagEvaluationDetails.reason?.lowercase() ?: Reason.UNKNOWN.name.lowercase()
-    attributes[TELEMETRY_CONTEXT_ID] =
-        flagEvaluationDetails.metadata.getString(TELEMETRY_FLAG_META_CONTEXT_ID) ?: hookContext.ctx?.getTargetingKey()
+
+    val contextId = flagEvaluationDetails.metadata.getString(TELEMETRY_FLAG_META_CONTEXT_ID)
+        ?: hookContext.ctx?.getTargetingKey()
+    if (!contextId.isNullOrEmpty()) {
+        attributes[TELEMETRY_CONTEXT_ID] = contextId
+    }
     flagEvaluationDetails.metadata.getString(TELEMETRY_FLAG_META_FLAG_SET_ID)?.let {
         attributes[TELEMETRY_FLAG_SET_ID] = it
     }
@@ -49,7 +56,7 @@ fun <T> createEvaluationEvent(
         attributes[TELEMETRY_VARIANT] = variant
     }
 
-    if (flagEvaluationDetails.reason == Reason.ERROR.name) {
+    if (flagEvaluationDetails.reason.equals(Reason.ERROR.name, ignoreCase = true)) {
         attributes[TELEMETRY_ERROR_CODE] = flagEvaluationDetails.errorCode ?: ErrorCode.GENERAL
         flagEvaluationDetails.errorMessage?.let { attributes[TELEMETRY_ERROR_MSG] = it }
     }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Telemetry.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Telemetry.kt
@@ -4,23 +4,21 @@ import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 
 const val TELEMETRY_KEY = "feature_flag.key"
 const val TELEMETRY_ERROR_CODE = "error.type"
-const val TELEMETRY_VARIANT = "feature_flag.variant"
+const val TELEMETRY_VARIANT = "feature_flag.result.variant"
 const val TELEMETRY_CONTEXT_ID = "feature_flag.context.id"
-const val TELEMETRY_ERROR_MSG = "feature_flag.evaluation.error.message"
-const val TELEMETRY_REASON = "feature_flag.evaluation.reason"
-const val TELEMETRY_PROVIDER = "feature_flag.provider_name"
+const val TELEMETRY_ERROR_MSG = "error.message"
+const val TELEMETRY_REASON = "feature_flag.result.reason"
+const val TELEMETRY_PROVIDER = "feature_flag.provider.name"
 const val TELEMETRY_FLAG_SET_ID = "feature_flag.set.id"
 const val TELEMETRY_VERSION = "feature_flag.version"
 
-// Well-known flag metadata attributes for telemetry events.
-// Specification: https://openfeature.dev/specification/appendix-d#flag-metadata
 const val TELEMETRY_FLAG_META_CONTEXT_ID = "contextId"
 const val TELEMETRY_FLAG_META_FLAG_SET_ID = "flagSetId"
 const val TELEMETRY_FLAG_META_VERSION = "version"
 
 // OpenTelemetry event body.
 // Specification: https://opentelemetry.io/docs/specs/semconv/feature-flags/feature-flags-logs/
-const val TELEMETRY_BODY = "value"
+const val TELEMETRY_BODY = "feature_flag.result.value"
 
 const val FLAG_EVALUATION_EVENT_NAME = "feature_flag.evaluation"
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
@@ -6,7 +6,9 @@ import dev.openfeature.kotlin.sdk.helpers.GenericSpyHookMock
 import dev.openfeature.kotlin.sdk.helpers.OverlyEmittingProvider
 import dev.openfeature.kotlin.sdk.helpers.SlowProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -62,24 +64,38 @@ class OpenFeatureClientTests {
     fun testClientGetProviderStatusShouldReturnReconcilingWhileContextIsBeingUpdated() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val slowProvider = SlowProvider(dispatcher = dispatcher)
+        val client = OpenFeatureAPI.getClient()
+
+        // 1. Launch a background collector to record the sequential history
+        val emittedStatuses = mutableListOf<OpenFeatureStatus>()
+        val collectorJob = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            client.statusFlow.collect { emittedStatuses.add(it) }
+        }
+
         OpenFeatureAPI.setProvider(slowProvider, dispatcher = dispatcher)
 
         // Wait for SlowProvider initialized (2000ms delay)
         advanceTimeBy(2001)
 
-        val client = OpenFeatureAPI.getClient()
-        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
-
         // Trigger a context update (takes 2000ms natively)
         OpenFeatureAPI.setEvaluationContext(ImmutableContext(targetingKey = "user-123"), dispatcher)
 
-        // Run execution queue deterministically to ensure coroutine reaches emit(Reconciling)
-        runCurrent()
-        assertEquals(OpenFeatureStatus.Reconciling, client.getProviderStatus())
-
         // Wait out the remaining 2000ms for slow context update finish
         advanceTimeBy(2001)
-        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
+
+        // 2. Assert the sequence natively!
+        // Expect: Initial NotReady -> Provider Ready -> Reconciling context -> Provider Ready again
+        assertEquals(
+            listOf(
+                OpenFeatureStatus.NotReady,
+                OpenFeatureStatus.Ready,
+                OpenFeatureStatus.Reconciling,
+                OpenFeatureStatus.Ready
+            ),
+            emittedStatuses
+        )
+
+        collectorJob.cancel()
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
@@ -136,4 +136,42 @@ class OpenFeatureClientTests {
 
         assertEquals(OpenFeatureStatus.Stale, client.providerStatus)
     }
+
+    @Test
+    fun testClientEvaluationShouldReturnProviderNotReadyWhenEvaluatingBeforeProviderIsReady() = runTest {
+        val client = OpenFeatureAPI.getClient()
+        val details = client.getBooleanDetails("test-flag", false)
+        assertEquals(dev.openfeature.kotlin.sdk.exceptions.ErrorCode.PROVIDER_NOT_READY, details.errorCode)
+    }
+
+    @Test
+    fun testClientEvaluationShouldReturnProviderFatalWhenEvaluatingWithFatalProvider() = runTest {
+        val fatalProvider = object : FeatureProvider by NoOpProvider() {
+            override suspend fun initialize(initialContext: EvaluationContext?) {
+                throw OpenFeatureError.ProviderFatalError("test fatal error")
+            }
+        }
+        OpenFeatureAPI.setProviderAndWait(fatalProvider)
+        val client = OpenFeatureAPI.getClient()
+        val details = client.getBooleanDetails("test-flag", false)
+        assertEquals(dev.openfeature.kotlin.sdk.exceptions.ErrorCode.PROVIDER_FATAL, details.errorCode)
+    }
+
+    @Test
+    fun testClientEvaluationShouldMapGeneralExceptionsToGeneralErrorCode() = runTest {
+        val throwingProvider = object : FeatureProvider by NoOpProvider() {
+            override fun getBooleanEvaluation(
+                key: String,
+                defaultValue: Boolean,
+                context: EvaluationContext?
+            ): ProviderEvaluation<Boolean> {
+                throw IllegalStateException("Generic unexpected crash")
+            }
+        }
+        OpenFeatureAPI.setProviderAndWait(throwingProvider)
+        val client = OpenFeatureAPI.getClient()
+        val details = client.getBooleanDetails("test-flag", false)
+        assertEquals(dev.openfeature.kotlin.sdk.exceptions.ErrorCode.GENERAL, details.errorCode)
+        assertEquals("Generic unexpected crash", details.errorMessage)
+    }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
@@ -39,7 +39,7 @@ class OpenFeatureClientTests {
     fun testClientGetProviderStatusShouldReturnReadyWhenProviderIsInitialized() = runTest {
         OpenFeatureAPI.setProviderAndWait(NoOpProvider())
         val client = OpenFeatureAPI.getClient()
-        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
+        assertEquals(OpenFeatureStatus.Ready, client.providerStatus)
     }
 
     /**
@@ -49,7 +49,7 @@ class OpenFeatureClientTests {
     fun testClientGetProviderStatusShouldReturnErrorWhenProviderFailsToInitialize() = runTest {
         OpenFeatureAPI.setProviderAndWait(BrokenInitProvider())
         val client = OpenFeatureAPI.getClient()
-        val status = client.getProviderStatus()
+        val status = client.providerStatus
         assertTrue(status is OpenFeatureStatus.Error)
         assertTrue(
             (status as OpenFeatureStatus.Error).error is OpenFeatureError.ProviderNotReadyError
@@ -107,7 +107,7 @@ class OpenFeatureClientTests {
         }
         OpenFeatureAPI.setProviderAndWait(fatalProvider)
         val client = OpenFeatureAPI.getClient()
-        val status = client.getProviderStatus()
+        val status = client.providerStatus
         assertTrue(status is OpenFeatureStatus.Fatal)
         assertTrue(
             (status as OpenFeatureStatus.Fatal).error is OpenFeatureError.ProviderFatalError
@@ -118,7 +118,7 @@ class OpenFeatureClientTests {
     fun testClientGetProviderStatusShouldReturnNotReadyBeforeProviderIsSet() = runTest {
         val client = OpenFeatureAPI.getClient()
         // No provider is set, so it should be NotReady
-        assertEquals(OpenFeatureStatus.NotReady, client.getProviderStatus())
+        assertEquals(OpenFeatureStatus.NotReady, client.providerStatus)
     }
 
     @Test
@@ -128,12 +128,12 @@ class OpenFeatureClientTests {
         OpenFeatureAPI.setProviderAndWait(emittingProvider, dispatcher = dispatcher)
 
         val client = OpenFeatureAPI.getClient()
-        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
+        assertEquals(OpenFeatureStatus.Ready, client.providerStatus)
 
         // Call track which forces the OverlyEmittingProvider to emit ProviderStale events
         client.track("test-stale-event")
         runCurrent()
 
-        assertEquals(OpenFeatureStatus.Stale, client.getProviderStatus())
+        assertEquals(OpenFeatureStatus.Stale, client.providerStatus)
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
@@ -1,5 +1,6 @@
 package dev.openfeature.kotlin.sdk
 
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import dev.openfeature.kotlin.sdk.helpers.BrokenInitProvider
 import dev.openfeature.kotlin.sdk.helpers.GenericSpyHookMock
 import dev.openfeature.kotlin.sdk.helpers.OverlyEmittingProvider
@@ -46,7 +47,11 @@ class OpenFeatureClientTests {
     fun testClientGetProviderStatusShouldReturnErrorWhenProviderFailsToInitialize() = runTest {
         OpenFeatureAPI.setProviderAndWait(BrokenInitProvider())
         val client = OpenFeatureAPI.getClient()
-        assertTrue(client.getProviderStatus() is OpenFeatureStatus.Error)
+        val status = client.getProviderStatus()
+        assertTrue(status is OpenFeatureStatus.Error)
+        assertTrue(
+            (status as OpenFeatureStatus.Error).error is OpenFeatureError.ProviderNotReadyError
+        )
     }
 
     /**
@@ -81,12 +86,16 @@ class OpenFeatureClientTests {
     fun testClientGetProviderStatusShouldReturnFatalWhenProviderFailsFatal() = runTest {
         val fatalProvider = object : FeatureProvider by NoOpProvider() {
             override suspend fun initialize(initialContext: EvaluationContext?) {
-                throw dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.ProviderFatalError("test fatal error")
+                throw OpenFeatureError.ProviderFatalError("test fatal error")
             }
         }
         OpenFeatureAPI.setProviderAndWait(fatalProvider)
         val client = OpenFeatureAPI.getClient()
-        assertTrue(client.getProviderStatus() is OpenFeatureStatus.Fatal)
+        val status = client.getProviderStatus()
+        assertTrue(status is OpenFeatureStatus.Fatal)
+        assertTrue(
+            (status as OpenFeatureStatus.Fatal).error is OpenFeatureError.ProviderFatalError
+        )
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
@@ -1,10 +1,17 @@
 package dev.openfeature.kotlin.sdk
 
+import dev.openfeature.kotlin.sdk.helpers.BrokenInitProvider
 import dev.openfeature.kotlin.sdk.helpers.GenericSpyHookMock
+import dev.openfeature.kotlin.sdk.helpers.SlowProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class OpenFeatureClientTests {
 
@@ -19,5 +26,53 @@ class OpenFeatureClientTests {
         OpenFeatureAPI.addHooks(listOf(GenericSpyHookMock()))
         val stringValue = OpenFeatureAPI.getClient().getStringValue("test", "defaultTest")
         assertEquals(stringValue, "defaultTest")
+    }
+
+    /**
+     * Spec 1.7.1: The client MUST define a provider status accessor.
+     */
+    @Test
+    fun testClientGetProviderStatusShouldReturnReadyWhenProviderIsInitialized() = runTest {
+        OpenFeatureAPI.setProviderAndWait(NoOpProvider())
+        val client = OpenFeatureAPI.getClient()
+        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
+    }
+
+    /**
+     * Spec 1.7.1: The client MUST define a provider status accessor.
+     */
+    @Test
+    fun testClientGetProviderStatusShouldReturnErrorWhenProviderFailsToInitialize() = runTest {
+        OpenFeatureAPI.setProviderAndWait(BrokenInitProvider())
+        val client = OpenFeatureAPI.getClient()
+        assertTrue(client.getProviderStatus() is OpenFeatureStatus.Error)
+    }
+
+    /**
+     * Spec 1.7.2.1: Provider status accessor must support RECONCILING state (static-context paradigm).
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testClientGetProviderStatusShouldReturnReconcilingWhileContextIsBeingUpdated() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val slowProvider = SlowProvider(dispatcher = dispatcher)
+        OpenFeatureAPI.setProvider(slowProvider, dispatcher = dispatcher)
+
+        // Wait for SlowProvider initialized (2000ms delay)
+        advanceTimeBy(2001)
+
+        val client = OpenFeatureAPI.getClient()
+        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
+
+        // Trigger a context update (takes 2000ms natively)
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext(targetingKey = "user-123"), dispatcher)
+
+        // Run execution queue deterministically to ensure coroutine reaches emit(Reconciling)
+        runCurrent()
+        assertEquals(OpenFeatureStatus.Reconciling, client.getProviderStatus())
+
+        // Wait out the remaining 2000ms for slow context update finish
+        advanceTimeBy(2001)
+        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClientTests.kt
@@ -2,6 +2,7 @@ package dev.openfeature.kotlin.sdk
 
 import dev.openfeature.kotlin.sdk.helpers.BrokenInitProvider
 import dev.openfeature.kotlin.sdk.helpers.GenericSpyHookMock
+import dev.openfeature.kotlin.sdk.helpers.OverlyEmittingProvider
 import dev.openfeature.kotlin.sdk.helpers.SlowProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -74,5 +75,40 @@ class OpenFeatureClientTests {
         // Wait out the remaining 2000ms for slow context update finish
         advanceTimeBy(2001)
         assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
+    }
+
+    @Test
+    fun testClientGetProviderStatusShouldReturnFatalWhenProviderFailsFatal() = runTest {
+        val fatalProvider = object : FeatureProvider by NoOpProvider() {
+            override suspend fun initialize(initialContext: EvaluationContext?) {
+                throw dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.ProviderFatalError("test fatal error")
+            }
+        }
+        OpenFeatureAPI.setProviderAndWait(fatalProvider)
+        val client = OpenFeatureAPI.getClient()
+        assertTrue(client.getProviderStatus() is OpenFeatureStatus.Fatal)
+    }
+
+    @Test
+    fun testClientGetProviderStatusShouldReturnNotReadyBeforeProviderIsSet() = runTest {
+        val client = OpenFeatureAPI.getClient()
+        // No provider is set, so it should be NotReady
+        assertEquals(OpenFeatureStatus.NotReady, client.getProviderStatus())
+    }
+
+    @Test
+    fun testClientGetProviderStatusShouldReturnStaleWhenProviderEmitsStale() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val emittingProvider = OverlyEmittingProvider("emitting_provider")
+        OpenFeatureAPI.setProviderAndWait(emittingProvider, dispatcher = dispatcher)
+
+        val client = OpenFeatureAPI.getClient()
+        assertEquals(OpenFeatureStatus.Ready, client.getProviderStatus())
+
+        // Call track which forces the OverlyEmittingProvider to emit ProviderStale events
+        client.track("test-stale-event")
+        runCurrent()
+
+        assertEquals(OpenFeatureStatus.Stale, client.getProviderStatus())
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/TelemetryTest.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/TelemetryTest.kt
@@ -3,6 +3,7 @@ package dev.openfeature.kotlin.sdk
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import dev.openfeature.kotlin.sdk.Reason as EvaluationReason
@@ -12,21 +13,80 @@ private val providerMetadata = object : ProviderMetadata {
         get() = "Provider name"
 }
 
+private fun <T> createGenericTestEvent(
+    flagKey: String = "flag key",
+    targetingKey: String = "targeting key",
+    testProviderMetadata: ProviderMetadata = providerMetadata,
+    reason: String? = null,
+    errorCode: ErrorCode? = null,
+    errorMessage: String? = null,
+    variant: String? = null,
+    value: T,
+    defaultValue: T,
+    flagValueType: FlagValueType,
+    metadata: EvaluationMetadata? = null
+): EvaluationEvent {
+    val ctx = ImmutableContext(targetingKey)
+    val hookContext = HookContext<T>(
+        flagKey,
+        flagValueType,
+        defaultValue,
+        ctx,
+        null,
+        testProviderMetadata
+    )
+    val providerEvaluation = if (metadata != null) {
+        ProviderEvaluation<T>(
+            value = value,
+            variant = variant,
+            reason = reason,
+            errorCode = errorCode,
+            errorMessage = errorMessage,
+            metadata = metadata
+        )
+    } else {
+        ProviderEvaluation<T>(
+            value = value,
+            variant = variant,
+            reason = reason,
+            errorCode = errorCode,
+            errorMessage = errorMessage
+        )
+    }
+    val flagEvaluationDetails = FlagEvaluationDetails.from(providerEvaluation, flagKey)
+    return createEvaluationEvent(hookContext, flagEvaluationDetails)
+}
+
+private fun createTestEvent(
+    flagKey: String = "flag key",
+    targetingKey: String = "targeting key",
+    testProviderMetadata: ProviderMetadata = providerMetadata,
+    reason: String? = null,
+    errorCode: ErrorCode? = null,
+    errorMessage: String? = null,
+    variant: String? = null,
+    value: String = "value",
+    metadata: EvaluationMetadata? = null
+): EvaluationEvent = createGenericTestEvent(
+    flagKey = flagKey,
+    targetingKey = targetingKey,
+    testProviderMetadata = testProviderMetadata,
+    reason = reason,
+    errorCode = errorCode,
+    errorMessage = errorMessage,
+    variant = variant,
+    value = value,
+    defaultValue = "default",
+    flagValueType = FlagValueType.STRING,
+    metadata = metadata
+)
+
 class TelemetryTest {
+
     @Test
     fun `flagKey is set correctly`() {
-        val flagKey = "flag key"
-        val ctx = ImmutableContext("targeting key")
-        val hookContext = HookContext(
-            flagKey,
-            FlagValueType.STRING,
-            "default",
-            ctx,
-            null,
-            providerMetadata
-        )
-        val flagEvaluationDetails = FlagEvaluationDetails.from(ProviderEvaluation("value"), flagKey)
-        val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+        val flagKey = "custom flag key"
+        val evaluationEvent = createTestEvent(flagKey = flagKey)
 
         assertEquals(flagKey, evaluationEvent.attributes[TELEMETRY_KEY])
     }
@@ -34,92 +94,60 @@ class TelemetryTest {
     class ProviderName {
         @Test
         fun `provider name is set correctly`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(ProviderEvaluation("value"), flagKey)
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent()
 
             assertEquals(providerMetadata.name, evaluationEvent.attributes[TELEMETRY_PROVIDER])
         }
 
         @Test
-        fun `provider name is set to empty string when not available`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                object : ProviderMetadata {
+        fun `provider name is omitted when not available`() {
+            val evaluationEvent = createTestEvent(
+                testProviderMetadata = object : ProviderMetadata {
                     override val name: String?
                         get() = null
                 }
             )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(ProviderEvaluation("value"), flagKey)
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
 
-            assertEquals("", evaluationEvent.attributes[TELEMETRY_PROVIDER])
+            assertFalse(evaluationEvent.attributes.containsKey(TELEMETRY_PROVIDER))
+        }
+
+        @Test
+        fun `provider name is omitted when empty string`() {
+            val evaluationEvent = createTestEvent(
+                testProviderMetadata = object : ProviderMetadata {
+                    override val name: String
+                        get() = ""
+                }
+            )
+
+            assertFalse(evaluationEvent.attributes.containsKey(TELEMETRY_PROVIDER))
         }
     }
 
     class Reason {
         @Test
         fun `create EvaluationEvent with UNKNOWN reason if reason is null`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    reason = null
-                ),
-                flagKey
-            )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent(reason = null)
 
             assertEquals(EvaluationReason.UNKNOWN.name.lowercase(), evaluationEvent.attributes[TELEMETRY_REASON])
         }
 
         @Test
         fun `create EvaluationEvent with correct reason if reason is set`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    reason = EvaluationReason.TARGETING_MATCH.name.lowercase()
-                ),
-                flagKey
-            )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent(reason = EvaluationReason.TARGETING_MATCH.name.lowercase())
 
             assertEquals(
                 EvaluationReason.TARGETING_MATCH.name.lowercase(),
+                evaluationEvent.attributes[TELEMETRY_REASON]
+            )
+        }
+
+        @Test
+        fun `reason is safely lowercased regardless of input casing`() {
+            val evaluationEvent = createTestEvent(reason = "StAte_CaChe_MaTch")
+
+            assertEquals(
+                "state_cache_match",
                 evaluationEvent.attributes[TELEMETRY_REASON]
             )
         }
@@ -128,93 +156,46 @@ class TelemetryTest {
     class ContextId {
         @Test
         fun `contextId is taken from evaluation metadata when available`() {
-            val flagKey = "flag key"
-            val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
             val contextId = "contextId metadata"
             val evaluationMetadata = EvaluationMetadata(mapOf(Pair("contextId", contextId)))
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    metadata = evaluationMetadata
-                ),
-                flagKey
+            val evaluationEvent = createTestEvent(
+                targetingKey = "targeting key",
+                metadata = evaluationMetadata
             )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
 
             assertEquals(contextId, evaluationEvent.attributes[TELEMETRY_CONTEXT_ID])
-            assertNotEquals(targetingKey, evaluationEvent.attributes[TELEMETRY_CONTEXT_ID])
+            assertNotEquals("targeting key", evaluationEvent.attributes[TELEMETRY_CONTEXT_ID])
         }
 
         @Test
         fun `contextId is taken from ctx when evaluation metadata is not available`() {
-            val flagKey = "flag key"
             val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(ProviderEvaluation("value"), flagKey)
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent(targetingKey = targetingKey)
 
             assertEquals(targetingKey, evaluationEvent.attributes[TELEMETRY_CONTEXT_ID])
+        }
+
+        @Test
+        fun `contextId is omitted when both evaluation metadata and ctx targetingKey are null or empty`() {
+            val evaluationEvent = createTestEvent(targetingKey = "")
+
+            assertFalse(evaluationEvent.attributes.containsKey(TELEMETRY_CONTEXT_ID))
         }
     }
 
     class FlagSetId {
         @Test
         fun `flagSetId is set correctly when available`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
             val flagSetId = "flag set id"
             val evaluationMetadata = EvaluationMetadata(mapOf(Pair("flagSetId", flagSetId)))
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    metadata = evaluationMetadata
-                ),
-                flagKey
-            )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent(metadata = evaluationMetadata)
 
             assertEquals(flagSetId, evaluationEvent.attributes[TELEMETRY_FLAG_SET_ID])
         }
 
         @Test
         fun `flagSetId is not set when not available`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(ProviderEvaluation("value"), flagKey)
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent()
 
             assertNull(evaluationEvent.attributes[TELEMETRY_FLAG_SET_ID])
         }
@@ -223,44 +204,16 @@ class TelemetryTest {
     class Version {
         @Test
         fun `version is set correctly when available`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val version = "flag set id"
+            val version = "v1.0.0"
             val evaluationMetadata = EvaluationMetadata(mapOf(Pair("version", version)))
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    metadata = evaluationMetadata
-                ),
-                flagKey
-            )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent(metadata = evaluationMetadata)
 
             assertEquals(version, evaluationEvent.attributes[TELEMETRY_VERSION])
         }
 
         @Test
         fun `version is not set when not available`() {
-            val flagKey = "flag key"
-            val ctx = ImmutableContext("targeting key")
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(ProviderEvaluation("value"), flagKey)
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent()
 
             assertNull(evaluationEvent.attributes[TELEMETRY_VERSION])
         }
@@ -269,113 +222,83 @@ class TelemetryTest {
     class Variant {
         @Test
         fun `variant is taken from provider evaluation when available`() {
-            val flagKey = "flag key"
-            val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
             val variant = "variant"
             val value = "value"
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    value,
-                    variant
-                ),
-                flagKey
+            val evaluationEvent = createTestEvent(
+                variant = variant,
+                value = value
             )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
 
             assertEquals(variant, evaluationEvent.attributes[TELEMETRY_VARIANT])
             assertNotEquals(value, evaluationEvent.attributes[TELEMETRY_VARIANT])
+            assertFalse(evaluationEvent.body.containsKey(TELEMETRY_BODY))
         }
 
         @Test
         fun `variant is not set when not available`() {
-            val flagKey = "flag key"
-            val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val variant = null
-            val value = "value"
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    value,
-                    variant
-                ),
-                flagKey
-            )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+            val evaluationEvent = createTestEvent(variant = null)
 
             assertNull(evaluationEvent.attributes[TELEMETRY_VARIANT])
         }
 
         @Test
         fun `telemetry body is set when variant is not available`() {
-            val flagKey = "flag key"
-            val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
-            val variant = null
             val value = "value"
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    value,
-                    variant
-                ),
-                flagKey
+            val evaluationEvent = createTestEvent(
+                variant = null,
+                value = value
             )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
 
             assertEquals(value, evaluationEvent.body[TELEMETRY_BODY])
+        }
+
+        @Test
+        fun `telemetry body correctly handles boolean values`() {
+            val evaluationEvent = createGenericTestEvent(
+                value = true,
+                defaultValue = false,
+                flagValueType = FlagValueType.BOOLEAN
+            )
+
+            assertEquals(true, evaluationEvent.body[TELEMETRY_BODY])
+        }
+
+        @Test
+        fun `telemetry body correctly handles integer values`() {
+            val evaluationEvent = createGenericTestEvent(
+                value = 42,
+                defaultValue = 0,
+                flagValueType = FlagValueType.INTEGER
+            )
+
+            assertEquals(42, evaluationEvent.body[TELEMETRY_BODY])
         }
     }
 
     class Error {
         @Test
         fun `error code and message are taken from provider evaluation when available`() {
-            val flagKey = "flag key"
-            val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
-            )
             val errorCode = ErrorCode.PARSE_ERROR
             val errorMessage = "error message"
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    reason = EvaluationReason.ERROR.name,
-                    errorCode = errorCode,
-                    errorMessage = errorMessage
-                ),
-                flagKey
+            val evaluationEvent = createTestEvent(
+                reason = EvaluationReason.ERROR.name,
+                errorCode = errorCode,
+                errorMessage = errorMessage
             )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
+
+            assertEquals(errorCode, evaluationEvent.attributes[TELEMETRY_ERROR_CODE])
+            assertEquals(errorMessage, evaluationEvent.attributes[TELEMETRY_ERROR_MSG])
+        }
+
+        @Test
+        fun `error code and message are taken from provider evaluation even if reason is lowercased`() {
+            val errorCode = ErrorCode.PARSE_ERROR
+            val errorMessage = "error message"
+            val evaluationEvent = createTestEvent(
+                reason = "error",
+                errorCode = errorCode,
+                errorMessage = errorMessage
+            )
 
             assertEquals(errorCode, evaluationEvent.attributes[TELEMETRY_ERROR_CODE])
             assertEquals(errorMessage, evaluationEvent.attributes[TELEMETRY_ERROR_MSG])
@@ -383,56 +306,23 @@ class TelemetryTest {
 
         @Test
         fun `error code and message use defaults when reason is error but no details are available`() {
-            val flagKey = "flag key"
-            val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
+            val evaluationEvent = createTestEvent(
+                reason = EvaluationReason.ERROR.name,
+                errorCode = null,
+                errorMessage = null
             )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    reason = EvaluationReason.ERROR.name,
-                    errorCode = null,
-                    errorMessage = null
-                ),
-                flagKey
-            )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
 
             assertEquals(ErrorCode.GENERAL, evaluationEvent.attributes[TELEMETRY_ERROR_CODE])
             assertNull(evaluationEvent.attributes[TELEMETRY_ERROR_MSG])
         }
 
         @Test
-        fun `error code and message are not set when no error is present`() {
-            val flagKey = "flag key"
-            val targetingKey = "targeting key"
-            val ctx = ImmutableContext(targetingKey)
-            val hookContext = HookContext(
-                flagKey,
-                FlagValueType.STRING,
-                "default",
-                ctx,
-                null,
-                providerMetadata
+        fun `error code and message are ignored when reason is not ERROR`() {
+            val evaluationEvent = createTestEvent(
+                reason = EvaluationReason.UNKNOWN.name,
+                errorCode = ErrorCode.PARSE_ERROR,
+                errorMessage = "This should be ignored"
             )
-            val flagEvaluationDetails = FlagEvaluationDetails.from(
-                ProviderEvaluation(
-                    "value",
-                    "variant",
-                    reason = EvaluationReason.UNKNOWN.name,
-                    errorCode = null,
-                    errorMessage = null
-                ),
-                flagKey
-            )
-            val evaluationEvent = createEvaluationEvent(hookContext, flagEvaluationDetails)
 
             assertNull(evaluationEvent.attributes[TELEMETRY_ERROR_CODE])
             assertNull(evaluationEvent.attributes[TELEMETRY_ERROR_MSG])


### PR DESCRIPTION
## Provider status at Client
Implements a synchronous provider status accessor across the core SDK to fully align with OpenFeature Specifications requirements [1.7.1](https://openfeature.dev/specification/sections/flag-evaluation#requirement-171) and [1.7.2.1](https://openfeature.dev/specification/sections/flag-evaluation#conditional-requirement-1721). 
- Adds `getProviderStatus(): OpenFeatureStatus` binding to the `Client` interface and Native `OpenFeatureClient` implementation.
- Surfaces the `RECONCILING` state under the static-context paradigm whenever global evaluation contexts are swapped, matching upstream specification requirements.

### Related Issues
Fixes #205

### Notes
Opted to retain `fun getProviderStatus()` over converting it to an idiomatic Kotlin property block inside the interface.

### How to test
Run the test block directly in your CLI using:
`./gradlew :kotlin-sdk:testDebugUnitTest --tests "dev.openfeature.kotlin.sdk.OpenFeatureClientTests"`
