### PR TITLE
fix: validate documentation links in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,5 +33,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Run checks
-        run: ./gradlew check --no-daemon --stacktrace
+      - name: Run checks and documentation
+        run: ./gradlew check :kotlin-sdk:dokkaGeneratePublicationHtml --no-daemon --stacktrace

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/Client.kt
@@ -10,7 +10,7 @@ interface Client : Features, Tracking {
 
     /**
      * Cold flow of events from the SDK's current [FeatureProvider], same pipeline as
-     * [OpenFeatureAPI.observe]. To handle a single event type, narrow with
+     * [OpenFeatureAPIInstance.observe]. To handle a single event type, narrow with
      * [kotlinx.coroutines.flow.filterIsInstance] (or equivalent) in application code.
      */
     fun observe(): Flow<OpenFeatureProviderEvents>


### PR DESCRIPTION
Fixes the stale observe KDoc link that broke snapshot publishing and runs Dokka in the macOS pre-merge CI job to catch documentation warnings before release. Verified with the exact combined check and Dokka Gradle command.