### PR TITLE
feat: add iosX64 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following [Kotlin Multiplatform Targets](https://www.jetbrains.com/help/kotl
 | --------- | -------------------- |--------------------------------------------------------------------------------|
 | ✅         | Android              | SDK 21+                                                                        |
 | ✅         | JVM                  | JDK 11+                                                                        |
-| ✅         | Native               | Linux x64, iosSimulatorArm64, iosArm64                                         |
+| ✅         | Native               | Linux x64, iosSimulatorArm64, iosArm64, iosX64                                 |
 | ❌         | Native               | [Other native targets](https://kotlinlang.org/docs/native-target-support.html) |
 | ✅         | Javascript (Node.js) |                                                                                |
 | ✅         | Javascript (Browser) |                                                                                |

--- a/kotlin-sdk/build.gradle.kts
+++ b/kotlin-sdk/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
         }
     }
     linuxX64 {}
+    iosX64()
     iosArm64()
     iosSimulatorArm64()
     js {
@@ -52,8 +53,6 @@ kotlin {
             }
         }
     }
-    iosArm64()
-    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
Add the iosX64 Kotlin/Native target so the SDK can be consumed from the iOS simulator on Intel-based Macs, alongside the existing iosArm64 and iosSimulatorArm64 targets.

Also remove the duplicate iosArm64()/iosSimulatorArm64() target declarations that were listed twice in the kotlin block.


