### PR TITLE
fix: reconcile evaluation context on every set

### DIFF
--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/FeatureProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/FeatureProvider.kt
@@ -24,8 +24,10 @@ interface FeatureProvider {
     fun shutdown()
 
     /**
-     * Called by OpenFeatureAPI whenever a new EvaluationContext is set by the application
-     * Perform blocking work here until the provider is ready again or throws an exception
+     * Called by OpenFeatureAPI whenever the application sets the [EvaluationContext], including when
+     * the new context is equal to or the same instance as the previous context.
+     * Implementations should suspend until the provider is ready again or throw an exception.
+     *
      * @param oldContext The old EvaluationContext
      * @param newContext The new EvaluationContext
      * @throws OpenFeatureError if the provider cannot perform the task

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -209,12 +209,10 @@ open class OpenFeatureAPIInstance internal constructor() {
     private suspend fun setEvaluationContextInternal(evaluationContext: EvaluationContext) {
         val oldContext = context
         context = evaluationContext
-        if (oldContext != evaluationContext) {
-            _statusFlow.emit(OpenFeatureStatus.Reconciling)
-            tryWithStatusEmitErrorHandling {
-                getProvider().onContextSet(oldContext, evaluationContext)
-                _statusFlow.emit(OpenFeatureStatus.Ready)
-            }
+        _statusFlow.emit(OpenFeatureStatus.Reconciling)
+        tryWithStatusEmitErrorHandling {
+            getProvider().onContextSet(oldContext, evaluationContext)
+            _statusFlow.emit(OpenFeatureStatus.Ready)
         }
     }
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -54,6 +54,10 @@ open class OpenFeatureAPIInstance internal constructor() {
     private var context: EvaluationContext? = null
     private var contextReconciliationGeneration: Long? = null
     private var activeContextReconciliations: Int = 0
+    private var contextReconciliationInitialStatus: OpenFeatureStatus? = null
+    private var contextReconciliationTerminalStatus: OpenFeatureStatus? = null
+    private var providerStatusGeneration: Long = 0
+    private var contextReconciliationTerminalProviderStatusGeneration: Long? = null
     val providersFlow: MutableStateFlow<FeatureProvider> = MutableStateFlow(noOpProvider)
 
     private val _statusFlow: MutableSharedFlow<OpenFeatureStatus> =
@@ -219,30 +223,37 @@ open class OpenFeatureAPIInstance internal constructor() {
     }
 
     private suspend fun setEvaluationContextInternal(evaluationContext: EvaluationContext) {
-        val reconciliation = providerMutex.withLock {
-            val oldContext = context
-            context = evaluationContext
-            ContextReconciliation(oldContext, provider, providerGeneration)
-        }
-
-        if (reconciliation.provider === noOpProvider) return
-
-        var reconciliationRegistered = false
+        var reconciliation: ContextReconciliation? = null
         var terminalStatus: OpenFeatureStatus? = null
         try {
             contextReconciliationMutex.withLock {
-                if (contextReconciliationGeneration != reconciliation.providerGeneration) {
-                    contextReconciliationGeneration = reconciliation.providerGeneration
-                    activeContextReconciliations = 0
-                }
-                activeContextReconciliations++
-                reconciliationRegistered = true
-                if (activeContextReconciliations == 1) {
-                    _statusFlow.emit(OpenFeatureStatus.Reconciling)
+                providerMutex.withLock {
+                    val oldContext = context
+                    context = evaluationContext
+                    if (provider !== noOpProvider) {
+                        reconciliation = ContextReconciliation(oldContext, provider, providerGeneration)
+                        if (contextReconciliationGeneration != providerGeneration) {
+                            contextReconciliationGeneration = providerGeneration
+                            activeContextReconciliations = 0
+                        }
+                        if (activeContextReconciliations == 0) {
+                            contextReconciliationInitialStatus = getStatus()
+                            contextReconciliationTerminalStatus = null
+                            contextReconciliationTerminalProviderStatusGeneration = null
+                        }
+                        activeContextReconciliations++
+                        if (activeContextReconciliations == 1) {
+                            _statusFlow.emit(OpenFeatureStatus.Reconciling)
+                        }
+                    }
                 }
             }
 
-            reconciliation.provider.onContextSet(reconciliation.oldContext, evaluationContext)
+            val registeredReconciliation = reconciliation ?: return
+            registeredReconciliation.provider.onContextSet(
+                registeredReconciliation.oldContext,
+                evaluationContext
+            )
             terminalStatus = OpenFeatureStatus.Ready
         } catch (e: CancellationException) {
             // This happens by design and shouldn't be treated as an error
@@ -253,11 +264,12 @@ open class OpenFeatureAPIInstance internal constructor() {
                 OpenFeatureError.GeneralError(e.message ?: "Unknown error")
             )
         } finally {
-            if (reconciliationRegistered) {
+            val registeredReconciliation = reconciliation
+            if (registeredReconciliation != null) {
                 withContext(NonCancellable) {
                     completeContextReconciliation(
-                        reconciliation.provider,
-                        reconciliation.providerGeneration,
+                        registeredReconciliation.provider,
+                        registeredReconciliation.providerGeneration,
                         terminalStatus
                     )
                 }
@@ -273,14 +285,31 @@ open class OpenFeatureAPIInstance internal constructor() {
         contextReconciliationMutex.withLock {
             if (contextReconciliationGeneration != reconciliationProviderGeneration) return
 
+            if (terminalStatus != null) {
+                contextReconciliationTerminalStatus = terminalStatus
+                contextReconciliationTerminalProviderStatusGeneration = providerStatusGeneration
+            }
             activeContextReconciliations--
-            if (activeContextReconciliations == 0 && terminalStatus != null) {
+            if (activeContextReconciliations == 0) {
+                val retainedTerminalStatus = contextReconciliationTerminalStatus
+                val statusToEmit = retainedTerminalStatus ?: contextReconciliationInitialStatus
+                val shouldEmitStatus = if (retainedTerminalStatus != null) {
+                    contextReconciliationTerminalProviderStatusGeneration == providerStatusGeneration
+                } else {
+                    getStatus() is OpenFeatureStatus.Reconciling
+                }
+                contextReconciliationInitialStatus = null
+                contextReconciliationTerminalStatus = null
+                contextReconciliationTerminalProviderStatusGeneration = null
+
                 providerMutex.withLock {
                     if (
                         provider === reconciliationProvider &&
-                        providerGeneration == reconciliationProviderGeneration
+                        providerGeneration == reconciliationProviderGeneration &&
+                        statusToEmit != null &&
+                        shouldEmitStatus
                     ) {
-                        _statusFlow.emit(terminalStatus)
+                        _statusFlow.emit(statusToEmit)
                     }
                 }
             }
@@ -372,19 +401,26 @@ open class OpenFeatureAPIInstance internal constructor() {
     private val handleProviderEvents: FlowCollector<OpenFeatureProviderEvents> = FlowCollector { providerEvent ->
         when (providerEvent) {
             is OpenFeatureProviderEvents.ProviderReady -> {
-                _statusFlow.emit(OpenFeatureStatus.Ready)
+                emitProviderStatus(OpenFeatureStatus.Ready)
             }
 
             is OpenFeatureProviderEvents.ProviderStale -> {
-                _statusFlow.emit(OpenFeatureStatus.Stale)
+                emitProviderStatus(OpenFeatureStatus.Stale)
             }
 
             is OpenFeatureProviderEvents.ProviderError -> {
-                _statusFlow.emit(providerEvent.toOpenFeatureStatusError())
+                emitProviderStatus(providerEvent.toOpenFeatureStatusError())
             }
 
             else -> { // All other states should not be emitted from here
             }
+        }
+    }
+
+    private suspend fun emitProviderStatus(status: OpenFeatureStatus) {
+        contextReconciliationMutex.withLock {
+            providerStatusGeneration++
+            _statusFlow.emit(status)
         }
     }
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -36,14 +36,24 @@ import kotlinx.coroutines.withContext
  */
 @Suppress("TooManyFunctions")
 open class OpenFeatureAPIInstance internal constructor() {
+    private data class ContextReconciliation(
+        val oldContext: EvaluationContext?,
+        val provider: FeatureProvider,
+        val providerGeneration: Long
+    )
+
     private var setProviderJob: Job? = null
     private var setEvaluationContextJob: Job? = null
     private var observeProviderEventsJob: Job? = null
 
     private val providerMutex = Mutex()
+    private val contextReconciliationMutex = Mutex()
     private val noOpProvider = NoOpProvider()
     private var provider: FeatureProvider = noOpProvider
+    private var providerGeneration: Long = 0
     private var context: EvaluationContext? = null
+    private var contextReconciliationGeneration: Long? = null
+    private var activeContextReconciliations: Int = 0
     val providersFlow: MutableStateFlow<FeatureProvider> = MutableStateFlow(noOpProvider)
 
     private val _statusFlow: MutableSharedFlow<OpenFeatureStatus> =
@@ -122,6 +132,7 @@ open class OpenFeatureAPIInstance internal constructor() {
             val oldProvider = providerMutex.withLock {
                 val current = this.provider
                 this.provider = provider
+                providerGeneration++
                 providersFlow.value = provider
                 if (initialContext != null) context = initialContext
                 current
@@ -171,6 +182,7 @@ open class OpenFeatureAPIInstance internal constructor() {
         val oldProvider = providerMutex.withLock {
             val current = this.provider
             this.provider = noOpProvider
+            providerGeneration++
             providersFlow.value = noOpProvider
             current
         }
@@ -207,12 +219,71 @@ open class OpenFeatureAPIInstance internal constructor() {
     }
 
     private suspend fun setEvaluationContextInternal(evaluationContext: EvaluationContext) {
-        val oldContext = context
-        context = evaluationContext
-        _statusFlow.emit(OpenFeatureStatus.Reconciling)
-        tryWithStatusEmitErrorHandling {
-            getProvider().onContextSet(oldContext, evaluationContext)
-            _statusFlow.emit(OpenFeatureStatus.Ready)
+        val reconciliation = providerMutex.withLock {
+            val oldContext = context
+            context = evaluationContext
+            ContextReconciliation(oldContext, provider, providerGeneration)
+        }
+
+        if (reconciliation.provider === noOpProvider) return
+
+        var reconciliationRegistered = false
+        var terminalStatus: OpenFeatureStatus? = null
+        try {
+            contextReconciliationMutex.withLock {
+                if (contextReconciliationGeneration != reconciliation.providerGeneration) {
+                    contextReconciliationGeneration = reconciliation.providerGeneration
+                    activeContextReconciliations = 0
+                }
+                activeContextReconciliations++
+                reconciliationRegistered = true
+                if (activeContextReconciliations == 1) {
+                    _statusFlow.emit(OpenFeatureStatus.Reconciling)
+                }
+            }
+
+            reconciliation.provider.onContextSet(reconciliation.oldContext, evaluationContext)
+            terminalStatus = OpenFeatureStatus.Ready
+        } catch (e: CancellationException) {
+            // This happens by design and shouldn't be treated as an error
+        } catch (e: OpenFeatureError) {
+            terminalStatus = OpenFeatureStatus.Error(e)
+        } catch (e: Throwable) {
+            terminalStatus = OpenFeatureStatus.Error(
+                OpenFeatureError.GeneralError(e.message ?: "Unknown error")
+            )
+        } finally {
+            if (reconciliationRegistered) {
+                withContext(NonCancellable) {
+                    completeContextReconciliation(
+                        reconciliation.provider,
+                        reconciliation.providerGeneration,
+                        terminalStatus
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun completeContextReconciliation(
+        reconciliationProvider: FeatureProvider,
+        reconciliationProviderGeneration: Long,
+        terminalStatus: OpenFeatureStatus?
+    ) {
+        contextReconciliationMutex.withLock {
+            if (contextReconciliationGeneration != reconciliationProviderGeneration) return
+
+            activeContextReconciliations--
+            if (activeContextReconciliations == 0 && terminalStatus != null) {
+                providerMutex.withLock {
+                    if (
+                        provider === reconciliationProvider &&
+                        providerGeneration == reconciliationProviderGeneration
+                    ) {
+                        _statusFlow.emit(terminalStatus)
+                    }
+                }
+            }
         }
     }
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
@@ -361,7 +361,7 @@ class DeveloperExperienceTests {
     }
 
     @Test
-    fun setEvaluationContextDoesDeepEqualsOnAttributes() = runTest {
+    fun setEvaluationContextUsesImmutableCopyOfAttributes() = runTest {
         val map = mutableMapOf<String, Value>()
         val provider = SpyProvider()
         OpenFeatureAPI.setProviderAndWait(provider)
@@ -369,13 +369,54 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext(attributes = map))
         assertEquals(1, provider.onContextSetCalls.size)
         map["myKey"] = Value.String("myValue")
-        println(OpenFeatureAPI.getEvaluationContext()?.asMap())
+        assertNull(OpenFeatureAPI.getEvaluationContext()?.getValue("myKey"))
+
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext(attributes = map))
         assertEquals(2, provider.onContextSetCalls.size)
+        assertEquals("myValue", OpenFeatureAPI.getEvaluationContext()?.getValue("myKey")?.asString())
     }
 
     @Test
-    fun setEvaluationContextDoesNotDetectDeepChangesInNestedStructures() = runTest {
+    fun setEvaluationContextReconcilesWhenGivenSameInstance() = runTest {
+        val context = ImmutableContext(
+            targetingKey = "targeting-key",
+            attributes = mapOf("key" to Value.String("value"))
+        )
+        val provider = SpyProvider()
+        OpenFeatureAPI.setProviderAndWait(provider)
+
+        OpenFeatureAPI.setEvaluationContextAndWait(context)
+        OpenFeatureAPI.setEvaluationContextAndWait(context)
+
+        assertEquals(2, provider.onContextSetCalls.size)
+        assertTrue(provider.onContextSetCalls[1].first === context)
+        assertTrue(provider.onContextSetCalls[1].second === context)
+    }
+
+    @Test
+    fun setEvaluationContextReconcilesWhenGivenEqualContext() = runTest {
+        val firstContext = ImmutableContext(
+            targetingKey = "targeting-key",
+            attributes = mapOf("key" to Value.String("value"))
+        )
+        val secondContext = ImmutableContext(
+            targetingKey = "targeting-key",
+            attributes = mapOf("key" to Value.String("value"))
+        )
+        val provider = SpyProvider()
+        OpenFeatureAPI.setProviderAndWait(provider)
+        assertTrue(firstContext !== secondContext)
+
+        OpenFeatureAPI.setEvaluationContextAndWait(firstContext)
+        OpenFeatureAPI.setEvaluationContextAndWait(secondContext)
+
+        assertEquals(2, provider.onContextSetCalls.size)
+        assertTrue(provider.onContextSetCalls[1].first === firstContext)
+        assertTrue(provider.onContextSetCalls[1].second === secondContext)
+    }
+
+    @Test
+    fun setEvaluationContextUsesImmutableCopyOfNestedStructures() = runTest {
         val nestedMap = mutableMapOf<String, Value>()
         val map = mutableMapOf<String, Value>()
         map["nested"] = Value.Structure(nestedMap)
@@ -387,11 +428,11 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext(attributes = map))
         assertEquals(1, provider.onContextSetCalls.size)
 
-        // This won't update the `nested` list in `map`, since Value.Structure returns an immutable copy
+        // This won't update the nested structure in `map`, since Value.Structure returns an immutable copy
         nestedMap["deepKey"] = Value.String("deepValue")
 
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext(attributes = map))
-        assertEquals(1, provider.onContextSetCalls.size)
+        assertEquals(2, provider.onContextSetCalls.size)
 
         val currentContext = OpenFeatureAPI.getEvaluationContext()
         val nestedStructure = currentContext?.getValue("nested")?.asStructure()
@@ -399,7 +440,7 @@ class DeveloperExperienceTests {
     }
 
     @Test
-    fun setEvaluationContextDoesNotDetectDeepChangesInNestedLists() = runTest {
+    fun setEvaluationContextUsesImmutableCopyOfNestedLists() = runTest {
         val nestedList = mutableListOf<Value>()
         val map = mutableMapOf<String, Value>()
         map["nested"] = Value.List(nestedList)
@@ -415,7 +456,7 @@ class DeveloperExperienceTests {
         nestedList.add(Value.String("deepValue"))
 
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext(attributes = map))
-        assertEquals(1, provider.onContextSetCalls.size)
+        assertEquals(2, provider.onContextSetCalls.size)
 
         val currentContext = OpenFeatureAPI.getEvaluationContext()
         val nestedListFromContext = currentContext?.getValue("nested")?.asList()

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
@@ -386,11 +386,29 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.setProviderAndWait(provider)
 
         OpenFeatureAPI.setEvaluationContextAndWait(context)
+        val emittedStatuses = mutableListOf<OpenFeatureStatus>()
+        val job = launch {
+            OpenFeatureAPI.statusFlow.collect {
+                emittedStatuses.add(it)
+            }
+        }
+        testScheduler.advanceUntilIdle()
+
         OpenFeatureAPI.setEvaluationContextAndWait(context)
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
 
         assertEquals(2, provider.onContextSetCalls.size)
         assertTrue(provider.onContextSetCalls[1].first === context)
         assertTrue(provider.onContextSetCalls[1].second === context)
+        assertEquals(
+            listOf(
+                OpenFeatureStatus.Ready,
+                OpenFeatureStatus.Reconciling,
+                OpenFeatureStatus.Ready
+            ),
+            emittedStatuses
+        )
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
@@ -1,18 +1,25 @@
 package dev.openfeature.kotlin.sdk
 
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.helpers.BrokenInitProvider
 import dev.openfeature.kotlin.sdk.helpers.DoSomethingProvider
 import dev.openfeature.kotlin.sdk.helpers.SlowProvider
 import dev.openfeature.kotlin.sdk.helpers.SpyProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -120,6 +127,94 @@ class StatusTests {
         assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
     }
 
+    @Test
+    fun testCancelledContextSetRestoresPreviousStatus() = runTest {
+        val provider = ControllableContextProvider()
+        OpenFeatureAPI.setProviderAndWait(provider)
+
+        val contextSet = launch {
+            OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("cancelled"))
+        }
+        provider.contextSetStarted.receive()
+        assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
+
+        contextSet.cancelAndJoin()
+
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testCancelledContextSetFinishingLastUsesReplacementStatus() = runTest {
+        val provider = CancellationRaceProvider()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(provider)
+
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"), dispatcher)
+        provider.firstContextSetStarted.receive()
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("replacement"), dispatcher)
+        provider.firstContextSetCancellationStarted.receive()
+        provider.replacementContextSetCompleted.receive()
+        runCurrent()
+        assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
+
+        provider.allowFirstContextSetToFinish.send(Unit)
+        advanceUntilIdle()
+
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testProviderEventAfterReplacementCompletionWinsOverRetainedStatus() = runTest {
+        val provider = CancellationRaceProvider()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
+        runCurrent()
+
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"), dispatcher)
+        provider.firstContextSetStarted.receive()
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("replacement"), dispatcher)
+        provider.firstContextSetCancellationStarted.receive()
+        provider.replacementContextSetCompleted.receive()
+        runCurrent()
+
+        provider.emitStale()
+        runCurrent()
+        assertEquals(OpenFeatureStatus.Stale, OpenFeatureAPI.getStatus())
+
+        provider.allowFirstContextSetToFinish.send(Unit)
+        advanceUntilIdle()
+
+        assertEquals(OpenFeatureStatus.Stale, OpenFeatureAPI.getStatus())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetiredProviderReconciliationDoesNotOverwriteReplacementStatus() = runTest {
+        val retiredProvider = ControllableContextProvider()
+        val replacementProvider = CancellationRaceProvider()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(retiredProvider)
+
+        val retiredContextSet = launch {
+            OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("retired"))
+        }
+        retiredProvider.contextSetStarted.receive()
+        assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
+
+        OpenFeatureAPI.setProviderAndWait(replacementProvider, dispatcher = dispatcher)
+        runCurrent()
+        replacementProvider.emitStale()
+        runCurrent()
+        assertEquals(OpenFeatureStatus.Stale, OpenFeatureAPI.getStatus())
+
+        retiredProvider.allowContextSetToComplete.send(Unit)
+        retiredContextSet.join()
+
+        assertEquals(OpenFeatureStatus.Stale, OpenFeatureAPI.getStatus())
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testSpamSetContextWithoutAwait() = runTest {
@@ -209,6 +304,39 @@ private class ControllableContextProvider : NoOpProvider() {
         contextSetStarted.send(Unit)
         allowContextSetToComplete.receive()
         contextSetCompleted.send(Unit)
+    }
+}
+
+private class CancellationRaceProvider : NoOpProvider() {
+    val firstContextSetStarted = Channel<Unit>(Channel.UNLIMITED)
+    val firstContextSetCancellationStarted = Channel<Unit>(Channel.UNLIMITED)
+    val allowFirstContextSetToFinish = Channel<Unit>(Channel.UNLIMITED)
+    val replacementContextSetCompleted = Channel<Unit>(Channel.UNLIMITED)
+
+    private val events = MutableSharedFlow<OpenFeatureProviderEvents>(extraBufferCapacity = 1)
+    private var contextSetCalls = 0
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = events
+
+    fun emitStale() {
+        events.tryEmit(OpenFeatureProviderEvents.ProviderStale())
+    }
+
+    override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+        contextSetCalls++
+        if (contextSetCalls == 1) {
+            firstContextSetStarted.send(Unit)
+            try {
+                awaitCancellation()
+            } finally {
+                withContext(NonCancellable) {
+                    firstContextSetCancellationStarted.send(Unit)
+                    allowFirstContextSetToFinish.receive()
+                }
+            }
+        } else {
+            replacementContextSetCompleted.send(Unit)
+        }
     }
 }
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
@@ -6,6 +6,7 @@ import dev.openfeature.kotlin.sdk.helpers.SlowProvider
 import dev.openfeature.kotlin.sdk.helpers.SpyProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -60,6 +61,19 @@ class StatusTests {
     }
 
     @Test
+    fun testContextSetAfterClearProviderRemainsNotReady() = runTest {
+        val context = ImmutableContext("same-context")
+        OpenFeatureAPI.setProviderAndWait(NoOpProvider())
+        OpenFeatureAPI.setEvaluationContextAndWait(context)
+        OpenFeatureAPI.clearProvider()
+
+        OpenFeatureAPI.setEvaluationContextAndWait(context)
+
+        assertTrue(OpenFeatureAPI.getEvaluationContext() === context)
+        assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+    }
+
+    @Test
     fun testProviderTransitionsToReconcilingOnContextSet() = runTest {
         waitAssert {
             assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
@@ -78,6 +92,32 @@ class StatusTests {
             assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
         }
         job.cancelAndJoin()
+    }
+
+    @Test
+    fun testStatusRemainsReconcilingUntilAllEqualContextSetsComplete() = runTest {
+        val context = ImmutableContext("same-context")
+        val provider = ControllableContextProvider()
+        OpenFeatureAPI.setProviderAndWait(provider)
+
+        val firstContextSet = launch {
+            OpenFeatureAPI.setEvaluationContextAndWait(context)
+        }
+        provider.contextSetStarted.receive()
+        val secondContextSet = launch {
+            OpenFeatureAPI.setEvaluationContextAndWait(context)
+        }
+        provider.contextSetStarted.receive()
+        assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
+
+        provider.allowContextSetToComplete.send(Unit)
+        provider.contextSetCompleted.receive()
+        assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
+
+        provider.allowContextSetToComplete.send(Unit)
+        firstContextSet.join()
+        secondContextSet.join()
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -157,6 +197,18 @@ class StatusTests {
         // Use waitAssert for shutdown calls to handle timing differences across platforms
         waitAssert { assertEquals(1, provider1.shutdownCalls.value) }
         assertEquals(0, provider2.shutdownCalls.value)
+    }
+}
+
+private class ControllableContextProvider : NoOpProvider() {
+    val contextSetStarted = Channel<Unit>(Channel.UNLIMITED)
+    val allowContextSetToComplete = Channel<Unit>(Channel.UNLIMITED)
+    val contextSetCompleted = Channel<Unit>(Channel.UNLIMITED)
+
+    override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+        contextSetStarted.send(Unit)
+        allowContextSetToComplete.receive()
+        contextSetCompleted.send(Unit)
     }
 }
 


### PR DESCRIPTION
Hi friends! Long-time user, first-time contributor here.

I was helping a customer debug stale flag values on Android when I noticed that repeated `setEvaluationContext` calls with the same values were not reaching the provider's `onContextSet` callback. I tried to keep the fix focused and added a few tests to cover it. Let me know if there is anything else I need to do to get this ready to merge. Thanks!

### What changed

The Kotlin SDK skips `FeatureProvider.onContextSet` when the new evaluation context is equal to the current context.

This means that calling `setEvaluationContext` with the same user and attributes does not give the provider a chance to refresh its state. For providers that fetch flag configuration during `onContextSet`, this can leave flag values stale.

This behavior was reported with Kotlin SDK 0.6.2, but the same equality check is still present on `main`.

### SDK behavior before this change

| SDK | Same instance | New object, same values | Changed values |
|---|---:|---:|---:|
| Kotlin 0.6.2 | No callback | No callback | Callback |
| Swift 0.5.0 | Callback | Callback | Callback |
| Web 1.10.0 | Callback | Callback | Callback |

The OpenFeature specification says:

> When the global `evaluation context` is set, the `on context changed` function **MUST** run.

See [Conditional Requirement 3.2.4.1](https://github.com/open-feature/spec/blob/d5b0a734d8cb9b42bf89be2a97c627f58208e811/specification/sections/03-evaluation-context.md#L125-L129).

The requirement is based on calling the setter. It does not make the callback conditional on context equality.

### Implementation

This PR:

- Calls `onContextSet` for every evaluation-context setter call.
- Keeps the provider in `RECONCILING` until all active context updates finish.
- Prevents an old provider callback from changing status after the provider has been replaced or cleared.
- Keeps the SDK `NOT_READY` when context is set without a configured provider.
- Documents that providers may receive equal contexts or the same context instance.

There are no public API signature changes.

### Tests

Added coverage for:

- Setting the same context instance more than once.
- Setting different context objects with equal values.
- The `READY` -> `RECONCILING` -> `READY` lifecycle.
- Overlapping context updates.
- Setting context after the provider has been cleared.
