### PR TITLE
fix!: derive provider status from a single ordered event relay

### DIFF
--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -286,10 +286,11 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
+	public final fun getProviderEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
-	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -329,7 +330,8 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureClient : dev/openfeatur
 	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;)Ldev/openfeature/kotlin/sdk/Value;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/Value;
-	public fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public synthetic fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -694,19 +694,21 @@ public abstract class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvent
 
 public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Set;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun component4 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
-	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getErrorCode ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun getEventMetadata ()Ljava/util/Map;
 	public final fun getFlagsChanged ()Ljava/util/Set;
 	public final fun getMessage ()Ljava/lang/String;
+	public final fun getProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -718,6 +720,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I
@@ -744,6 +759,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -286,10 +286,11 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
+	public final fun getProviderEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
-	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -329,7 +330,8 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureClient : dev/openfeatur
 	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;)Ldev/openfeature/kotlin/sdk/Value;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/Value;
-	public fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public synthetic fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -694,19 +694,21 @@ public abstract class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvent
 
 public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Set;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun component4 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
-	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getErrorCode ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun getEventMetadata ()Ljava/util/Map;
 	public final fun getFlagsChanged ()Ljava/util/Set;
 	public final fun getMessage ()Ljava/lang/String;
+	public final fun getProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -718,6 +720,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I
@@ -744,6 +759,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -1,29 +1,34 @@
 package dev.openfeature.kotlin.sdk
 
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
-import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
+import dev.openfeature.kotlin.sdk.events.toCurrentStateEvent
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
+import dev.openfeature.kotlin.sdk.events.withProviderName
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.logging.LoggerFactory
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+
+private const val EVENT_BUFFER_CAPACITY = 64
+private const val LOGGER_NAME = "OpenFeatureAPI"
 
 /**
  * Core implementation of the OpenFeature API.
@@ -63,13 +68,32 @@ open class OpenFeatureAPIInstance internal constructor() {
     private var contextReconciliationTerminalProviderStatusGeneration: Long? = null
     val providersFlow: MutableStateFlow<FeatureProvider> = MutableStateFlow(noOpProvider)
 
-    private val _statusFlow: MutableSharedFlow<OpenFeatureStatus> =
-        MutableSharedFlow<OpenFeatureStatus>(replay = 1, extraBufferCapacity = 5)
-            .apply {
-                tryEmit(OpenFeatureStatus.NotReady)
-            }
+    private val _status: MutableStateFlow<OpenFeatureStatus> = MutableStateFlow(OpenFeatureStatus.NotReady)
 
-    val statusFlow: Flow<OpenFeatureStatus> get() = _statusFlow.distinctUntilChanged()
+    val statusFlow: StateFlow<OpenFeatureStatus> get() = _status
+
+    /**
+     * Events from the active provider, republished by the SDK so that the status is always updated
+     * before subscribers observe the event that caused it.
+     *
+     * Overflow drops the oldest event rather than suspending: a slow subscriber must never stall the
+     * SDK's own status derivation.
+     */
+    private val _events: MutableSharedFlow<OpenFeatureProviderEvents> = MutableSharedFlow(
+        replay = 0,
+        extraBufferCapacity = EVENT_BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    @PublishedApi
+    internal val providerEvents: Flow<OpenFeatureProviderEvents>
+        get() = _events.onSubscription {
+            // Replays the state, not the last event: a handler attached while the provider is already
+            // in a state must run, but a stateless event must not resurface.
+            _status.value.toCurrentStateEvent()
+                ?.withProviderName(getProvider().metadata.name)
+                ?.let { emit(it) }
+        }
 
     var hooks: List<Hook<*>> = listOf()
         private set
@@ -111,11 +135,12 @@ open class OpenFeatureAPIInstance internal constructor() {
     private fun listenToProviderEvents(provider: FeatureProvider, dispatcher: CoroutineDispatcher) {
         observeProviderEventsJob?.cancel(CancellationException("Provider job was cancelled due to new provider"))
         this.observeProviderEventsJob = CoroutineScope(SupervisorJob() + dispatcher).launch {
-            provider.observe().collect(handleProviderEvents)
+            provider.observe().collect { event ->
+                dispatchProviderEvent(event, provider.metadata.name)
+            }
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun setProviderInternal(
         provider: FeatureProvider,
         dispatcher: CoroutineDispatcher,
@@ -124,10 +149,8 @@ open class OpenFeatureAPIInstance internal constructor() {
         try {
             trackProviderBinding(provider)
         } catch (e: Throwable) {
-            _statusFlow.emit(
-                OpenFeatureStatus.Error(
-                    OpenFeatureError.GeneralError(e.message ?: "Unknown error")
-                )
+            _status.value = OpenFeatureStatus.Error(
+                OpenFeatureError.GeneralError(e.message ?: "Unknown error")
             )
             return
         }
@@ -149,7 +172,7 @@ open class OpenFeatureAPIInstance internal constructor() {
             swapCommitted = true
 
             // Emit NotReady status after swapping provider
-            _statusFlow.emit(OpenFeatureStatus.NotReady)
+            _status.value = OpenFeatureStatus.NotReady
 
             // Shutdown the previous provider outside the mutex
             if (oldProvider !== provider) {
@@ -164,7 +187,7 @@ open class OpenFeatureAPIInstance internal constructor() {
                 listenToProviderEvents(provider, dispatcher)
                 val state = getEvaluationState()
                 state.provider.initialize(state.context)
-                _statusFlow.emit(OpenFeatureStatus.Ready)
+                _status.value = OpenFeatureStatus.Ready
             }
         } catch (e: CancellationException) {
             // if cancellation hit before we committed the swap, release the binding we just claimed
@@ -209,7 +232,7 @@ open class OpenFeatureAPIInstance internal constructor() {
         }
         untrackProviderBinding(oldProvider)
         oldProvider.shutdown()
-        _statusFlow.emit(OpenFeatureStatus.NotReady)
+        _status.value = OpenFeatureStatus.NotReady
     }
 
     /**
@@ -265,7 +288,7 @@ open class OpenFeatureAPIInstance internal constructor() {
                         }
                     }
                     if (shouldEmitReconciling) {
-                        _statusFlow.emit(OpenFeatureStatus.Reconciling)
+                        _status.value = OpenFeatureStatus.Reconciling
                     }
                 }
             }
@@ -330,7 +353,7 @@ open class OpenFeatureAPIInstance internal constructor() {
                         statusToEmit != null &&
                         shouldEmitStatus
                     ) {
-                        _statusFlow.emit(statusToEmit)
+                        _status.value = statusToEmit
                     }
                 }
             }
@@ -343,13 +366,11 @@ open class OpenFeatureAPIInstance internal constructor() {
         } catch (e: CancellationException) {
             // This happens by design and shouldn't be treated as an error
         } catch (e: OpenFeatureError) {
-            _statusFlow.emit(OpenFeatureStatus.Error(e))
+            _status.value = OpenFeatureStatus.Error(e)
         } catch (e: Throwable) {
-            _statusFlow.emit(
-                OpenFeatureStatus.Error(
-                    OpenFeatureError.GeneralError(
-                        e.message ?: "Unknown error"
-                    )
+            _status.value = OpenFeatureStatus.Error(
+                OpenFeatureError.GeneralError(
+                    e.message ?: "Unknown error"
                 )
             )
         }
@@ -406,42 +427,34 @@ open class OpenFeatureAPIInstance internal constructor() {
     /**
      * Get the current [OpenFeatureStatus] of this instance.
      */
-    fun getStatus(): OpenFeatureStatus = _statusFlow.replayCache.first()
+    fun getStatus(): OpenFeatureStatus = _status.value
 
     /**
-     * Observe events from the currently configured Provider.
+     * Observe events of type [T] from the currently configured Provider.
+     *
+     * The status is always updated before an event reaches subscribers. Subscribing while the provider
+     * is already in a state yields the event for that state immediately.
      */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    inline fun <reified T : OpenFeatureProviderEvents> observe(): Flow<T> = providersFlow
-        .flatMapLatest { it.observe() }.filterIsInstance()
+    inline fun <reified T : OpenFeatureProviderEvents> observe(): Flow<T> = providerEvents.filterIsInstance()
 
     /**
      * Aligning the state management to
      * https://openfeature.dev/specification/sections/events#requirement-535
      */
-    private val handleProviderEvents: FlowCollector<OpenFeatureProviderEvents> = FlowCollector { providerEvent ->
-        when (providerEvent) {
-            is OpenFeatureProviderEvents.ProviderReady -> {
-                emitProviderStatus(OpenFeatureStatus.Ready)
-            }
-
-            is OpenFeatureProviderEvents.ProviderStale -> {
-                emitProviderStatus(OpenFeatureStatus.Stale)
-            }
-
-            is OpenFeatureProviderEvents.ProviderError -> {
-                emitProviderStatus(providerEvent.toOpenFeatureStatusError())
-            }
-
-            else -> { // All other states should not be emitted from here
-            }
+    private suspend fun dispatchProviderEvent(event: OpenFeatureProviderEvents, providerName: String?) {
+        val stamped = event.withProviderName(providerName)
+        stamped.toOpenFeatureStatus()?.let { emitProviderStatus(it) }
+        if (!_events.tryEmit(stamped)) {
+            LoggerFactory.getLogger(LOGGER_NAME).warn(
+                { "Dropped provider event ${stamped::class.simpleName}: a subscriber is not keeping up." }
+            )
         }
     }
 
     private suspend fun emitProviderStatus(status: OpenFeatureStatus) {
         contextReconciliationMutex.withLock {
             providerStatusGeneration++
-            _statusFlow.emit(status)
+            _status.value = status
         }
     }
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
@@ -9,7 +9,8 @@ sealed class OpenFeatureProviderEvents {
         val flagsChanged: Set<String> = emptySet(),
         val message: String? = null,
         val errorCode: ErrorCode? = null,
-        val eventMetadata: Map<String, Any> = emptyMap()
+        val eventMetadata: Map<String, Any> = emptyMap(),
+        val providerName: String? = null
     )
 
     abstract val eventDetails: EventDetails?
@@ -45,6 +46,36 @@ sealed class OpenFeatureProviderEvents {
     data class ProviderStale(
         override val eventDetails: EventDetails? = null
     ) : OpenFeatureProviderEvents()
+
+    /**
+     * The provider started reconciling its state with a new [dev.openfeature.kotlin.sdk.EvaluationContext].
+     * [eventDetails] may supply [EventDetails.flagsChanged], [EventDetails.message], [EventDetails.errorCode], and [EventDetails.eventMetadata] as applicable.
+     */
+    data class ProviderReconciling(
+        override val eventDetails: EventDetails? = null
+    ) : OpenFeatureProviderEvents()
+
+    /**
+     * The provider finished reconciling its state with a new [dev.openfeature.kotlin.sdk.EvaluationContext].
+     * [eventDetails] may supply [EventDetails.flagsChanged], [EventDetails.message], [EventDetails.errorCode], and [EventDetails.eventMetadata] as applicable.
+     */
+    data class ProviderContextChanged(
+        override val eventDetails: EventDetails? = null
+    ) : OpenFeatureProviderEvents()
+}
+
+/**
+ * Status implied by an event, per the event/status association table in the specification.
+ *
+ * Returns null for events that carry no status transition, leaving the current status untouched.
+ */
+internal fun OpenFeatureProviderEvents.toOpenFeatureStatus(): OpenFeatureStatus? = when (this) {
+    is OpenFeatureProviderEvents.ProviderReady -> OpenFeatureStatus.Ready
+    is OpenFeatureProviderEvents.ProviderStale -> OpenFeatureStatus.Stale
+    is OpenFeatureProviderEvents.ProviderError -> toOpenFeatureStatusError()
+    is OpenFeatureProviderEvents.ProviderReconciling -> OpenFeatureStatus.Reconciling
+    is OpenFeatureProviderEvents.ProviderContextChanged -> OpenFeatureStatus.Ready
+    is OpenFeatureProviderEvents.ProviderConfigurationChanged -> null
 }
 
 internal fun OpenFeatureProviderEvents.ProviderError.toOpenFeatureStatusError(): OpenFeatureStatus {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
@@ -64,6 +64,37 @@ sealed class OpenFeatureProviderEvents {
     ) : OpenFeatureProviderEvents()
 }
 
+internal fun OpenFeatureProviderEvents.withProviderName(providerName: String?): OpenFeatureProviderEvents {
+    val details = (eventDetails ?: OpenFeatureProviderEvents.EventDetails()).copy(providerName = providerName)
+    return when (this) {
+        is OpenFeatureProviderEvents.ProviderReady -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderError -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderConfigurationChanged -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderStale -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderReconciling -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderContextChanged -> copy(eventDetails = details)
+    }
+}
+
+/**
+ * Event representing this status, so that a handler attached once the provider is already in a given
+ * state runs immediately.
+ *
+ * Returns null for [OpenFeatureStatus.NotReady], which has no corresponding event type.
+ */
+internal fun OpenFeatureStatus.toCurrentStateEvent(): OpenFeatureProviderEvents? = when (this) {
+    is OpenFeatureStatus.Ready -> OpenFeatureProviderEvents.ProviderReady()
+    is OpenFeatureStatus.Stale -> OpenFeatureProviderEvents.ProviderStale()
+    is OpenFeatureStatus.Reconciling -> OpenFeatureProviderEvents.ProviderReconciling()
+    is OpenFeatureStatus.Error -> OpenFeatureProviderEvents.ProviderError(
+        OpenFeatureProviderEvents.EventDetails(message = error.message, errorCode = error.errorCode())
+    )
+    is OpenFeatureStatus.Fatal -> OpenFeatureProviderEvents.ProviderError(
+        OpenFeatureProviderEvents.EventDetails(message = error.message, errorCode = ErrorCode.PROVIDER_FATAL)
+    )
+    is OpenFeatureStatus.NotReady -> null
+}
+
 /**
  * Status implied by an event, per the event/status association table in the specification.
  *

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -9,7 +9,7 @@ import dev.openfeature.kotlin.sdk.ProviderMetadata
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
-import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -202,16 +202,10 @@ class MultiProvider(
     }
 
     private suspend fun handleProviderEvent(provider: ChildFeatureProvider, event: OpenFeatureProviderEvents) {
-        val newChildStatus = when (event) {
-            // ProviderConfigurationChanged events should always re-emit
-            is OpenFeatureProviderEvents.ProviderConfigurationChanged -> {
-                eventFlow.emit(event)
-                return
-            }
-
-            is OpenFeatureProviderEvents.ProviderReady -> OpenFeatureStatus.Ready
-            is OpenFeatureProviderEvents.ProviderStale -> OpenFeatureStatus.Stale
-            is OpenFeatureProviderEvents.ProviderError -> event.toOpenFeatureStatusError()
+        // Events carrying no status transition (e.g. ProviderConfigurationChanged) always re-emit.
+        val newChildStatus = event.toOpenFeatureStatus() ?: run {
+            eventFlow.emit(event)
+            return
         }
 
         val previousStatus = _statusFlow.value

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
@@ -231,13 +231,15 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.shutdown()
         testScheduler.advanceUntilIdle()
         job.cancelAndJoin()
-        assertEquals(5, emittedStatuses.size)
+        // statusFlow is a snapshot: the transient Reconciling between onContextSet starting and
+        // completing is conflated away here. StatusTests covers that transition against a provider
+        // that holds onContextSet open.
+        assertEquals(4, emittedStatuses.size)
         assertTrue(emittedStatuses[0] is OpenFeatureStatus.NotReady)
         assertTrue(emittedStatuses[1] is OpenFeatureStatus.Error)
         assertTrue((emittedStatuses[1] as OpenFeatureStatus.Error).error is OpenFeatureError.ProviderNotReadyError)
-        assertTrue(emittedStatuses[2] is OpenFeatureStatus.Reconciling)
-        assertTrue(emittedStatuses[3] is OpenFeatureStatus.Ready)
-        assertTrue(emittedStatuses[4] is OpenFeatureStatus.NotReady)
+        assertTrue(emittedStatuses[2] is OpenFeatureStatus.Ready)
+        assertTrue(emittedStatuses[3] is OpenFeatureStatus.NotReady)
     }
 
     @Test
@@ -326,6 +328,7 @@ class DeveloperExperienceTests {
 
     @Test
     fun testProviderEventFlowShouldSupportFiltering() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val provider = OverlyEmittingProvider("Overly Emitting Provider")
         val staleEvents = mutableListOf<OpenFeatureProviderEvents>()
         val job = launch {
@@ -334,11 +337,14 @@ class DeveloperExperienceTests {
                 staleEvents.add(it)
             }
         }
+        // Let the collector subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
         // emits ProviderReady
         OpenFeatureAPI.setProviderAndWait(
             provider,
-            initialContext = ImmutableContext("first")
+            initialContext = ImmutableContext("first"),
+            dispatcher = testDispatcher
         )
         // emits ProviderStale + ProviderStale + ProviderStale
         OpenFeatureAPI.getClient().track("hello-world")
@@ -349,15 +355,9 @@ class DeveloperExperienceTests {
 
         OpenFeatureAPI.shutdown()
         job.cancelAndJoin()
-        assertEquals(
-            listOf<OpenFeatureProviderEvents>(
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale()
-            ),
-            staleEvents
-        )
+        assertEquals(4, staleEvents.size)
+        assertTrue(staleEvents.all { it is OpenFeatureProviderEvents.ProviderStale })
+        assertTrue(staleEvents.all { it.eventDetails?.providerName == "Overly Emitting Provider" })
     }
 
     @Test
@@ -386,29 +386,13 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.setProviderAndWait(provider)
 
         OpenFeatureAPI.setEvaluationContextAndWait(context)
-        val emittedStatuses = mutableListOf<OpenFeatureStatus>()
-        val job = launch {
-            OpenFeatureAPI.statusFlow.collect {
-                emittedStatuses.add(it)
-            }
-        }
-        testScheduler.advanceUntilIdle()
-
         OpenFeatureAPI.setEvaluationContextAndWait(context)
         testScheduler.advanceUntilIdle()
-        job.cancelAndJoin()
 
         assertEquals(2, provider.onContextSetCalls.size)
         assertTrue(provider.onContextSetCalls[1].first === context)
         assertTrue(provider.onContextSetCalls[1].second === context)
-        assertEquals(
-            listOf(
-                OpenFeatureStatus.Ready,
-                OpenFeatureStatus.Reconciling,
-                OpenFeatureStatus.Ready
-            ),
-            emittedStatuses
-        )
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/EventDetailsTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/EventDetailsTests.kt
@@ -1,12 +1,14 @@
 package dev.openfeature.kotlin.sdk
 
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 class EventDetailsTests {
 
@@ -78,5 +80,73 @@ class EventDetailsTests {
         val errorStatus = assertIs<OpenFeatureStatus.Error>(status)
         val err = assertIs<OpenFeatureError.GeneralError>(errorStatus.error)
         assertEquals("test", err.message)
+    }
+
+    @Test
+    fun readyEventMapsToReadyStatus() {
+        assertEquals(
+            OpenFeatureStatus.Ready,
+            OpenFeatureProviderEvents.ProviderReady().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun staleEventMapsToStaleStatus() {
+        assertEquals(
+            OpenFeatureStatus.Stale,
+            OpenFeatureProviderEvents.ProviderStale().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun reconcilingEventMapsToReconcilingStatus() {
+        assertEquals(
+            OpenFeatureStatus.Reconciling,
+            OpenFeatureProviderEvents.ProviderReconciling().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun contextChangedEventMapsToReadyStatus() {
+        assertEquals(
+            OpenFeatureStatus.Ready,
+            OpenFeatureProviderEvents.ProviderContextChanged().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun configurationChangedEventMapsToNoStatusTransition() {
+        assertNull(OpenFeatureProviderEvents.ProviderConfigurationChanged().toOpenFeatureStatus())
+    }
+
+    @Test
+    fun errorEventMapsThroughToErrorStatus() {
+        val evt = OpenFeatureProviderEvents.ProviderError(
+            OpenFeatureProviderEvents.EventDetails(
+                message = "flag missing",
+                errorCode = ErrorCode.FLAG_NOT_FOUND
+            )
+        )
+
+        val error = assertIs<OpenFeatureStatus.Error>(evt.toOpenFeatureStatus())
+        assertIs<OpenFeatureError.FlagNotFoundError>(error.error)
+    }
+
+    @Test
+    fun errorEventWithFatalCodeMapsThroughToFatalStatus() {
+        val evt = OpenFeatureProviderEvents.ProviderError(
+            OpenFeatureProviderEvents.EventDetails(
+                message = "unrecoverable",
+                errorCode = ErrorCode.PROVIDER_FATAL
+            )
+        )
+
+        assertIs<OpenFeatureStatus.Fatal>(evt.toOpenFeatureStatus())
+    }
+
+    @Test
+    fun eventDetailsCarryProviderName() {
+        val details = OpenFeatureProviderEvents.EventDetails(providerName = "my-provider")
+        assertEquals("my-provider", details.providerName)
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventRelayTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventRelayTests.kt
@@ -1,0 +1,198 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.helpers.DoSomethingProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The SDK republishes provider events itself rather than exposing the provider's stream directly, so
+ * that the status is always updated before subscribers see the event that caused it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProviderEventRelayTests {
+
+    @BeforeTest
+    fun setUp() = runTest {
+        OpenFeatureAPI.shutdown()
+    }
+
+    private class ControllableEmitter(name: String) : DoSomethingProvider(
+        metadata = object : ProviderMetadata {
+            override val name: String = name
+        }
+    ) {
+        private val emissions = MutableSharedFlow<OpenFeatureProviderEvents>(extraBufferCapacity = 16)
+
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            emissions.emit(OpenFeatureProviderEvents.ProviderReady())
+        }
+
+        override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+            // Nothing: these tests drive emissions explicitly.
+        }
+
+        override fun observe(): Flow<OpenFeatureProviderEvents> = emissions
+
+        fun emit(event: OpenFeatureProviderEvents) {
+            check(emissions.tryEmit(event)) { "Test emitter buffer exhausted" }
+        }
+    }
+
+    @Test
+    fun statusReflectsTheEventBeforeSubscribersSeeIt() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("relay-ordering")
+        val statusesSeenByHandler = mutableListOf<OpenFeatureStatus>()
+
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents.ProviderStale>().collect {
+                statusesSeenByHandler.add(OpenFeatureAPI.getStatus())
+            }
+        }
+        testScheduler.runCurrent()
+
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        provider.emit(OpenFeatureProviderEvents.ProviderStale())
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(listOf<OpenFeatureStatus>(OpenFeatureStatus.Stale), statusesSeenByHandler)
+    }
+
+    @Test
+    fun handlerAttachedWhenAlreadyReadyRunsImmediately() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(ControllableEmitter("late-subscriber"), dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+
+        val received = mutableListOf<OpenFeatureProviderEvents.ProviderReady>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents.ProviderReady>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertEquals(1, received.size)
+        assertEquals("late-subscriber", received.single().eventDetails?.providerName)
+    }
+
+    @Test
+    fun handlerAttachedWhenAlreadyStaleReceivesStaleNotReady() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("stale-state")
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        provider.emit(OpenFeatureProviderEvents.ProviderStale())
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertIs<OpenFeatureProviderEvents.ProviderStale>(received.single())
+    }
+
+    @Test
+    fun statelessEventIsNotResurfacedForLateSubscribers() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("stateless-event")
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // The most recent event carries no status, so it must not be what a late subscriber is told.
+        provider.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertIs<OpenFeatureProviderEvents.ProviderReady>(received.single())
+    }
+
+    @Test
+    fun eventsFromAReplacedProviderAreNotResurfaced() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val first = ControllableEmitter("first")
+        OpenFeatureAPI.setProviderAndWait(first, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        first.emit(OpenFeatureProviderEvents.ProviderStale())
+        testScheduler.advanceUntilIdle()
+
+        OpenFeatureAPI.setProviderAndWait(ControllableEmitter("second"), dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertIs<OpenFeatureProviderEvents.ProviderReady>(received.single())
+        assertEquals("second", received.single().eventDetails?.providerName)
+    }
+
+    @Test
+    fun shutdownRevertsToNotReadyWithoutEmittingAnEvent() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(ControllableEmitter("shutdown"), dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        // Subscribing while Ready yields exactly one event, so a later count proves nothing was added.
+        assertEquals(1, received.size)
+
+        OpenFeatureAPI.shutdown()
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+        // There is no event type for NOT_READY: the SDK infers the transition instead of emitting.
+        assertEquals(1, received.size)
+    }
+
+    @Test
+    fun everyRelayedEventCarriesTheEmittingProviderName() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("attribution")
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        provider.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertTrue(received.isNotEmpty())
+        assertTrue(received.all { it.eventDetails?.providerName == "attribution" })
+    }
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
@@ -89,6 +89,7 @@ class ProviderEventingTests {
 
     @Test
     fun testProviderEventFlowShouldSupportSwappingProviders() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val firstProvider = OverlyEmittingProvider("First Provider")
         val secondProvider = OverlyEmittingProvider("Second Provider")
 
@@ -98,27 +99,32 @@ class ProviderEventingTests {
                 emittedEvents.add(it)
             }
         }
+        // Let the collector subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
         // emits ProviderReady
         OpenFeatureAPI.setProviderAndWait(
             firstProvider,
-            initialContext = ImmutableContext("first")
+            initialContext = ImmutableContext("first"),
+            dispatcher = testDispatcher
         )
         // emits ProviderStale + ProviderConfigurationChanged
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("first.v2"))
         testScheduler.advanceUntilIdle()
         assertEquals(
             listOf(
-                OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderConfigurationChanged()
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class
             ),
-            emittedEvents
+            emittedEvents.map { it::class }
         )
+        assertTrue(emittedEvents.all { it.eventDetails?.providerName == "First Provider" })
         // emits ProviderReady
         OpenFeatureAPI.setProviderAndWait(
             secondProvider,
-            initialContext = ImmutableContext("second")
+            initialContext = ImmutableContext("second"),
+            dispatcher = testDispatcher
         )
         testScheduler.advanceUntilIdle()
         // emits ProviderStale + ProviderStale + ProviderStale
@@ -133,22 +139,28 @@ class ProviderEventingTests {
         job.cancelAndJoin()
         assertEquals(
             listOf(
-                OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderConfigurationChanged(),
-                OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderConfigurationChanged()
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class,
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class
             ),
-            emittedEvents
+            emittedEvents.map { it::class }
+        )
+        // The relay attributes each event to whichever provider was active when it was emitted.
+        assertEquals(
+            List(3) { "First Provider" } + List(6) { "Second Provider" },
+            emittedEvents.map { it.eventDetails?.providerName }
         )
     }
 
     @Test
     fun clientObserveMatchesApiObserveWhenCollectingAllProviderEvents() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val provider = OverlyEmittingProvider("Client parity provider")
         val fromApi = mutableListOf<OpenFeatureProviderEvents>()
         val fromClient = mutableListOf<OpenFeatureProviderEvents>()
@@ -160,8 +172,14 @@ class ProviderEventingTests {
         val clientJob = launch {
             client.observe().collect { fromClient.add(it) }
         }
+        // Let both collectors subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
-        OpenFeatureAPI.setProviderAndWait(provider, initialContext = ImmutableContext("ctx"))
+        OpenFeatureAPI.setProviderAndWait(
+            provider,
+            initialContext = ImmutableContext("ctx"),
+            dispatcher = testDispatcher
+        )
         testScheduler.advanceUntilIdle()
         OpenFeatureAPI.shutdown()
         apiJob.cancelAndJoin()
@@ -173,6 +191,7 @@ class ProviderEventingTests {
 
     @Test
     fun clientObserveFiltersByReifiedEventType() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val provider = OverlyEmittingProvider("filter-by-type")
         val client = OpenFeatureAPI.getClient("filter-by-type")
         val staleEvents = mutableListOf<OpenFeatureProviderEvents.ProviderStale>()
@@ -189,8 +208,14 @@ class ProviderEventingTests {
                 .filterIsInstance<OpenFeatureProviderEvents.ProviderConfigurationChanged>()
                 .collect { configurationChangedEvents.add(it) }
         }
+        // Let both collectors subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
-        OpenFeatureAPI.setProviderAndWait(provider, initialContext = ImmutableContext("ctx"))
+        OpenFeatureAPI.setProviderAndWait(
+            provider,
+            initialContext = ImmutableContext("ctx"),
+            dispatcher = testDispatcher
+        )
         testScheduler.advanceUntilIdle()
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("ctx.v2"))
         testScheduler.advanceUntilIdle()
@@ -198,10 +223,9 @@ class ProviderEventingTests {
         staleJob.cancelAndJoin()
         configJob.cancelAndJoin()
 
-        assertEquals(listOf(OpenFeatureProviderEvents.ProviderStale()), staleEvents)
-        assertEquals(
-            listOf(OpenFeatureProviderEvents.ProviderConfigurationChanged()),
-            configurationChangedEvents
-        )
+        assertEquals(1, staleEvents.size)
+        assertEquals(1, configurationChangedEvents.size)
+        assertEquals("filter-by-type", staleEvents.single().eventDetails?.providerName)
+        assertEquals("filter-by-type", configurationChangedEvents.single().eventDetails?.providerName)
     }
 }


### PR DESCRIPTION
> **Stacked on #258.** Base is `main` because the branch lives in a fork and GitHub requires a base branch in the upstream repository, so the diff shown here includes #258's commit. Review only the second commit, `fix!: derive provider status from a single ordered event relay`, or merge #258 first and this diff will reduce to it.

## Intent

Provider status and provider events are two independent subscriptions to the same provider stream. `handleProviderEvents` collects it to update the status, and `observe<T>()` hands application code its own subscription — so nothing orders the two, and a handler can observe an event before the status reflects it. SDK-inferred transitions also never appear in the event stream at all. This PR makes the SDK collect the provider once, write the status, and only then republish, so the status is always current by the time subscribers see the event that caused it.

## Motivation

Requirement 5.3.5 requires the status be updated *before* the handlers for that event run; with two independent subscriptions that cannot be guaranteed. Requirement 5.3.3 requires a handler attached when the provider is already in a state to run immediately, which nothing currently provides. Both are prerequisites for [spec #385](https://github.com/open-feature/spec/pull/385), where the status is derived entirely from provider events.

It also closes the gap raised on [spec #365](https://github.com/open-feature/spec/issues/365) that Kotlin's `observe` is a straight passthrough to the provider, so lifecycle events around `setProvider`/`setEvaluationContext` never appear in it.

## Spec Requirements

| Requirement | Relationship |
| --- | --- |
| [5.3.5](https://openfeature.dev/specification/sections/events/#requirement-535) — the SDK **MUST** update the status "**before** invoking any event handlers for that event" | **Fixes an existing violation** |
| [5.3.3](https://openfeature.dev/specification/sections/events/#requirement-533) — "Handlers attached after the provider is already in the associated state, **MUST** run immediately" | **Fixes an existing violation** |
| [5.2.3](https://openfeature.dev/specification/sections/events/#requirement-523) — event details **MUST** contain the provider name | **Fixes an existing violation** — stamped by the relay |
| [1.7.1](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-171), [1.7.2.1](https://openfeature.dev/specification/sections/flag-evaluation/#conditional-requirement-1721) | Satisfied — status accessor incl. `RECONCILING` |
| [1.7.3](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-173), [1.7.4](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-174), [1.7.5](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-175) | Satisfied — derived from provider events via the 5.3.5 table |
| [1.7.6](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-176) — `NOT_READY` once `shutdown` terminates | Satisfied — inferred by the SDK, status only, no event (5.1.1 has no `PROVIDER_NOT_READY`) |
| [5.2.6](https://openfeature.dev/specification/sections/events/#requirement-526) — handlers **MUST** persist across provider changes | **Improved** — an SDK-owned stream outlives provider swaps |
| [1.4.9](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-149), [1.4.10](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-1410) | Preserved — see *NOT_READY/FATAL short-circuit* below |

## Changes

### Implementation
- One internal collector on `provider.observe()`: stamps the provider name, writes the status from the event, then republishes onto an SDK-owned `MutableSharedFlow` that `observe<T>()` reads.
- Republication uses `tryEmit` against a bounded buffer, so a slow application subscriber can never stall the SDK's own status derivation — requirement 1.1.2.4 notes application handlers need not complete. Overflow drops the oldest and logs.
- New subscribers receive an event synthesised from the *current status*, not a replay of the last raw event. Replaying the last event would resurface a stateless `PROVIDER_CONFIGURATION_CHANGED`, or an event belonging to a provider that has since been replaced.
- `statusFlow` becomes a `StateFlow`; `getStatus()` reads `.value` instead of a replay cache.

### NOT_READY/FATAL short-circuit
Requirements 1.7.6/1.7.7 as they stood — the client short-circuiting evaluation while `NOT_READY`/`FATAL` — were **removed** by #385 and retagged `@spec-2.2.7`, on the grounds that reading the status and then evaluating is itself a time-of-check/time-of-use gap ([spec #369](https://github.com/open-feature/spec/issues/369)). They were removed rather than inverted, so short-circuiting remains *permitted*. This SDK keeps it: dropping it would change the error codes callers already depend on, and `EvaluationState` snapshots the provider and context together, which bounds the staleness. Only the KDoc changes, to record that this is now deliberate policy rather than a requirement.

## Testing

- A handler reads the matching status at the moment it runs (5.3.5).
- A subscriber attaching while the provider is already `READY` — and separately while `STALE` — receives that state's event immediately; a stateless `CONFIGURATION_CHANGED` is not resurfaced, nor is an event from a replaced provider (5.3.3).
- Every relayed event carries the emitting provider's name, synthesised ones included (5.2.3).
- `shutdown` reverts to `NOT_READY` without putting an event into the stream (1.7.6).
- 241 tests, `ktlintCheck` and `apiCheck` green, `apiDump` regenerated.

Two pre-existing test weaknesses surfaced and were corrected rather than worked around: several event tests launched a collector and then registered a provider before it had subscribed, passing only because the *provider's own* flow replayed; and status-sequence assertions relied on the relay running in real time. Both now subscribe first and drive the relay on the test dispatcher.

## Breaking Changes

`statusFlow` is now `StateFlow<OpenFeatureStatus>` rather than `Flow<OpenFeatureStatus>`, and conflates consecutive equal values — status is a snapshot, and the transition sequence belongs to `observe<T>()`. Source-compatible for collection; binary-incompatible, and code asserting on every intermediate status should move to the event stream.
