### PR TITLE
feat!: add StateManagingProvider and deprecate SDK-synthesized lifecycle events

### DIFF
--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -286,10 +286,11 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
+	public final fun getProviderEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
-	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -329,7 +330,8 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureClient : dev/openfeatur
 	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;)Ldev/openfeature/kotlin/sdk/Value;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/Value;
-	public fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public synthetic fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -426,6 +426,14 @@ public final class dev/openfeature/kotlin/sdk/Reason : java/lang/Enum {
 	public static fun values ()[Ldev/openfeature/kotlin/sdk/Reason;
 }
 
+public abstract interface class dev/openfeature/kotlin/sdk/StateManagingProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
+	public abstract fun observe ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class dev/openfeature/kotlin/sdk/StateManagingProvider$DefaultImpls {
+	public static fun track (Ldev/openfeature/kotlin/sdk/StateManagingProvider;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
+}
+
 public abstract interface class dev/openfeature/kotlin/sdk/Structure {
 	public abstract fun asMap ()Ljava/util/Map;
 	public abstract fun asObjectMap ()Ljava/util/Map;

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -694,19 +694,21 @@ public abstract class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvent
 
 public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Set;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun component4 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
-	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getErrorCode ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun getEventMetadata ()Ljava/util/Map;
 	public final fun getFlagsChanged ()Ljava/util/Set;
 	public final fun getMessage ()Ljava/lang/String;
+	public final fun getProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -718,6 +720,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I
@@ -744,6 +759,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -286,10 +286,11 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getEvaluationContext ()Ldev/openfeature/kotlin/sdk/EvaluationContext;
 	public final fun getHooks ()Ljava/util/List;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
+	public final fun getProviderEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
-	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -329,7 +330,8 @@ public final class dev/openfeature/kotlin/sdk/OpenFeatureClient : dev/openfeatur
 	public fun getObjectDetails (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;)Ldev/openfeature/kotlin/sdk/Value;
 	public fun getObjectValue (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/Value;
-	public fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public synthetic fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringDetails (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/FlagEvaluationOptions;)Ldev/openfeature/kotlin/sdk/FlagEvaluationDetails;
 	public fun getStringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -426,6 +426,14 @@ public final class dev/openfeature/kotlin/sdk/Reason : java/lang/Enum {
 	public static fun values ()[Ldev/openfeature/kotlin/sdk/Reason;
 }
 
+public abstract interface class dev/openfeature/kotlin/sdk/StateManagingProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
+	public abstract fun observe ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class dev/openfeature/kotlin/sdk/StateManagingProvider$DefaultImpls {
+	public static fun track (Ldev/openfeature/kotlin/sdk/StateManagingProvider;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
+}
+
 public abstract interface class dev/openfeature/kotlin/sdk/Structure {
 	public abstract fun asMap ()Ljava/util/Map;
 	public abstract fun asObjectMap ()Ljava/util/Map;

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -694,19 +694,21 @@ public abstract class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvent
 
 public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Set;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun component4 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
-	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;Ljava/util/Set;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getErrorCode ()Ldev/openfeature/kotlin/sdk/exceptions/ErrorCode;
 	public final fun getEventMetadata ()Ljava/util/Map;
 	public final fun getFlagsChanged ()Ljava/util/Set;
 	public final fun getMessage ()Ljava/lang/String;
+	public final fun getProviderName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -718,6 +720,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderConfigurationChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I
@@ -744,6 +759,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/LegacyProviderWrapper.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/LegacyProviderWrapper.kt
@@ -1,0 +1,269 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+
+private const val WRAPPER_EVENT_BUFFER_CAPACITY = 64
+
+/**
+ * Presents a provider that does not emit its own lifecycle events as one that does, by synthesising
+ * those events around the lifecycle methods.
+ *
+ * This is the deprecated compatibility path. Everything the SDK used to do for every provider —
+ * inferring readiness from `initialize` returning, and coalescing overlapping context reconciliations —
+ * lives here and nowhere else, so that removing support for it later is a matter of deleting this class
+ * and the branch that installs it.
+ *
+ * Events the wrapped provider emits itself are passed through unchanged. Where a wrapped provider emits
+ * a lifecycle event of its own, the wrapper suppresses the event it would otherwise have synthesised, so
+ * a partially migrated provider does not produce the same transition twice.
+ */
+internal class LegacyProviderWrapper(
+    val inner: FeatureProvider,
+    private val eventDispatcher: CoroutineDispatcher
+) : StateManagingProvider,
+    FeatureProvider by inner {
+
+    private val lock = SynchronizedObject()
+
+    /**
+     * Replays its most recent event because the SDK subscribes concurrently with `initialize` being
+     * called: without a replay the synthesised readiness event can be emitted before the SDK is
+     * listening and be lost. Only the SDK consumes this; application subscribers read the SDK's own
+     * stream, which does not replay.
+     */
+    private val events = MutableSharedFlow<OpenFeatureProviderEvents>(
+        replay = 1,
+        extraBufferCapacity = WRAPPER_EVENT_BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    /**
+     * Single queue for everything this wrapper publishes, so that events forwarded from [inner] and
+     * events synthesised here keep a total order instead of racing each other into [events].
+     */
+    private val outgoing = Channel<Outgoing>(Channel.UNLIMITED)
+
+    private var scope: CoroutineScope? = null
+    private var relayJob: Job? = null
+    private var publishJob: Job? = null
+    private var initialized = false
+
+    private sealed interface Outgoing {
+        /** An event from [inner], forwarded unchanged. */
+        class Forwarded(val event: OpenFeatureProviderEvents) : Outgoing
+
+        /**
+         * An event the wrapper stands in for, dropped if [inner] has reported a lifecycle event of its
+         * own since [innerReportsAtRequest]. Evaluated when this item is dequeued, so anything [inner]
+         * queued first has already been counted.
+         */
+        class Synthesised(val event: OpenFeatureProviderEvents, val innerReportsAtRequest: Long) : Outgoing
+    }
+
+    /** Counts lifecycle events seen from [inner], so a synthesised event can be suppressed. */
+    private var innerLifecycleEvents: Long = 0
+
+    /**
+     * Last lifecycle event actually published, whichever side it came from. Readiness is usually this
+     * wrapper's own synthesised event rather than anything [inner] emitted, so a cancelled reconciliation
+     * has to be restored from what was published, not from what was forwarded.
+     */
+    private var lastPublishedLifecycleEvent: OpenFeatureProviderEvents? = null
+
+    private var activeReconciliations = 0
+    private var reconciliationRestoreEvent: OpenFeatureProviderEvents? = null
+    private var reconciliationTerminalEvent: OpenFeatureProviderEvents? = null
+    private var reconciliationTerminalInnerEvents: Long? = null
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = events
+
+    override suspend fun initialize(initialContext: EvaluationContext?) {
+        if (synchronized(lock) { initialized }) return
+
+        val seen = startRelay()
+        try {
+            inner.initialize(initialContext)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // Emitted before propagating so handlers see the failure, not just the caller.
+            synthesise(
+                seen,
+                OpenFeatureProviderEvents.ProviderError(
+                    OpenFeatureProviderEvents.EventDetails(
+                        message = e.message ?: "Provider failed to initialize",
+                        errorCode = (e as? OpenFeatureError)?.errorCode()
+                    )
+                )
+            )
+            throw e
+        }
+
+        synchronized(lock) { initialized = true }
+        synthesise(seen, OpenFeatureProviderEvents.ProviderReady())
+    }
+
+    override fun shutdown() {
+        val toCancel = synchronized(lock) {
+            initialized = false
+            activeReconciliations = 0
+            reconciliationRestoreEvent = null
+            reconciliationTerminalEvent = null
+            reconciliationTerminalInnerEvents = null
+            val job = relayJob
+            relayJob = null
+            job
+        }
+        toCancel?.cancel(CancellationException("Provider event relay cancelled due to shutdown"))
+
+        try {
+            inner.shutdown()
+        } finally {
+            val toClose = synchronized(lock) {
+                val current = scope
+                scope = null
+                current
+            }
+            toClose?.cancel(CancellationException("Legacy provider wrapper closed due to shutdown"))
+        }
+    }
+
+    override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+        val shouldAnnounce = synchronized(lock) {
+            if (activeReconciliations == 0) {
+                reconciliationRestoreEvent = lastPublishedLifecycleEvent
+                reconciliationTerminalEvent = null
+                reconciliationTerminalInnerEvents = null
+            }
+            activeReconciliations++
+            activeReconciliations == 1
+        }
+        if (shouldAnnounce) {
+            outgoing.send(Outgoing.Forwarded(OpenFeatureProviderEvents.ProviderReconciling()))
+        }
+
+        var terminal: OpenFeatureProviderEvents? = null
+        try {
+            inner.onContextSet(oldContext, newContext)
+            terminal = OpenFeatureProviderEvents.ProviderContextChanged()
+        } catch (e: CancellationException) {
+            // Cancelled by design: contributes no outcome, so the pre-reconciliation state is restored.
+        } catch (e: OpenFeatureError) {
+            terminal = OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(message = e.message, errorCode = e.errorCode())
+            )
+        } catch (e: Throwable) {
+            terminal = OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(message = e.message ?: "Context reconciliation failed")
+            )
+        } finally {
+            // Non-cancellable: a cancelled invocation still has to report or restore.
+            withContext(NonCancellable) {
+                completeReconciliation(terminal)?.let { queueAfterRelay(it) }
+            }
+        }
+    }
+
+    /**
+     * Records this invocation's outcome and returns the event to emit, if this was the last invocation
+     * in flight and nothing from [inner] has superseded the outcome in the meantime.
+     */
+    private fun completeReconciliation(terminal: OpenFeatureProviderEvents?): OpenFeatureProviderEvents? =
+        synchronized(lock) {
+            if (terminal != null) {
+                reconciliationTerminalEvent = terminal
+                reconciliationTerminalInnerEvents = innerLifecycleEvents
+            }
+            activeReconciliations--
+            if (activeReconciliations > 0) return@synchronized null
+
+            val recorded = reconciliationTerminalEvent
+            val supersededByInner = recorded != null && reconciliationTerminalInnerEvents != innerLifecycleEvents
+            val result = when {
+                supersededByInner -> null
+                recorded != null -> recorded
+                // No outcome recorded means every invocation was cancelled.
+                else -> reconciliationRestoreEvent
+            }
+            reconciliationRestoreEvent = null
+            reconciliationTerminalEvent = null
+            reconciliationTerminalInnerEvents = null
+            result
+        }
+
+    /** Queues an event the wrapper originates, after letting the relay forward what it already has. */
+    private suspend fun queueAfterRelay(event: OpenFeatureProviderEvents) {
+        yield()
+        outgoing.send(Outgoing.Forwarded(event))
+    }
+
+    private fun startRelay(): Long = synchronized(lock) {
+        relayJob?.cancel(CancellationException("Provider event relay cancelled due to re-initialization"))
+        val relayScope = scope ?: CoroutineScope(SupervisorJob() + eventDispatcher).also { scope = it }
+        if (publishJob == null) {
+            publishJob = relayScope.launch { publishOutgoing() }
+        }
+        relayJob = relayScope.launch {
+            inner.observe().collect { event ->
+                outgoing.send(Outgoing.Forwarded(event))
+            }
+        }
+        innerLifecycleEvents
+    }
+
+    private suspend fun publishOutgoing() {
+        for (item in outgoing) {
+            when (item) {
+                is Outgoing.Forwarded -> {
+                    if (item.event.toOpenFeatureStatus() != null) {
+                        synchronized(lock) {
+                            innerLifecycleEvents++
+                            lastPublishedLifecycleEvent = item.event
+                        }
+                    }
+                    events.emit(item.event)
+                }
+
+                is Outgoing.Synthesised -> {
+                    val reported = synchronized(lock) { innerLifecycleEvents > item.innerReportsAtRequest }
+                    if (!reported) {
+                        if (item.event.toOpenFeatureStatus() != null) {
+                            synchronized(lock) { lastPublishedLifecycleEvent = item.event }
+                        }
+                        events.emit(item.event)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Queues [event] to be published unless [inner] reports a lifecycle event of its own first.
+     *
+     * A provider midway through migrating may emit some of its own lifecycle events; where it does, the
+     * wrapper stands aside rather than reporting the same transition twice.
+     */
+    private suspend fun synthesise(seen: Long, event: OpenFeatureProviderEvents) {
+        // The relay goes first so anything the provider emitted can suppress this stand-in.
+        yield()
+        outgoing.send(Outgoing.Synthesised(event, seen))
+    }
+}

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -1,29 +1,34 @@
 package dev.openfeature.kotlin.sdk
 
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
-import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
+import dev.openfeature.kotlin.sdk.events.toCurrentStateEvent
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
+import dev.openfeature.kotlin.sdk.events.withProviderName
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.logging.LoggerFactory
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+
+private const val EVENT_BUFFER_CAPACITY = 64
+private const val LOGGER_NAME = "OpenFeatureAPI"
 
 /**
  * Core implementation of the OpenFeature API.
@@ -63,13 +68,32 @@ open class OpenFeatureAPIInstance internal constructor() {
     private var contextReconciliationTerminalProviderStatusGeneration: Long? = null
     val providersFlow: MutableStateFlow<FeatureProvider> = MutableStateFlow(noOpProvider)
 
-    private val _statusFlow: MutableSharedFlow<OpenFeatureStatus> =
-        MutableSharedFlow<OpenFeatureStatus>(replay = 1, extraBufferCapacity = 5)
-            .apply {
-                tryEmit(OpenFeatureStatus.NotReady)
-            }
+    private val _status: MutableStateFlow<OpenFeatureStatus> = MutableStateFlow(OpenFeatureStatus.NotReady)
 
-    val statusFlow: Flow<OpenFeatureStatus> get() = _statusFlow.distinctUntilChanged()
+    val statusFlow: StateFlow<OpenFeatureStatus> get() = _status
+
+    /**
+     * Events from the active provider, republished by the SDK so that the status is always updated
+     * before subscribers observe the event that caused it.
+     *
+     * Overflow drops the oldest event rather than suspending: a slow subscriber must never stall the
+     * SDK's own status derivation.
+     */
+    private val _events: MutableSharedFlow<OpenFeatureProviderEvents> = MutableSharedFlow(
+        replay = 0,
+        extraBufferCapacity = EVENT_BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    @PublishedApi
+    internal val providerEvents: Flow<OpenFeatureProviderEvents>
+        get() = _events.onSubscription {
+            // Replays the state, not the last event: a handler attached while the provider is already
+            // in a state must run, but a stateless event must not resurface.
+            _status.value.toCurrentStateEvent()
+                ?.withProviderName(getProvider().metadata.name)
+                ?.let { emit(it) }
+        }
 
     var hooks: List<Hook<*>> = listOf()
         private set
@@ -111,11 +135,12 @@ open class OpenFeatureAPIInstance internal constructor() {
     private fun listenToProviderEvents(provider: FeatureProvider, dispatcher: CoroutineDispatcher) {
         observeProviderEventsJob?.cancel(CancellationException("Provider job was cancelled due to new provider"))
         this.observeProviderEventsJob = CoroutineScope(SupervisorJob() + dispatcher).launch {
-            provider.observe().collect(handleProviderEvents)
+            provider.observe().collect { event ->
+                dispatchProviderEvent(event, provider.metadata.name)
+            }
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun setProviderInternal(
         provider: FeatureProvider,
         dispatcher: CoroutineDispatcher,
@@ -124,10 +149,8 @@ open class OpenFeatureAPIInstance internal constructor() {
         try {
             trackProviderBinding(provider)
         } catch (e: Throwable) {
-            _statusFlow.emit(
-                OpenFeatureStatus.Error(
-                    OpenFeatureError.GeneralError(e.message ?: "Unknown error")
-                )
+            _status.value = OpenFeatureStatus.Error(
+                OpenFeatureError.GeneralError(e.message ?: "Unknown error")
             )
             return
         }
@@ -149,7 +172,7 @@ open class OpenFeatureAPIInstance internal constructor() {
             swapCommitted = true
 
             // Emit NotReady status after swapping provider
-            _statusFlow.emit(OpenFeatureStatus.NotReady)
+            _status.value = OpenFeatureStatus.NotReady
 
             // Shutdown the previous provider outside the mutex
             if (oldProvider !== provider) {
@@ -164,7 +187,7 @@ open class OpenFeatureAPIInstance internal constructor() {
                 listenToProviderEvents(provider, dispatcher)
                 val state = getEvaluationState()
                 state.provider.initialize(state.context)
-                _statusFlow.emit(OpenFeatureStatus.Ready)
+                _status.value = OpenFeatureStatus.Ready
             }
         } catch (e: CancellationException) {
             // if cancellation hit before we committed the swap, release the binding we just claimed
@@ -209,7 +232,7 @@ open class OpenFeatureAPIInstance internal constructor() {
         }
         untrackProviderBinding(oldProvider)
         oldProvider.shutdown()
-        _statusFlow.emit(OpenFeatureStatus.NotReady)
+        _status.value = OpenFeatureStatus.NotReady
     }
 
     /**
@@ -265,7 +288,7 @@ open class OpenFeatureAPIInstance internal constructor() {
                         }
                     }
                     if (shouldEmitReconciling) {
-                        _statusFlow.emit(OpenFeatureStatus.Reconciling)
+                        _status.value = OpenFeatureStatus.Reconciling
                     }
                 }
             }
@@ -330,7 +353,7 @@ open class OpenFeatureAPIInstance internal constructor() {
                         statusToEmit != null &&
                         shouldEmitStatus
                     ) {
-                        _statusFlow.emit(statusToEmit)
+                        _status.value = statusToEmit
                     }
                 }
             }
@@ -343,13 +366,11 @@ open class OpenFeatureAPIInstance internal constructor() {
         } catch (e: CancellationException) {
             // This happens by design and shouldn't be treated as an error
         } catch (e: OpenFeatureError) {
-            _statusFlow.emit(OpenFeatureStatus.Error(e))
+            _status.value = OpenFeatureStatus.Error(e)
         } catch (e: Throwable) {
-            _statusFlow.emit(
-                OpenFeatureStatus.Error(
-                    OpenFeatureError.GeneralError(
-                        e.message ?: "Unknown error"
-                    )
+            _status.value = OpenFeatureStatus.Error(
+                OpenFeatureError.GeneralError(
+                    e.message ?: "Unknown error"
                 )
             )
         }
@@ -406,42 +427,34 @@ open class OpenFeatureAPIInstance internal constructor() {
     /**
      * Get the current [OpenFeatureStatus] of this instance.
      */
-    fun getStatus(): OpenFeatureStatus = _statusFlow.replayCache.first()
+    fun getStatus(): OpenFeatureStatus = _status.value
 
     /**
-     * Observe events from the currently configured Provider.
+     * Observe events of type [T] from the currently configured Provider.
+     *
+     * The status is always updated before an event reaches subscribers. Subscribing while the provider
+     * is already in a state yields the event for that state immediately.
      */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    inline fun <reified T : OpenFeatureProviderEvents> observe(): Flow<T> = providersFlow
-        .flatMapLatest { it.observe() }.filterIsInstance()
+    inline fun <reified T : OpenFeatureProviderEvents> observe(): Flow<T> = providerEvents.filterIsInstance()
 
     /**
      * Aligning the state management to
      * https://openfeature.dev/specification/sections/events#requirement-535
      */
-    private val handleProviderEvents: FlowCollector<OpenFeatureProviderEvents> = FlowCollector { providerEvent ->
-        when (providerEvent) {
-            is OpenFeatureProviderEvents.ProviderReady -> {
-                emitProviderStatus(OpenFeatureStatus.Ready)
-            }
-
-            is OpenFeatureProviderEvents.ProviderStale -> {
-                emitProviderStatus(OpenFeatureStatus.Stale)
-            }
-
-            is OpenFeatureProviderEvents.ProviderError -> {
-                emitProviderStatus(providerEvent.toOpenFeatureStatusError())
-            }
-
-            else -> { // All other states should not be emitted from here
-            }
+    private suspend fun dispatchProviderEvent(event: OpenFeatureProviderEvents, providerName: String?) {
+        val stamped = event.withProviderName(providerName)
+        stamped.toOpenFeatureStatus()?.let { emitProviderStatus(it) }
+        if (!_events.tryEmit(stamped)) {
+            LoggerFactory.getLogger(LOGGER_NAME).warn(
+                { "Dropped provider event ${stamped::class.simpleName}: a subscriber is not keeping up." }
+            )
         }
     }
 
     private suspend fun emitProviderStatus(status: OpenFeatureStatus) {
         contextReconciliationMutex.withLock {
             providerStatusGeneration++
-            _statusFlow.emit(status)
+            _status.value = status
         }
     }
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -9,6 +9,7 @@ import dev.openfeature.kotlin.sdk.logging.LoggerFactory
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -43,29 +45,27 @@ private const val LOGGER_NAME = "OpenFeatureAPI"
  */
 @Suppress("TooManyFunctions")
 open class OpenFeatureAPIInstance internal constructor() {
-    private data class ContextReconciliation(
-        val oldContext: EvaluationContext?,
-        val provider: FeatureProvider,
-        val providerGeneration: Long
-    )
-
     private var setProviderJob: Job? = null
     private var setEvaluationContextJob: Job? = null
     private var observeProviderEventsJob: Job? = null
 
     private val providerMutex = Mutex()
-    private val contextReconciliationMutex = Mutex()
     private val stateLock = SynchronizedObject()
     private val noOpProvider = NoOpProvider()
+
+    /** The provider as registered by the application: what evaluations and [getProvider] use. */
     private var provider: FeatureProvider = noOpProvider
+
+    /**
+     * The provider the lifecycle is driven through and whose events are relayed. Identical to [provider]
+     * for a [StateManagingProvider]; otherwise the [LegacyProviderWrapper] standing in for it.
+     */
+    private var lifecycleProvider: FeatureProvider = noOpProvider
     private var providerGeneration: Long = 0
     private var context: EvaluationContext? = null
-    private var contextReconciliationGeneration: Long? = null
-    private var activeContextReconciliations: Int = 0
-    private var contextReconciliationInitialStatus: OpenFeatureStatus? = null
-    private var contextReconciliationTerminalStatus: OpenFeatureStatus? = null
-    private var providerStatusGeneration: Long = 0
-    private var contextReconciliationTerminalProviderStatusGeneration: Long? = null
+
+    /** Completed when the active provider reports a lifecycle event, so registration can settle. */
+    private var pendingLifecycleReport: CompletableDeferred<Unit>? = null
     val providersFlow: MutableStateFlow<FeatureProvider> = MutableStateFlow(noOpProvider)
 
     private val _status: MutableStateFlow<OpenFeatureStatus> = MutableStateFlow(OpenFeatureStatus.NotReady)
@@ -91,7 +91,7 @@ open class OpenFeatureAPIInstance internal constructor() {
             // Replays the state, not the last event: a handler attached while the provider is already
             // in a state must run, but a stateless event must not resurface.
             _status.value.toCurrentStateEvent()
-                ?.withProviderName(getProvider().metadata.name)
+                ?.withProviderName(getProvider().attributionName())
                 ?.let { emit(it) }
         }
 
@@ -132,13 +132,69 @@ open class OpenFeatureAPIInstance internal constructor() {
         setProviderInternal(provider, dispatcher, initialContext)
     }
 
-    private fun listenToProviderEvents(provider: FeatureProvider, dispatcher: CoroutineDispatcher) {
-        observeProviderEventsJob?.cancel(CancellationException("Provider job was cancelled due to new provider"))
-        this.observeProviderEventsJob = CoroutineScope(SupervisorJob() + dispatcher).launch {
-            provider.observe().collect { event ->
-                dispatchProviderEvent(event, provider.metadata.name)
-            }
+    private class ReplacedProvider(val registered: FeatureProvider, val lifecycle: FeatureProvider)
+
+    /**
+     * Provider name for attribution and diagnostics, or null if the provider cannot supply one.
+     *
+     * Naming an event's origin must never be the reason a registration or an evaluation fails, so a
+     * provider whose metadata is unavailable simply goes unattributed.
+     */
+    private fun FeatureProvider.attributionName(): String? = runCatching { metadata.name }.getOrNull()
+
+    /**
+     * Returns the provider the lifecycle should be driven through: the provider itself when it emits its
+     * own lifecycle events, otherwise a wrapper that synthesises them on its behalf.
+     */
+    private fun normalizeProvider(
+        provider: FeatureProvider,
+        dispatcher: CoroutineDispatcher
+    ): FeatureProvider {
+        if (provider is StateManagingProvider) return provider
+        LoggerFactory.getLogger(LOGGER_NAME).warn({
+            "Provider ${provider.attributionName()} does not implement StateManagingProvider, so the SDK is " +
+                "synthesizing its lifecycle events. This compatibility behavior is deprecated and will " +
+                "be removed in a future major version; see StateManagingProvider."
+        })
+        return LegacyProviderWrapper(provider, dispatcher)
+    }
+
+    /**
+     * Waits for the provider's own lifecycle event to be applied to the status, so that registration
+     * settles on what the provider reported rather than on the fact that `initialize` returned.
+     *
+     * A provider that terminates `initialize` without reporting anything leaves nothing to wait for; the
+     * violation is logged rather than worked around, since substituting a status here is what created the
+     * race this design removes.
+     */
+    private suspend fun awaitLifecycleReport(report: CompletableDeferred<Unit>, provider: FeatureProvider) {
+        if (!report.isCompleted) {
+            LoggerFactory.getLogger(LOGGER_NAME).warn({
+                "Provider ${provider.attributionName()} returned from initialize without emitting a " +
+                    "lifecycle event; waiting for it. Providers must emit ProviderReady or ProviderError " +
+                    "before initialize terminates."
+            })
         }
+        report.await()
+    }
+
+    /**
+     * Starts relaying [provider]'s events, returning once collection has begun.
+     *
+     * Providers are required to report readiness before `initialize` terminates, so the relay has to be
+     * listening before `initialize` is called or that report can be missed.
+     */
+    private suspend fun listenToProviderEvents(provider: FeatureProvider, dispatcher: CoroutineDispatcher) {
+        observeProviderEventsJob?.cancel(CancellationException("Provider job was cancelled due to new provider"))
+        val listening = CompletableDeferred<Unit>()
+        this.observeProviderEventsJob = CoroutineScope(SupervisorJob() + dispatcher).launch {
+            provider.observe()
+                .onStart { listening.complete(Unit) }
+                .collect { event ->
+                    dispatchProviderEvent(event, provider.attributionName())
+                }
+        }
+        listening.await()
     }
 
     private suspend fun setProviderInternal(
@@ -155,17 +211,26 @@ open class OpenFeatureAPIInstance internal constructor() {
             return
         }
 
+        // Reusing the wrapper avoids initializing the provider twice and orphaning the old relay.
+        val reusable = synchronized(stateLock) { if (this.provider === provider) lifecycleProvider else null }
+        val normalizedProvider = reusable ?: normalizeProvider(provider, dispatcher)
+        val lifecycleReport = CompletableDeferred<Unit>()
+
         // Track whether the swap committed so a mid-flight cancellation can roll back the binding.
         var swapCommitted = false
         try {
             // Atomically swap the old and new provider to prevent race conditions
-            val oldProvider = providerMutex.withLock {
+            val replaced = providerMutex.withLock {
                 synchronized(stateLock) {
-                    val current = this.provider
+                    val current = ReplacedProvider(this.provider, this.lifecycleProvider)
                     this.provider = provider
+                    this.lifecycleProvider = normalizedProvider
                     providerGeneration++
                     providersFlow.value = provider
                     if (initialContext != null) context = initialContext
+                    // Release a registration waiting on a provider it no longer owns.
+                    pendingLifecycleReport?.complete(Unit)
+                    pendingLifecycleReport = lifecycleReport
                     current
                 }
             }
@@ -175,19 +240,26 @@ open class OpenFeatureAPIInstance internal constructor() {
             _status.value = OpenFeatureStatus.NotReady
 
             // Shutdown the previous provider outside the mutex
-            if (oldProvider !== provider) {
+            if (replaced.registered !== provider) {
                 tryWithStatusEmitErrorHandling {
-                    untrackProviderBinding(oldProvider)
-                    oldProvider.shutdown()
+                    untrackProviderBinding(replaced.registered)
+                    replaced.lifecycle.shutdown()
                 }
             }
 
             // Initialize the new provider
-            tryWithStatusEmitErrorHandling {
-                listenToProviderEvents(provider, dispatcher)
-                val state = getEvaluationState()
-                state.provider.initialize(state.context)
-                _status.value = OpenFeatureStatus.Ready
+            try {
+                listenToProviderEvents(normalizedProvider, dispatcher)
+                normalizedProvider.initialize(getEvaluationState().context)
+                awaitLifecycleReport(lifecycleReport, normalizedProvider)
+            } catch (e: CancellationException) {
+                // This happens by design and shouldn't be treated as an error
+            } catch (e: Throwable) {
+                // The provider's event sets the status; writing one here would publish it twice.
+                LoggerFactory.getLogger(LOGGER_NAME).warn(
+                    { "Provider ${normalizedProvider.attributionName()} failed to initialize" },
+                    throwable = e
+                )
             }
         } catch (e: CancellationException) {
             // if cancellation hit before we committed the swap, release the binding we just claimed
@@ -221,17 +293,21 @@ open class OpenFeatureAPIInstance internal constructor() {
      * Clear the current [FeatureProvider] and reset to a no-op provider.
      */
     suspend fun clearProvider() {
-        val oldProvider = providerMutex.withLock {
+        val replaced = providerMutex.withLock {
             synchronized(stateLock) {
-                val current = this.provider
+                val current = ReplacedProvider(this.provider, this.lifecycleProvider)
                 this.provider = noOpProvider
+                this.lifecycleProvider = noOpProvider
                 providerGeneration++
                 providersFlow.value = noOpProvider
+                // Release any registration still waiting.
+                pendingLifecycleReport?.complete(Unit)
+                pendingLifecycleReport = null
                 current
             }
         }
-        untrackProviderBinding(oldProvider)
-        oldProvider.shutdown()
+        untrackProviderBinding(replaced.registered)
+        replaced.lifecycle.shutdown()
         _status.value = OpenFeatureStatus.NotReady
     }
 
@@ -263,102 +339,28 @@ open class OpenFeatureAPIInstance internal constructor() {
     }
 
     private suspend fun setEvaluationContextInternal(evaluationContext: EvaluationContext) {
-        var reconciliation: ContextReconciliation? = null
-        var terminalStatus: OpenFeatureStatus? = null
-        try {
-            contextReconciliationMutex.withLock {
-                providerMutex.withLock {
-                    var shouldEmitReconciling = false
-                    synchronized(stateLock) {
-                        val oldContext = context
-                        context = evaluationContext
-                        if (provider !== noOpProvider) {
-                            reconciliation = ContextReconciliation(oldContext, provider, providerGeneration)
-                            if (contextReconciliationGeneration != providerGeneration) {
-                                contextReconciliationGeneration = providerGeneration
-                                activeContextReconciliations = 0
-                            }
-                            if (activeContextReconciliations == 0) {
-                                contextReconciliationInitialStatus = getStatus()
-                                contextReconciliationTerminalStatus = null
-                                contextReconciliationTerminalProviderStatusGeneration = null
-                            }
-                            activeContextReconciliations++
-                            shouldEmitReconciling = activeContextReconciliations == 1
-                        }
-                    }
-                    if (shouldEmitReconciling) {
-                        _status.value = OpenFeatureStatus.Reconciling
-                    }
-                }
-            }
-
-            val registeredReconciliation = reconciliation ?: return
-            registeredReconciliation.provider.onContextSet(
-                registeredReconciliation.oldContext,
-                evaluationContext
-            )
-            terminalStatus = OpenFeatureStatus.Ready
-        } catch (e: CancellationException) {
-            // This happens by design and shouldn't be treated as an error
-        } catch (e: OpenFeatureError) {
-            terminalStatus = OpenFeatureStatus.Error(e)
-        } catch (e: Throwable) {
-            terminalStatus = OpenFeatureStatus.Error(
-                OpenFeatureError.GeneralError(e.message ?: "Unknown error")
-            )
-        } finally {
-            val registeredReconciliation = reconciliation
-            if (registeredReconciliation != null) {
-                withContext(NonCancellable) {
-                    completeContextReconciliation(
-                        registeredReconciliation.provider,
-                        registeredReconciliation.providerGeneration,
-                        terminalStatus
-                    )
-                }
-            }
-        }
-    }
-
-    private suspend fun completeContextReconciliation(
-        reconciliationProvider: FeatureProvider,
-        reconciliationProviderGeneration: Long,
-        terminalStatus: OpenFeatureStatus?
-    ) {
-        contextReconciliationMutex.withLock {
-            if (contextReconciliationGeneration != reconciliationProviderGeneration) return
-
-            if (terminalStatus != null) {
-                contextReconciliationTerminalStatus = terminalStatus
-                contextReconciliationTerminalProviderStatusGeneration = providerStatusGeneration
-            }
-            activeContextReconciliations--
-            if (activeContextReconciliations == 0) {
-                val retainedTerminalStatus = contextReconciliationTerminalStatus
-                val statusToEmit = retainedTerminalStatus ?: contextReconciliationInitialStatus
-                val shouldEmitStatus = if (retainedTerminalStatus != null) {
-                    contextReconciliationTerminalProviderStatusGeneration == providerStatusGeneration
+        val reconciliation = providerMutex.withLock {
+            synchronized(stateLock) {
+                val oldContext = context
+                context = evaluationContext
+                if (provider === noOpProvider) {
+                    null
                 } else {
-                    getStatus() is OpenFeatureStatus.Reconciling
-                }
-                contextReconciliationInitialStatus = null
-                contextReconciliationTerminalStatus = null
-                contextReconciliationTerminalProviderStatusGeneration = null
-
-                providerMutex.withLock {
-                    if (
-                        synchronized(stateLock) { provider === reconciliationProvider } &&
-                        providerGeneration == reconciliationProviderGeneration &&
-                        statusToEmit != null &&
-                        shouldEmitStatus
-                    ) {
-                        _status.value = statusToEmit
-                    }
+                    ContextReconciliation(oldContext, lifecycleProvider)
                 }
             }
+        } ?: return
+
+        try {
+            reconciliation.provider.onContextSet(reconciliation.oldContext, evaluationContext)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // The outcome arrives as an event; not rethrown so a failed reconciliation is not fatal.
         }
     }
+
+    private class ContextReconciliation(val oldContext: EvaluationContext?, val provider: FeatureProvider)
 
     private suspend fun tryWithStatusEmitErrorHandling(function: suspend () -> Unit) {
         try {
@@ -441,20 +443,16 @@ open class OpenFeatureAPIInstance internal constructor() {
      * Aligning the state management to
      * https://openfeature.dev/specification/sections/events#requirement-535
      */
-    private suspend fun dispatchProviderEvent(event: OpenFeatureProviderEvents, providerName: String?) {
+    private fun dispatchProviderEvent(event: OpenFeatureProviderEvents, providerName: String?) {
         val stamped = event.withProviderName(providerName)
-        stamped.toOpenFeatureStatus()?.let { emitProviderStatus(it) }
+        stamped.toOpenFeatureStatus()?.let { status ->
+            _status.value = status
+            synchronized(stateLock) { pendingLifecycleReport }?.complete(Unit)
+        }
         if (!_events.tryEmit(stamped)) {
             LoggerFactory.getLogger(LOGGER_NAME).warn(
                 { "Dropped provider event ${stamped::class.simpleName}: a subscriber is not keeping up." }
             )
-        }
-    }
-
-    private suspend fun emitProviderStatus(status: OpenFeatureStatus) {
-        contextReconciliationMutex.withLock {
-            providerStatusGeneration++
-            _status.value = status
         }
     }
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/StateManagingProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/StateManagingProvider.kt
@@ -1,0 +1,46 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Opt-in marker for providers that emit their own lifecycle events.
+ *
+ * The SDK derives [OpenFeatureStatus] from provider events. For a provider that does not implement this
+ * interface the SDK synthesises those events itself once a lifecycle method returns — which leaves a
+ * window in which the provider can emit something from background work and have the synthesised event
+ * overwrite it. Implementing this interface closes that window: the SDK synthesises nothing and reports
+ * exactly what the provider signals, in the order the provider signals it.
+ *
+ * Note that the provider does not own the status; it owns the *events*. The SDK remains the single place
+ * the status is stored and read from, so there is no status accessor to implement here and no
+ * requirement to make one safe for concurrent access.
+ *
+ * Implementations must emit:
+ * - [OpenFeatureProviderEvents.ProviderReady] before [initialize] terminates normally
+ * - [OpenFeatureProviderEvents.ProviderError] before [initialize] terminates abnormally, with
+ *   [dev.openfeature.kotlin.sdk.exceptions.ErrorCode.PROVIDER_FATAL] if the failure is irrecoverable
+ * - [OpenFeatureProviderEvents.ProviderReconciling] while [onContextSet] is reconciling, unless it
+ *   reconciles synchronously
+ * - [OpenFeatureProviderEvents.ProviderContextChanged] when [onContextSet] terminates normally, or
+ *   [OpenFeatureProviderEvents.ProviderError] when it terminates abnormally
+ *
+ * Where [onContextSet] can be invoked again before an earlier invocation has terminated, emit the
+ * terminal event only once the last one terminates, so intermediate reconciliations do not surface as
+ * spurious updates.
+ *
+ * [shutdown] is the exception: the SDK initiates it and infers the transition to
+ * [OpenFeatureStatus.NotReady] itself, so no event is required.
+ *
+ * A provider that terminates [initialize] without having emitted anything leaves the SDK with nothing to
+ * report, and [OpenFeatureAPIInstance.setProviderAndWait] will wait for the event it was promised.
+ */
+interface StateManagingProvider : FeatureProvider {
+    /**
+     * Lifecycle and provider events for this instance.
+     *
+     * Unlike [FeatureProvider.observe] this has no default: a provider claiming to emit its own
+     * lifecycle events needs somewhere to emit them.
+     */
+    override fun observe(): Flow<OpenFeatureProviderEvents>
+}

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
@@ -9,7 +9,8 @@ sealed class OpenFeatureProviderEvents {
         val flagsChanged: Set<String> = emptySet(),
         val message: String? = null,
         val errorCode: ErrorCode? = null,
-        val eventMetadata: Map<String, Any> = emptyMap()
+        val eventMetadata: Map<String, Any> = emptyMap(),
+        val providerName: String? = null
     )
 
     abstract val eventDetails: EventDetails?
@@ -45,6 +46,36 @@ sealed class OpenFeatureProviderEvents {
     data class ProviderStale(
         override val eventDetails: EventDetails? = null
     ) : OpenFeatureProviderEvents()
+
+    /**
+     * The provider started reconciling its state with a new [dev.openfeature.kotlin.sdk.EvaluationContext].
+     * [eventDetails] may supply [EventDetails.flagsChanged], [EventDetails.message], [EventDetails.errorCode], and [EventDetails.eventMetadata] as applicable.
+     */
+    data class ProviderReconciling(
+        override val eventDetails: EventDetails? = null
+    ) : OpenFeatureProviderEvents()
+
+    /**
+     * The provider finished reconciling its state with a new [dev.openfeature.kotlin.sdk.EvaluationContext].
+     * [eventDetails] may supply [EventDetails.flagsChanged], [EventDetails.message], [EventDetails.errorCode], and [EventDetails.eventMetadata] as applicable.
+     */
+    data class ProviderContextChanged(
+        override val eventDetails: EventDetails? = null
+    ) : OpenFeatureProviderEvents()
+}
+
+/**
+ * Status implied by an event, per the event/status association table in the specification.
+ *
+ * Returns null for events that carry no status transition, leaving the current status untouched.
+ */
+internal fun OpenFeatureProviderEvents.toOpenFeatureStatus(): OpenFeatureStatus? = when (this) {
+    is OpenFeatureProviderEvents.ProviderReady -> OpenFeatureStatus.Ready
+    is OpenFeatureProviderEvents.ProviderStale -> OpenFeatureStatus.Stale
+    is OpenFeatureProviderEvents.ProviderError -> toOpenFeatureStatusError()
+    is OpenFeatureProviderEvents.ProviderReconciling -> OpenFeatureStatus.Reconciling
+    is OpenFeatureProviderEvents.ProviderContextChanged -> OpenFeatureStatus.Ready
+    is OpenFeatureProviderEvents.ProviderConfigurationChanged -> null
 }
 
 internal fun OpenFeatureProviderEvents.ProviderError.toOpenFeatureStatusError(): OpenFeatureStatus {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
@@ -64,6 +64,37 @@ sealed class OpenFeatureProviderEvents {
     ) : OpenFeatureProviderEvents()
 }
 
+internal fun OpenFeatureProviderEvents.withProviderName(providerName: String?): OpenFeatureProviderEvents {
+    val details = (eventDetails ?: OpenFeatureProviderEvents.EventDetails()).copy(providerName = providerName)
+    return when (this) {
+        is OpenFeatureProviderEvents.ProviderReady -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderError -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderConfigurationChanged -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderStale -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderReconciling -> copy(eventDetails = details)
+        is OpenFeatureProviderEvents.ProviderContextChanged -> copy(eventDetails = details)
+    }
+}
+
+/**
+ * Event representing this status, so that a handler attached once the provider is already in a given
+ * state runs immediately.
+ *
+ * Returns null for [OpenFeatureStatus.NotReady], which has no corresponding event type.
+ */
+internal fun OpenFeatureStatus.toCurrentStateEvent(): OpenFeatureProviderEvents? = when (this) {
+    is OpenFeatureStatus.Ready -> OpenFeatureProviderEvents.ProviderReady()
+    is OpenFeatureStatus.Stale -> OpenFeatureProviderEvents.ProviderStale()
+    is OpenFeatureStatus.Reconciling -> OpenFeatureProviderEvents.ProviderReconciling()
+    is OpenFeatureStatus.Error -> OpenFeatureProviderEvents.ProviderError(
+        OpenFeatureProviderEvents.EventDetails(message = error.message, errorCode = error.errorCode())
+    )
+    is OpenFeatureStatus.Fatal -> OpenFeatureProviderEvents.ProviderError(
+        OpenFeatureProviderEvents.EventDetails(message = error.message, errorCode = ErrorCode.PROVIDER_FATAL)
+    )
+    is OpenFeatureStatus.NotReady -> null
+}
+
 /**
  * Status implied by an event, per the event/status association table in the specification.
  *

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -9,7 +9,7 @@ import dev.openfeature.kotlin.sdk.ProviderMetadata
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
-import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -202,16 +202,10 @@ class MultiProvider(
     }
 
     private suspend fun handleProviderEvent(provider: ChildFeatureProvider, event: OpenFeatureProviderEvents) {
-        val newChildStatus = when (event) {
-            // ProviderConfigurationChanged events should always re-emit
-            is OpenFeatureProviderEvents.ProviderConfigurationChanged -> {
-                eventFlow.emit(event)
-                return
-            }
-
-            is OpenFeatureProviderEvents.ProviderReady -> OpenFeatureStatus.Ready
-            is OpenFeatureProviderEvents.ProviderStale -> OpenFeatureStatus.Stale
-            is OpenFeatureProviderEvents.ProviderError -> event.toOpenFeatureStatusError()
+        // Events carrying no status transition (e.g. ProviderConfigurationChanged) always re-emit.
+        val newChildStatus = event.toOpenFeatureStatus() ?: run {
+            eventFlow.emit(event)
+            return
         }
 
         val previousStatus = _statusFlow.value

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
@@ -151,7 +151,8 @@ class DeveloperExperienceTests {
         val job = CoroutineScope(dispatcher).launch {
             OpenFeatureAPI.setProviderAndWait(
                 SlowProvider(dispatcher = dispatcher),
-                ImmutableContext()
+                ImmutableContext(),
+                dispatcher = dispatcher
             )
         }
         testScheduler.advanceTimeBy(1) // Make sure setProviderAndWait is called
@@ -182,7 +183,8 @@ class DeveloperExperienceTests {
         // start out with Not Ready
         OpenFeatureAPI.setProviderAndWait(
             SlowProvider(dispatcher = dispatcher),
-            ImmutableContext(targetingKey = "0")
+            ImmutableContext(targetingKey = "0"),
+            dispatcher = dispatcher
         )
         testScheduler.advanceUntilIdle()
         // After 2 seconds the slow provider is ready
@@ -208,6 +210,7 @@ class DeveloperExperienceTests {
 
     @Test
     fun testStatusFlowWithErrors() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
         val emittedStatuses = mutableListOf<OpenFeatureStatus>()
         val job = launch {
             OpenFeatureAPI.statusFlow.collect {
@@ -219,7 +222,8 @@ class DeveloperExperienceTests {
         // start out with Not Ready
         OpenFeatureAPI.setProviderAndWait(
             BrokenInitProvider(),
-            ImmutableContext(targetingKey = "0")
+            ImmutableContext(targetingKey = "0"),
+            dispatcher = dispatcher
         )
         testScheduler.advanceUntilIdle()
 
@@ -231,15 +235,13 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.shutdown()
         testScheduler.advanceUntilIdle()
         job.cancelAndJoin()
-        // statusFlow is a snapshot: the transient Reconciling between onContextSet starting and
-        // completing is conflated away here. StatusTests covers that transition against a provider
-        // that holds onContextSet open.
-        assertEquals(4, emittedStatuses.size)
+        assertEquals(5, emittedStatuses.size)
         assertTrue(emittedStatuses[0] is OpenFeatureStatus.NotReady)
         assertTrue(emittedStatuses[1] is OpenFeatureStatus.Error)
         assertTrue((emittedStatuses[1] as OpenFeatureStatus.Error).error is OpenFeatureError.ProviderNotReadyError)
-        assertTrue(emittedStatuses[2] is OpenFeatureStatus.Ready)
-        assertTrue(emittedStatuses[3] is OpenFeatureStatus.NotReady)
+        assertTrue(emittedStatuses[2] is OpenFeatureStatus.Reconciling)
+        assertTrue(emittedStatuses[3] is OpenFeatureStatus.Ready)
+        assertTrue(emittedStatuses[4] is OpenFeatureStatus.NotReady)
     }
 
     @Test
@@ -383,7 +385,7 @@ class DeveloperExperienceTests {
             attributes = mapOf("key" to Value.String("value"))
         )
         val provider = SpyProvider()
-        OpenFeatureAPI.setProviderAndWait(provider)
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
 
         OpenFeatureAPI.setEvaluationContextAndWait(context)
         OpenFeatureAPI.setEvaluationContextAndWait(context)

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
@@ -231,13 +231,15 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.shutdown()
         testScheduler.advanceUntilIdle()
         job.cancelAndJoin()
-        assertEquals(5, emittedStatuses.size)
+        // statusFlow is a snapshot: the transient Reconciling between onContextSet starting and
+        // completing is conflated away here. StatusTests covers that transition against a provider
+        // that holds onContextSet open.
+        assertEquals(4, emittedStatuses.size)
         assertTrue(emittedStatuses[0] is OpenFeatureStatus.NotReady)
         assertTrue(emittedStatuses[1] is OpenFeatureStatus.Error)
         assertTrue((emittedStatuses[1] as OpenFeatureStatus.Error).error is OpenFeatureError.ProviderNotReadyError)
-        assertTrue(emittedStatuses[2] is OpenFeatureStatus.Reconciling)
-        assertTrue(emittedStatuses[3] is OpenFeatureStatus.Ready)
-        assertTrue(emittedStatuses[4] is OpenFeatureStatus.NotReady)
+        assertTrue(emittedStatuses[2] is OpenFeatureStatus.Ready)
+        assertTrue(emittedStatuses[3] is OpenFeatureStatus.NotReady)
     }
 
     @Test
@@ -326,6 +328,7 @@ class DeveloperExperienceTests {
 
     @Test
     fun testProviderEventFlowShouldSupportFiltering() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val provider = OverlyEmittingProvider("Overly Emitting Provider")
         val staleEvents = mutableListOf<OpenFeatureProviderEvents>()
         val job = launch {
@@ -334,11 +337,14 @@ class DeveloperExperienceTests {
                 staleEvents.add(it)
             }
         }
+        // Let the collector subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
         // emits ProviderReady
         OpenFeatureAPI.setProviderAndWait(
             provider,
-            initialContext = ImmutableContext("first")
+            initialContext = ImmutableContext("first"),
+            dispatcher = testDispatcher
         )
         // emits ProviderStale + ProviderStale + ProviderStale
         OpenFeatureAPI.getClient().track("hello-world")
@@ -349,15 +355,9 @@ class DeveloperExperienceTests {
 
         OpenFeatureAPI.shutdown()
         job.cancelAndJoin()
-        assertEquals(
-            listOf<OpenFeatureProviderEvents>(
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale()
-            ),
-            staleEvents
-        )
+        assertEquals(4, staleEvents.size)
+        assertTrue(staleEvents.all { it is OpenFeatureProviderEvents.ProviderStale })
+        assertTrue(staleEvents.all { it.eventDetails?.providerName == "Overly Emitting Provider" })
     }
 
     @Test
@@ -386,29 +386,13 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.setProviderAndWait(provider)
 
         OpenFeatureAPI.setEvaluationContextAndWait(context)
-        val emittedStatuses = mutableListOf<OpenFeatureStatus>()
-        val job = launch {
-            OpenFeatureAPI.statusFlow.collect {
-                emittedStatuses.add(it)
-            }
-        }
-        testScheduler.advanceUntilIdle()
-
         OpenFeatureAPI.setEvaluationContextAndWait(context)
         testScheduler.advanceUntilIdle()
-        job.cancelAndJoin()
 
         assertEquals(2, provider.onContextSetCalls.size)
         assertTrue(provider.onContextSetCalls[1].first === context)
         assertTrue(provider.onContextSetCalls[1].second === context)
-        assertEquals(
-            listOf(
-                OpenFeatureStatus.Ready,
-                OpenFeatureStatus.Reconciling,
-                OpenFeatureStatus.Ready
-            ),
-            emittedStatuses
-        )
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/EventDetailsTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/EventDetailsTests.kt
@@ -1,12 +1,14 @@
 package dev.openfeature.kotlin.sdk
 
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 class EventDetailsTests {
 
@@ -78,5 +80,73 @@ class EventDetailsTests {
         val errorStatus = assertIs<OpenFeatureStatus.Error>(status)
         val err = assertIs<OpenFeatureError.GeneralError>(errorStatus.error)
         assertEquals("test", err.message)
+    }
+
+    @Test
+    fun readyEventMapsToReadyStatus() {
+        assertEquals(
+            OpenFeatureStatus.Ready,
+            OpenFeatureProviderEvents.ProviderReady().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun staleEventMapsToStaleStatus() {
+        assertEquals(
+            OpenFeatureStatus.Stale,
+            OpenFeatureProviderEvents.ProviderStale().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun reconcilingEventMapsToReconcilingStatus() {
+        assertEquals(
+            OpenFeatureStatus.Reconciling,
+            OpenFeatureProviderEvents.ProviderReconciling().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun contextChangedEventMapsToReadyStatus() {
+        assertEquals(
+            OpenFeatureStatus.Ready,
+            OpenFeatureProviderEvents.ProviderContextChanged().toOpenFeatureStatus()
+        )
+    }
+
+    @Test
+    fun configurationChangedEventMapsToNoStatusTransition() {
+        assertNull(OpenFeatureProviderEvents.ProviderConfigurationChanged().toOpenFeatureStatus())
+    }
+
+    @Test
+    fun errorEventMapsThroughToErrorStatus() {
+        val evt = OpenFeatureProviderEvents.ProviderError(
+            OpenFeatureProviderEvents.EventDetails(
+                message = "flag missing",
+                errorCode = ErrorCode.FLAG_NOT_FOUND
+            )
+        )
+
+        val error = assertIs<OpenFeatureStatus.Error>(evt.toOpenFeatureStatus())
+        assertIs<OpenFeatureError.FlagNotFoundError>(error.error)
+    }
+
+    @Test
+    fun errorEventWithFatalCodeMapsThroughToFatalStatus() {
+        val evt = OpenFeatureProviderEvents.ProviderError(
+            OpenFeatureProviderEvents.EventDetails(
+                message = "unrecoverable",
+                errorCode = ErrorCode.PROVIDER_FATAL
+            )
+        )
+
+        assertIs<OpenFeatureStatus.Fatal>(evt.toOpenFeatureStatus())
+    }
+
+    @Test
+    fun eventDetailsCarryProviderName() {
+        val details = OpenFeatureProviderEvents.EventDetails(providerName = "my-provider")
+        assertEquals("my-provider", details.providerName)
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventRelayTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventRelayTests.kt
@@ -1,0 +1,198 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.helpers.DoSomethingProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The SDK republishes provider events itself rather than exposing the provider's stream directly, so
+ * that the status is always updated before subscribers see the event that caused it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProviderEventRelayTests {
+
+    @BeforeTest
+    fun setUp() = runTest {
+        OpenFeatureAPI.shutdown()
+    }
+
+    private class ControllableEmitter(name: String) : DoSomethingProvider(
+        metadata = object : ProviderMetadata {
+            override val name: String = name
+        }
+    ) {
+        private val emissions = MutableSharedFlow<OpenFeatureProviderEvents>(extraBufferCapacity = 16)
+
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            emissions.emit(OpenFeatureProviderEvents.ProviderReady())
+        }
+
+        override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+            // Nothing: these tests drive emissions explicitly.
+        }
+
+        override fun observe(): Flow<OpenFeatureProviderEvents> = emissions
+
+        fun emit(event: OpenFeatureProviderEvents) {
+            check(emissions.tryEmit(event)) { "Test emitter buffer exhausted" }
+        }
+    }
+
+    @Test
+    fun statusReflectsTheEventBeforeSubscribersSeeIt() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("relay-ordering")
+        val statusesSeenByHandler = mutableListOf<OpenFeatureStatus>()
+
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents.ProviderStale>().collect {
+                statusesSeenByHandler.add(OpenFeatureAPI.getStatus())
+            }
+        }
+        testScheduler.runCurrent()
+
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        provider.emit(OpenFeatureProviderEvents.ProviderStale())
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(listOf<OpenFeatureStatus>(OpenFeatureStatus.Stale), statusesSeenByHandler)
+    }
+
+    @Test
+    fun handlerAttachedWhenAlreadyReadyRunsImmediately() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(ControllableEmitter("late-subscriber"), dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+
+        val received = mutableListOf<OpenFeatureProviderEvents.ProviderReady>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents.ProviderReady>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertEquals(1, received.size)
+        assertEquals("late-subscriber", received.single().eventDetails?.providerName)
+    }
+
+    @Test
+    fun handlerAttachedWhenAlreadyStaleReceivesStaleNotReady() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("stale-state")
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        provider.emit(OpenFeatureProviderEvents.ProviderStale())
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertIs<OpenFeatureProviderEvents.ProviderStale>(received.single())
+    }
+
+    @Test
+    fun statelessEventIsNotResurfacedForLateSubscribers() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("stateless-event")
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // The most recent event carries no status, so it must not be what a late subscriber is told.
+        provider.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertIs<OpenFeatureProviderEvents.ProviderReady>(received.single())
+    }
+
+    @Test
+    fun eventsFromAReplacedProviderAreNotResurfaced() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val first = ControllableEmitter("first")
+        OpenFeatureAPI.setProviderAndWait(first, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        first.emit(OpenFeatureProviderEvents.ProviderStale())
+        testScheduler.advanceUntilIdle()
+
+        OpenFeatureAPI.setProviderAndWait(ControllableEmitter("second"), dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancelAndJoin()
+
+        assertIs<OpenFeatureProviderEvents.ProviderReady>(received.single())
+        assertEquals("second", received.single().eventDetails?.providerName)
+    }
+
+    @Test
+    fun shutdownRevertsToNotReadyWithoutEmittingAnEvent() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(ControllableEmitter("shutdown"), dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+        // Subscribing while Ready yields exactly one event, so a later count proves nothing was added.
+        assertEquals(1, received.size)
+
+        OpenFeatureAPI.shutdown()
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+        // There is no event type for NOT_READY: the SDK infers the transition instead of emitting.
+        assertEquals(1, received.size)
+    }
+
+    @Test
+    fun everyRelayedEventCarriesTheEmittingProviderName() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val provider = ControllableEmitter("attribution")
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch {
+            OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) }
+        }
+        testScheduler.runCurrent()
+
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+        provider.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertTrue(received.isNotEmpty())
+        assertTrue(received.all { it.eventDetails?.providerName == "attribution" })
+    }
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
@@ -89,6 +89,7 @@ class ProviderEventingTests {
 
     @Test
     fun testProviderEventFlowShouldSupportSwappingProviders() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val firstProvider = OverlyEmittingProvider("First Provider")
         val secondProvider = OverlyEmittingProvider("Second Provider")
 
@@ -98,27 +99,32 @@ class ProviderEventingTests {
                 emittedEvents.add(it)
             }
         }
+        // Let the collector subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
         // emits ProviderReady
         OpenFeatureAPI.setProviderAndWait(
             firstProvider,
-            initialContext = ImmutableContext("first")
+            initialContext = ImmutableContext("first"),
+            dispatcher = testDispatcher
         )
         // emits ProviderStale + ProviderConfigurationChanged
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("first.v2"))
         testScheduler.advanceUntilIdle()
         assertEquals(
             listOf(
-                OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderConfigurationChanged()
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class
             ),
-            emittedEvents
+            emittedEvents.map { it::class }
         )
+        assertTrue(emittedEvents.all { it.eventDetails?.providerName == "First Provider" })
         // emits ProviderReady
         OpenFeatureAPI.setProviderAndWait(
             secondProvider,
-            initialContext = ImmutableContext("second")
+            initialContext = ImmutableContext("second"),
+            dispatcher = testDispatcher
         )
         testScheduler.advanceUntilIdle()
         // emits ProviderStale + ProviderStale + ProviderStale
@@ -133,22 +139,28 @@ class ProviderEventingTests {
         job.cancelAndJoin()
         assertEquals(
             listOf(
-                OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderConfigurationChanged(),
-                OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderStale(),
-                OpenFeatureProviderEvents.ProviderConfigurationChanged()
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class,
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class
             ),
-            emittedEvents
+            emittedEvents.map { it::class }
+        )
+        // The relay attributes each event to whichever provider was active when it was emitted.
+        assertEquals(
+            List(3) { "First Provider" } + List(6) { "Second Provider" },
+            emittedEvents.map { it.eventDetails?.providerName }
         )
     }
 
     @Test
     fun clientObserveMatchesApiObserveWhenCollectingAllProviderEvents() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val provider = OverlyEmittingProvider("Client parity provider")
         val fromApi = mutableListOf<OpenFeatureProviderEvents>()
         val fromClient = mutableListOf<OpenFeatureProviderEvents>()
@@ -160,8 +172,14 @@ class ProviderEventingTests {
         val clientJob = launch {
             client.observe().collect { fromClient.add(it) }
         }
+        // Let both collectors subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
-        OpenFeatureAPI.setProviderAndWait(provider, initialContext = ImmutableContext("ctx"))
+        OpenFeatureAPI.setProviderAndWait(
+            provider,
+            initialContext = ImmutableContext("ctx"),
+            dispatcher = testDispatcher
+        )
         testScheduler.advanceUntilIdle()
         OpenFeatureAPI.shutdown()
         apiJob.cancelAndJoin()
@@ -173,6 +191,7 @@ class ProviderEventingTests {
 
     @Test
     fun clientObserveFiltersByReifiedEventType() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
         val provider = OverlyEmittingProvider("filter-by-type")
         val client = OpenFeatureAPI.getClient("filter-by-type")
         val staleEvents = mutableListOf<OpenFeatureProviderEvents.ProviderStale>()
@@ -189,8 +208,14 @@ class ProviderEventingTests {
                 .filterIsInstance<OpenFeatureProviderEvents.ProviderConfigurationChanged>()
                 .collect { configurationChangedEvents.add(it) }
         }
+        // Let both collectors subscribe: the SDK relays events live and does not replay past ones.
+        testScheduler.runCurrent()
 
-        OpenFeatureAPI.setProviderAndWait(provider, initialContext = ImmutableContext("ctx"))
+        OpenFeatureAPI.setProviderAndWait(
+            provider,
+            initialContext = ImmutableContext("ctx"),
+            dispatcher = testDispatcher
+        )
         testScheduler.advanceUntilIdle()
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("ctx.v2"))
         testScheduler.advanceUntilIdle()
@@ -198,10 +223,9 @@ class ProviderEventingTests {
         staleJob.cancelAndJoin()
         configJob.cancelAndJoin()
 
-        assertEquals(listOf(OpenFeatureProviderEvents.ProviderStale()), staleEvents)
-        assertEquals(
-            listOf(OpenFeatureProviderEvents.ProviderConfigurationChanged()),
-            configurationChangedEvents
-        )
+        assertEquals(1, staleEvents.size)
+        assertEquals(1, configurationChangedEvents.size)
+        assertEquals("filter-by-type", staleEvents.single().eventDetails?.providerName)
+        assertEquals("filter-by-type", configurationChangedEvents.single().eventDetails?.providerName)
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
@@ -78,13 +78,14 @@ class ProviderEventingTests {
         testScheduler.advanceUntilIdle()
         j.cancelAndJoin()
         waitAssert {
-            assertEquals(5, statusList.size)
+            assertEquals(6, statusList.size)
         }
-        assertEquals(OpenFeatureStatus.Ready, statusList[0])
-        assertEquals(OpenFeatureStatus.Reconciling, statusList[1])
-        assertTrue(statusList[2] is OpenFeatureStatus.Error)
-        assertEquals(OpenFeatureStatus.Ready, statusList[3])
-        assertEquals(OpenFeatureStatus.NotReady, statusList[4])
+        assertEquals(OpenFeatureStatus.NotReady, statusList[0])
+        assertEquals(OpenFeatureStatus.Ready, statusList[1])
+        assertEquals(OpenFeatureStatus.Reconciling, statusList[2])
+        assertTrue(statusList[3] is OpenFeatureStatus.Error)
+        assertEquals(OpenFeatureStatus.Ready, statusList[4])
+        assertEquals(OpenFeatureStatus.NotReady, statusList[5])
     }
 
     @Test
@@ -114,8 +115,10 @@ class ProviderEventingTests {
         assertEquals(
             listOf(
                 OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderReconciling::class,
                 OpenFeatureProviderEvents.ProviderStale::class,
-                OpenFeatureProviderEvents.ProviderConfigurationChanged::class
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class,
+                OpenFeatureProviderEvents.ProviderContextChanged::class
             ),
             emittedEvents.map { it::class }
         )
@@ -140,20 +143,24 @@ class ProviderEventingTests {
         assertEquals(
             listOf(
                 OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderReconciling::class,
                 OpenFeatureProviderEvents.ProviderStale::class,
                 OpenFeatureProviderEvents.ProviderConfigurationChanged::class,
+                OpenFeatureProviderEvents.ProviderContextChanged::class,
                 OpenFeatureProviderEvents.ProviderReady::class,
                 OpenFeatureProviderEvents.ProviderStale::class,
                 OpenFeatureProviderEvents.ProviderStale::class,
                 OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderReconciling::class,
                 OpenFeatureProviderEvents.ProviderStale::class,
-                OpenFeatureProviderEvents.ProviderConfigurationChanged::class
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class,
+                OpenFeatureProviderEvents.ProviderContextChanged::class
             ),
             emittedEvents.map { it::class }
         )
         // The relay attributes each event to whichever provider was active when it was emitted.
         assertEquals(
-            List(3) { "First Provider" } + List(6) { "Second Provider" },
+            List(5) { "First Provider" } + List(8) { "Second Provider" },
             emittedEvents.map { it.eventDetails?.providerName }
         )
     }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StateManagingProviderTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StateManagingProviderTests.kt
@@ -1,0 +1,253 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.helpers.DoSomethingProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * A provider implementing [StateManagingProvider] reports its own lifecycle, and the SDK adds nothing of
+ * its own; a provider that does not gets those events synthesised on its behalf.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class StateManagingProviderTests {
+
+    @BeforeTest
+    fun setUp() = runTest {
+        OpenFeatureAPI.shutdown()
+        OpenFeatureAPIInstance.clearBoundProviders()
+    }
+
+    /** Reports whatever it is told to report, from inside `initialize`, as the specification requires. */
+    private class ReportingProvider(
+        private val onInitialize: List<OpenFeatureProviderEvents>,
+        override val metadata: ProviderMetadata = object : ProviderMetadata {
+            override val name: String = "reporting"
+        }
+    ) : StateManagingProvider {
+        override val hooks: List<Hook<*>> = listOf()
+        private val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 16)
+        var initializeCalls = 0
+        var shutdownCalls = 0
+
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            initializeCalls++
+            onInitialize.forEach { events.emit(it) }
+        }
+
+        override fun shutdown() {
+            shutdownCalls++
+        }
+
+        override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+            events.emit(OpenFeatureProviderEvents.ProviderReconciling())
+            events.emit(OpenFeatureProviderEvents.ProviderContextChanged())
+        }
+
+        override fun observe(): Flow<OpenFeatureProviderEvents> = events
+
+        override fun getBooleanEvaluation(key: String, defaultValue: Boolean, context: EvaluationContext?) =
+            ProviderEvaluation(!defaultValue)
+
+        override fun getStringEvaluation(key: String, defaultValue: String, context: EvaluationContext?) =
+            ProviderEvaluation(defaultValue)
+
+        override fun getIntegerEvaluation(key: String, defaultValue: Int, context: EvaluationContext?) =
+            ProviderEvaluation(defaultValue)
+
+        override fun getLongEvaluation(key: String, defaultValue: Long, context: EvaluationContext?) =
+            ProviderEvaluation(defaultValue)
+
+        override fun getDoubleEvaluation(key: String, defaultValue: Double, context: EvaluationContext?) =
+            ProviderEvaluation(defaultValue)
+
+        override fun getObjectEvaluation(key: String, defaultValue: Value, context: EvaluationContext?) =
+            ProviderEvaluation(defaultValue)
+    }
+
+    /** Emits its own readiness, so the SDK has no need to stand in for it. */
+    private class SelfReportingLegacyProvider : DoSomethingProvider(
+        metadata = object : ProviderMetadata {
+            override val name: String = "self-reporting-legacy"
+        }
+    ) {
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            events.emit(OpenFeatureProviderEvents.ProviderReady())
+        }
+    }
+
+    @Test
+    fun statusIsWhateverTheProviderReported() = runTest {
+        val provider = ReportingProvider(listOf(OpenFeatureProviderEvents.ProviderReady()))
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
+
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+    }
+
+    @Test
+    fun readinessReportedDuringInitializeIsNotOverwrittenBySomethingLater() = runTest {
+        // The SDK used to publish Ready after initialize returned, discarding this.
+        val provider = ReportingProvider(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady(),
+                OpenFeatureProviderEvents.ProviderStale()
+            )
+        )
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(OpenFeatureStatus.Stale, OpenFeatureAPI.getStatus())
+    }
+
+    @Test
+    fun reportedFatalErrorBecomesFatalStatus() = runTest {
+        val provider = ReportingProvider(
+            listOf(
+                OpenFeatureProviderEvents.ProviderError(
+                    OpenFeatureProviderEvents.EventDetails(
+                        message = "unrecoverable",
+                        errorCode = ErrorCode.PROVIDER_FATAL
+                    )
+                )
+            )
+        )
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
+
+        assertIs<OpenFeatureStatus.Fatal>(OpenFeatureAPI.getStatus())
+    }
+
+    @Test
+    fun reconciliationReportedByTheProviderIsNotDuplicatedByTheSdk() = runTest {
+        val provider = ReportingProvider(listOf(OpenFeatureProviderEvents.ProviderReady()))
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch { OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) } }
+        testScheduler.runCurrent()
+        received.clear()
+
+        OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("ctx"))
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReconciling::class,
+                OpenFeatureProviderEvents.ProviderContextChanged::class
+            ),
+            received.map { it::class }
+        )
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+    }
+
+    @Test
+    fun registrationWaitsForAProviderThatReportsNothing() = runTest {
+        // The SDK does not invent a status, so a silent provider leaves registration unsettled.
+        val silent = ReportingProvider(emptyList())
+
+        val settled = withTimeoutOrNull(1_000) {
+            OpenFeatureAPI.setProviderAndWait(silent, dispatcher = StandardTestDispatcher(testScheduler))
+            true
+        }
+
+        assertNull(settled)
+        assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+    }
+
+    @Test
+    fun aLegacyProviderThatReportsForItselfIsNotReportedForTwice() = runTest {
+        val provider = SelfReportingLegacyProvider()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch { OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) } }
+        testScheduler.runCurrent()
+
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(listOf(OpenFeatureProviderEvents.ProviderReady::class), received.map { it::class })
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+    }
+
+    @Test
+    fun aSilentLegacyProviderIsReportedReadyOnce() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch { OpenFeatureAPI.observe<OpenFeatureProviderEvents>().collect { received.add(it) } }
+        testScheduler.runCurrent()
+
+        OpenFeatureAPI.setProviderAndWait(NoOpProvider(), dispatcher = dispatcher)
+        testScheduler.advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(listOf(OpenFeatureProviderEvents.ProviderReady::class), received.map { it::class })
+    }
+
+    @Test
+    fun getProviderReturnsTheRegisteredInstanceNotAWrapper() = runTest {
+        val provider = NoOpProvider()
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
+
+        assertSame(provider, OpenFeatureAPI.getProvider())
+        assertTrue(OpenFeatureAPI.getProvider() !is StateManagingProvider)
+    }
+
+    @Test
+    fun aProviderThatFailedToInitializeCanBeRegisteredAgain() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        var failNext = true
+        val provider = object : DoSomethingProvider(
+            metadata = object : ProviderMetadata {
+                override val name: String = "retryable"
+            }
+        ) {
+            var initializeCalls = 0
+
+            override suspend fun initialize(initialContext: EvaluationContext?) {
+                initializeCalls++
+                if (failNext) throw OpenFeatureError.GeneralError("first attempt fails")
+            }
+        }
+
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
+        testScheduler.advanceUntilIdle()
+        assertIs<OpenFeatureStatus.Error>(OpenFeatureAPI.getStatus())
+
+        failNext = false
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
+        assertEquals(2, provider.initializeCalls)
+    }
+
+    @Test
+    fun shutdownIsRepeatable() = runTest {
+        val provider = ReportingProvider(listOf(OpenFeatureProviderEvents.ProviderReady()))
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
+
+        OpenFeatureAPI.shutdown()
+        OpenFeatureAPI.shutdown()
+
+        assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
+        assertEquals(1, provider.shutdownCalls)
+    }
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
@@ -105,7 +105,7 @@ class StatusTests {
     fun testStatusRemainsReconcilingUntilAllEqualContextSetsComplete() = runTest {
         val context = ImmutableContext("same-context")
         val provider = ControllableContextProvider()
-        OpenFeatureAPI.setProviderAndWait(provider)
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
 
         val firstContextSet = launch {
             OpenFeatureAPI.setEvaluationContextAndWait(context)
@@ -115,31 +115,35 @@ class StatusTests {
             OpenFeatureAPI.setEvaluationContextAndWait(context)
         }
         provider.contextSetStarted.receive()
+        advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
 
         provider.allowContextSetToComplete.send(Unit)
         provider.contextSetCompleted.receive()
+        advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
 
         provider.allowContextSetToComplete.send(Unit)
         firstContextSet.join()
         secondContextSet.join()
+        advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
     }
 
     @Test
     fun testCancelledContextSetRestoresPreviousStatus() = runTest {
         val provider = ControllableContextProvider()
-        OpenFeatureAPI.setProviderAndWait(provider)
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = StandardTestDispatcher(testScheduler))
 
         val contextSet = launch {
             OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("cancelled"))
         }
         provider.contextSetStarted.receive()
+        advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
 
         contextSet.cancelAndJoin()
-
+        advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
     }
 
@@ -148,7 +152,7 @@ class StatusTests {
     fun testCancelledContextSetFinishingLastUsesReplacementStatus() = runTest {
         val provider = CancellationRaceProvider()
         val dispatcher = StandardTestDispatcher(testScheduler)
-        OpenFeatureAPI.setProviderAndWait(provider)
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
 
         OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"), dispatcher)
         provider.firstContextSetStarted.receive()
@@ -195,12 +199,13 @@ class StatusTests {
         val retiredProvider = ControllableContextProvider()
         val replacementProvider = CancellationRaceProvider()
         val dispatcher = StandardTestDispatcher(testScheduler)
-        OpenFeatureAPI.setProviderAndWait(retiredProvider)
+        OpenFeatureAPI.setProviderAndWait(retiredProvider, dispatcher = dispatcher)
 
         val retiredContextSet = launch {
             OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("retired"))
         }
         retiredProvider.contextSetStarted.receive()
+        advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus())
 
         OpenFeatureAPI.setProviderAndWait(replacementProvider, dispatcher = dispatcher)
@@ -211,7 +216,7 @@ class StatusTests {
 
         retiredProvider.allowContextSetToComplete.send(Unit)
         retiredContextSet.join()
-
+        advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Stale, OpenFeatureAPI.getStatus())
     }
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/SpyProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/SpyProvider.kt
@@ -9,10 +9,10 @@ import dev.openfeature.kotlin.sdk.Value
 import kotlinx.atomicfu.atomic
 
 class SpyProvider : FeatureProvider {
-    override val hooks: List<Hook<*>>
-        get() = TODO("Not yet implemented")
-    override val metadata: ProviderMetadata
-        get() = TODO("Not yet implemented")
+    override val hooks: List<Hook<*>> = listOf()
+    override val metadata: ProviderMetadata = object : ProviderMetadata {
+        override val name: String = "SpyProvider"
+    }
 
     val initializeCalls = mutableListOf<EvaluationContext?>()
     val onContextSetCalls = mutableListOf<Pair<EvaluationContext?, EvaluationContext>>()


### PR DESCRIPTION
> **Stacked on #259** (which is stacked on #258). Base is `main` because the branch lives in a fork and GitHub requires a base branch in the upstream repository, so the diff shown here includes both parents' commits. Review only the last commit, `feat!: add StateManagingProvider…`, or merge #258 and #259 first and this diff will reduce to it.

## Intent

The SDK infers provider readiness from lifecycle methods returning: it publishes `Ready` once `initialize` returns, and drives the `RECONCILING`/`READY` transitions around `onContextSet` itself. A provider doing work in the background can report something in that window and have the SDK's own conclusion overwrite it — the race in [spec #365](https://github.com/open-feature/spec/issues/365). This PR lets a provider declare that it reports its own lifecycle events, in which case the SDK publishes nothing of its own and reports exactly what the provider signals, in the order signalled.

## Motivation

[spec #385](https://github.com/open-feature/spec/pull/385) resolves #365 by making provider status derived entirely from provider-emitted events, with an opt-in marker so existing providers keep working. Notably it was chosen over [#380](https://github.com/open-feature/spec/pull/380), which moved the status itself onto the provider: state stays in the SDK precisely so that providers are not burdened with concurrency-safe status accessors. So `StateManagingProvider` here carries **no status accessor** — the provider owns the *events*, the SDK still owns the *status*.

The Kotlin SDK is the first to implement this; the Java, JS and Go PoCs on #365 predate #385 and still follow the rejected shape. The marker keeps their name for cross-SDK recognisability despite the changed meaning; happy to revisit if the ecosystem settles on something else.

## Spec Requirements

| Requirement | Relationship |
| --- | --- |
| [2.8.1](https://openfeature.dev/specification/sections/providers/#requirement-281) — provider **MUST** emit an event for each status transition | Satisfied for marker providers |
| [2.8.2](https://openfeature.dev/specification/sections/providers/#requirement-282), [2.8.3](https://openfeature.dev/specification/sections/providers/#requirement-283) — `PROVIDER_READY`/`PROVIDER_ERROR` **before** `initialize` terminates | Satisfied — **closes the #365 init race** |
| [2.8.4](https://openfeature.dev/specification/sections/providers/#requirement-284) — `PROVIDER_CONTEXT_CHANGED`/`PROVIDER_ERROR` for `on context changed` | Satisfied |
| [5.3.4.1](https://openfeature.dev/specification/sections/events/#conditional-requirement-5341), [5.3.4.2](https://openfeature.dev/specification/sections/events/#conditional-requirement-5342), [5.3.4.3](https://openfeature.dev/specification/sections/events/#conditional-requirement-5343) — reconciliation events, terminal one only after the last reentrant invocation | Satisfied — provider-owned; the wrapper does it for legacy providers |
| [1.1.2.4](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-1124) — wait for `initialize` **and** its resulting lifecycle event to be processed | Satisfied |
| [1.8.4](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-184) — a provider **SHOULD NOT** be bound to two API instances | Preserved — the registry keys the registered instance, not the wrapper |
| [2.5.2](https://openfeature.dev/specification/sections/providers/#requirement-252), [2.5.3](https://openfeature.dev/specification/sections/providers/#requirement-253) — shutdown reverts state, is idempotent | Satisfied |
| Condition [2.8.5](https://openfeature.dev/specification/sections/providers/#condition-285) | Not expressible in Kotlin — `initialize` is abstract, so every provider defines it; the legacy path covers the behaviour |
| [Appendix E](https://openfeature.dev/specification/appendix-e-migrations) | Legacy path implemented as the deprecated compatibility path, with a registration-time warning |

## Changes

### Implementation
- `StateManagingProvider`: marker extending `FeatureProvider`, redeclaring `observe()` without a default so opting in requires a real event stream — implementing #408's advice to couple lifecycle methods with event support.
- `LegacyProviderWrapper` (internal): holds **all** deprecated behaviour for providers without the marker — synthesising readiness and reconciliation events, and coalescing overlapping `onContextSet` invocations. The generation-counter arbitration previously in `OpenFeatureAPIInstance` moves here, so withdrawing the legacy path later is a deletion rather than an untangling.
- Registration normalises to one lifecycle path; `getProvider()` unwraps so callers always get the instance they registered.
- `setProviderAndWait` settles on the provider's reported event rather than on `initialize` returning.
- Registering a provider without the marker logs a deprecation warning.

### Mixed mode
Appendix E permits duplicate events where a legacy provider also emits its own. Its sanction covers the *derived status*, which absorbs a repeat — but the event stream would deliver both to application handlers, which on `main` it does not. So the wrapper stands aside when the provider has already reported a transition itself. Everything the wrapper publishes goes through one queue with a single consumer, so forwarded and synthesised events keep a total order rather than racing.

### Usage Examples

```kotlin
class MyProvider : StateManagingProvider {
    private val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1)
    override fun observe(): Flow<OpenFeatureProviderEvents> = events

    override suspend fun initialize(initialContext: EvaluationContext?) {
        try {
            connect()
            events.emit(OpenFeatureProviderEvents.ProviderReady())
        } catch (e: Exception) {
            events.emit(OpenFeatureProviderEvents.ProviderError(/* … */))
            throw e
        }
    }

    override suspend fun onContextSet(old: EvaluationContext?, new: EvaluationContext) {
        events.emit(OpenFeatureProviderEvents.ProviderReconciling())
        reconcile(new)
        events.emit(OpenFeatureProviderEvents.ProviderContextChanged())
    }
}
```

## Testing

- A marker provider's reported status is what the SDK publishes, and readiness reported *during* `initialize` is not overwritten afterwards — the #365 regression test.
- A reported `PROVIDER_FATAL` becomes `FATAL`, not `ERROR`.
- Provider-owned reconciliation produces exactly `RECONCILING` → `CONTEXT_CHANGED`, with nothing added by the SDK.
- A legacy provider emitting its own readiness yields one event, not two; a silent one also yields exactly one.
- `getProvider()` returns the registered instance, never the wrapper.
- A provider whose `initialize` threw can be registered again and succeed; `shutdown` is repeatable.
- All five pre-existing reconciliation race tests still pass against the wrapper, unchanged in intent.
- 251 tests, `ktlintCheck` and `apiCheck` green, `apiDump` regenerated (`LegacyProviderWrapper` stays internal).

### A note on the test diff
Two consequences are worth knowing when reading it. Status is now observable only once the event carrying it has been dispatched, so tests asserting status straight after a gated lifecycle call have to let the dispatcher run. And registration settling on an event means a collector started alongside it observes `NOT_READY` first.

## Breaking Changes

Providers wanting to own their lifecycle events implement `StateManagingProvider`; the SDK synthesising them is deprecated but still the default for existing providers, so no provider needs changing yet. `setProviderAndWait` now waits for the provider's lifecycle event rather than for `initialize` to return — a provider that returns without reporting anything is in breach of 2.8.2, and the SDK logs that and keeps waiting rather than substituting a status, since substituting one is what caused the original race. Applications needing a bound can impose their own with `withTimeout`.
