### PR TITLE
fix!: move provider status tracking back to provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ coroutineScope.launch(Dispatchers.Default) {
 
 Asynchronous API that doesn't wait is also available. It's useful when you want to set a provider and continue with other tasks.
 
-However, flag evaluations are only possible after the provider is Ready.
+However, flag evaluations are only meaningful after the provider is Ready. The SDK does not gate them on the status: an evaluation made earlier reaches the provider, which reports its own unreadiness with a `PROVIDER_NOT_READY` or `PROVIDER_FATAL` error code, and the client returns the default value.
 
 ```kotlin
 OpenFeatureAPI.setProvider(MyProvider()) // can pass a dispatcher here
@@ -425,6 +425,10 @@ The easiest way to satisfy both requirements is to delegate to `ProviderStatusTr
 `status` from the events you send it and replays the current status to new subscribers. Emit at least
 one non-not-ready event before `initialize` returns, otherwise the provider stays `NotReady`:
 throwing does not set a status.
+
+Refusing an evaluation made before the provider is ready is the provider's job too, per requirement
+2.2.7: return or throw with error code `PROVIDER_NOT_READY`, or `PROVIDER_FATAL` where the failure is
+irrecoverable, and the client returns the default value.
 
 #### Example implementation
 

--- a/README.md
+++ b/README.md
@@ -356,9 +356,9 @@ Support for domains is currently in development.
 ### Eventing
 
 Events from the Provider allow the SDK to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions.
-Events are optional which mean that not all Providers will emit them and it is not a must have. Some providers support additional events, such as `PROVIDER_CONFIGURATION_CHANGED`.
+A provider reports every status transition as an event — that is how the SDK knows a provider is ready, stale or in error — and some providers report additional events, such as `PROVIDER_CONFIGURATION_CHANGED`.
 
-Please refer to the documentation of the provider you're using to see what events are supported.
+Please refer to the documentation of the provider you're using to see what additional events are supported.
 
 Example usage:
 ```kotlin
@@ -415,8 +415,27 @@ in an Android app.
 To develop a provider, you need to create a new project and include the OpenFeature SDK as a dependency.
 You’ll then need to write the provider by implementing the `FeatureProvider` interface exported by the OpenFeature SDK.
 
+#### Status ownership
+
+A provider is responsible for its own `status`. The SDK reads it but never sets it, so you must keep it
+consistent with the events you emit, and it must be thread-safe because the SDK reads it from flag
+evaluation paths on any thread.
+
+The easiest way to satisfy both requirements is to delegate to `ProviderStatusTracker`, which derives
+`status` from the events you send it and replays the current status to new subscribers. Emit at least
+one non-not-ready event before `initialize` returns, otherwise the provider stays `NotReady`:
+throwing does not set a status.
+
+#### Example implementation
+
 ```kotlin
 class NewProvider(override val hooks: List<Hook<*>>, override val metadata: ProviderMetadata) : FeatureProvider {
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     override fun getBooleanEvaluation(
         key: String,
         defaultValue: Boolean,
@@ -466,11 +485,21 @@ class NewProvider(override val hooks: List<Hook<*>>, override val metadata: Prov
     }
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
-        // add context-aware provider initialization
+        // add context-aware provider initialization, then report the outcome
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
-    override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        // add necessary changes on context change
+    override suspend fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) = statusTracker.reconciling {
+        // add necessary changes on context change; reconciling reports the transitions around this,
+        // and collapses overlapping invocations into a single reported outcome
+    }
+
+    override fun shutdown() {
+        // release resources, and return to NotReady in case this provider is registered again
+        statusTracker.reset()
     }
   
     override fun track(
@@ -481,9 +510,6 @@ class NewProvider(override val hooks: List<Hook<*>>, override val metadata: Prov
       // Optionally track an event
     }
   
-    override fun observe(): Flow<OpenFeatureProviderEvents> {
-        // Optionally return a `Flow` of OpenFeatureProviderEvents
-    }
 }
 ```
 

--- a/docs/multiprovider/README.md
+++ b/docs/multiprovider/README.md
@@ -75,19 +75,11 @@ Aggregation is `Strategy.status(providers)`, which you can override. The default
 4. Reconciling / Stale
 5. Ready
 
-`RECONCILING` is not in the appendix's list; it is treated as `STALE` is, since both mean the provider is usable but not current.
-
-An aggregate transition carries the `EventDetails` of the child event that triggered it, as the appendix asks, and `ProviderConfigurationChanged` is re-emitted whenever any child reports one.
-
-Because aggregation reads each child's current status rather than replaying what it observed, a child that reports several transitions in one burst is observed at the status it settles on.
-
-There is no `PROVIDER_NOT_READY` event in the specification, so an aggregate that returns to `NOT_READY` — a child shut down while its `MultiProvider` stays registered — is reported through `MultiProvider.status` and `OpenFeatureAPI.getStatus()`, but cannot reach `observe()` or `statusFlow`, which have no event to carry it. The Swift implementation has the same gap.
-
-> **Divergence from the Swift SDK.** Its `Strategy.status` default selects the *best* child status, so one fatal child among healthy ones reports `READY`. That contradicts the appendix, so this SDK keeps the pessimistic ordering above. This SDK also keeps reacting to child events after initialization, where the Swift implementation only re-aggregates at lifecycle boundaries.
+An aggregate transition carries the `EventDetails` of the child event that triggered it.
 
 ### Context propagation
 
-When the evaluation context changes, `MultiProvider` reconciles through its `ProviderStatusTracker`: `PROVIDER_RECONCILING` is reported once even across overlapping context sets, `onContextSet` is called on all child providers concurrently, and only the last invocation to terminate reports an outcome. A context set that is cancelled restores the status that preceded it rather than leaving the aggregate reconciling. A child that fails reports its own error event, so one failing child does not fail the others — the same holds during `initialize` — and the aggregate settles on whatever the children report: `Ready`, but equally `Error`, `Fatal` or `Stale`.
+When the evaluation context changes, `MultiProvider` reconciles through its `ProviderStatusTracker`: `PROVIDER_RECONCILING` is reported once even across overlapping context sets, `onContextSet` is called on all child providers concurrently, and only the last invocation to terminate reports an outcome.
 
 ### Provider metadata
 

--- a/docs/multiprovider/README.md
+++ b/docs/multiprovider/README.md
@@ -65,7 +65,9 @@ Children are evaluated in the order provided. Put the most authoritative or fast
 
 ### Events and status aggregation
 
-`MultiProvider` listens to child provider events and emits a single, aggregate status via `OpenFeatureAPI.statusFlow`. Per the OpenFeature specification: a child stays `NOT_READY` until it emits `PROVIDER_READY`, `PROVIDER_ERROR`, or `PROVIDER_STALE` (or only `PROVIDER_CONFIGURATION_CHANGED`, which does not change readiness). The highest-precedence status among children wins:
+`MultiProvider` owns a `ProviderStatusTracker` like any other provider, and reports a single aggregate status through it. A child stays `NOT_READY` until it reports `PROVIDER_READY`, `PROVIDER_ERROR` or `PROVIDER_STALE`; `PROVIDER_CONFIGURATION_CHANGED` carries no status and does not change readiness.
+
+Aggregation is `Strategy.status(providers)`, which you can override. The default reports the most severe child status, which is the order the specification's [Multi-Provider appendix](https://openfeature.dev/specification/appendix-a/#status-and-event-handling) defines:
 
 1. Fatal
 2. NotReady
@@ -73,11 +75,17 @@ Children are evaluated in the order provided. Put the most authoritative or fast
 4. Reconciling / Stale
 5. Ready
 
-`ProviderConfigurationChanged` is re-emitted as-is. When the aggregate status changes due to a child event, the original triggering event is also emitted.
+`RECONCILING` is not in the appendix's list; it is treated as `STALE` is, since both mean the provider is usable but not current.
+
+An aggregate transition carries the `EventDetails` of the child event that triggered it, as the appendix asks, and `ProviderConfigurationChanged` is re-emitted whenever any child reports one.
+
+Because aggregation reads each child's current status rather than replaying what it observed, a child that reports several transitions in one burst is observed at the status it settles on.
+
+> **Divergence from the Swift SDK.** Its `Strategy.status` default selects the *best* child status, so one fatal child among healthy ones reports `READY`. That contradicts the appendix, so this SDK keeps the pessimistic ordering above. This SDK also keeps reacting to child events after initialization, where the Swift implementation only re-aggregates at lifecycle boundaries.
 
 ### Context propagation
 
-When the evaluation context changes, `MultiProvider` calls `onContextSet` on all child providers concurrently. Aggregate status transitions to Reconciling and then back to Ready (or Error) in line with SDK behavior.
+When the evaluation context changes, `MultiProvider` reports `PROVIDER_RECONCILING`, calls `onContextSet` on all child providers concurrently, and then re-aggregates. A child that fails reports its own error event, so one failing child does not fail the others; the aggregate settles on whatever the children report — `Ready`, but equally `Error`, `Fatal` or `Stale`.
 
 ### Provider metadata
 

--- a/docs/multiprovider/README.md
+++ b/docs/multiprovider/README.md
@@ -81,11 +81,13 @@ An aggregate transition carries the `EventDetails` of the child event that trigg
 
 Because aggregation reads each child's current status rather than replaying what it observed, a child that reports several transitions in one burst is observed at the status it settles on.
 
+There is no `PROVIDER_NOT_READY` event in the specification, so an aggregate that returns to `NOT_READY` — a child shut down while its `MultiProvider` stays registered — is reported through `MultiProvider.status` and `OpenFeatureAPI.getStatus()`, but cannot reach `observe()` or `statusFlow`, which have no event to carry it. The Swift implementation has the same gap.
+
 > **Divergence from the Swift SDK.** Its `Strategy.status` default selects the *best* child status, so one fatal child among healthy ones reports `READY`. That contradicts the appendix, so this SDK keeps the pessimistic ordering above. This SDK also keeps reacting to child events after initialization, where the Swift implementation only re-aggregates at lifecycle boundaries.
 
 ### Context propagation
 
-When the evaluation context changes, `MultiProvider` reports `PROVIDER_RECONCILING`, calls `onContextSet` on all child providers concurrently, and then re-aggregates. A child that fails reports its own error event, so one failing child does not fail the others; the aggregate settles on whatever the children report — `Ready`, but equally `Error`, `Fatal` or `Stale`.
+When the evaluation context changes, `MultiProvider` reconciles through its `ProviderStatusTracker`: `PROVIDER_RECONCILING` is reported once even across overlapping context sets, `onContextSet` is called on all child providers concurrently, and only the last invocation to terminate reports an outcome. A context set that is cancelled restores the status that preceded it rather than leaving the aggregate reconciling. A child that fails reports its own error event, so one failing child does not fail the others — the same holds during `initialize` — and the aggregate settles on whatever the children report: `Ready`, but equally `Error`, `Fatal` or `Stale`.
 
 ### Provider metadata
 

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -291,8 +291,7 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
 	public final fun observe ()Lkotlinx/coroutines/flow/Flow;
-	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
-	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
+	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setProvider (Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public static synthetic fun setProvider$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;ILjava/lang/Object;)V

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -953,11 +953,13 @@ public final class dev/openfeature/kotlin/sdk/logging/NoOpLogger : dev/openfeatu
 public final class dev/openfeature/kotlin/sdk/multiprovider/FirstMatchStrategy : dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {
 	public fun <init> ()V
 	public fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun status (Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 
 public final class dev/openfeature/kotlin/sdk/multiprovider/FirstSuccessfulStrategy : dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {
 	public fun <init> ()V
 	public fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun status (Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 
 public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
@@ -972,7 +974,6 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider : dev/
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
-	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;
@@ -1005,5 +1006,10 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Compan
 
 public abstract interface class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {
 	public abstract fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun status (Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
+}
+
+public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy$DefaultImpls {
+	public static fun status (Ldev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy;Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -74,16 +74,16 @@ public abstract interface class dev/openfeature/kotlin/sdk/FeatureProvider {
 	public abstract fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public abstract fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public abstract fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public abstract fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public abstract fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public abstract fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun observe ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun observe ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun onContextSet (Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun shutdown ()V
 	public fun track (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/FeatureProvider$DefaultImpls {
-	public static fun observe (Ldev/openfeature/kotlin/sdk/FeatureProvider;)Lkotlinx/coroutines/flow/Flow;
 	public static fun track (Ldev/openfeature/kotlin/sdk/FeatureProvider;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
 }
 
@@ -252,6 +252,7 @@ public class dev/openfeature/kotlin/sdk/NoOpProvider : dev/openfeature/kotlin/sd
 	public fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;
@@ -287,9 +288,9 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getHooks ()Ljava/util/List;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
-	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun observe ()Lkotlinx/coroutines/flow/Flow;
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -354,12 +355,16 @@ public abstract interface class dev/openfeature/kotlin/sdk/OpenFeatureStatus {
 
 public final class dev/openfeature/kotlin/sdk/OpenFeatureStatus$Error : dev/openfeature/kotlin/sdk/OpenFeatureStatus {
 	public fun <init> (Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;
+	public fun hashCode ()I
 }
 
 public final class dev/openfeature/kotlin/sdk/OpenFeatureStatus$Fatal : dev/openfeature/kotlin/sdk/OpenFeatureStatus {
 	public fun <init> (Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;
+	public fun hashCode ()I
 }
 
 public final class dev/openfeature/kotlin/sdk/OpenFeatureStatus$NotReady : dev/openfeature/kotlin/sdk/OpenFeatureStatus {
@@ -966,6 +971,7 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider : dev/
 	public fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -985,6 +991,7 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$ChildF
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getName ()Ljava/lang/String;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -409,6 +409,15 @@ public final class dev/openfeature/kotlin/sdk/ProviderMetadata$DefaultImpls {
 	public static fun getOriginalMetadata (Ldev/openfeature/kotlin/sdk/ProviderMetadata;)Ljava/util/Map;
 }
 
+public final class dev/openfeature/kotlin/sdk/ProviderStatusTracker {
+	public fun <init> ()V
+	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
+	public final fun observe ()Lkotlinx/coroutines/flow/Flow;
+	public final fun reconciling (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reset ()V
+	public final fun send (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents;)V
+}
+
 public final class dev/openfeature/kotlin/sdk/Reason : java/lang/Enum {
 	public static final field CACHED Ldev/openfeature/kotlin/sdk/Reason;
 	public static final field DEFAULT Ldev/openfeature/kotlin/sdk/Reason;

--- a/kotlin-sdk/api/android/kotlin-sdk.api
+++ b/kotlin-sdk/api/android/kotlin-sdk.api
@@ -724,6 +724,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderError : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
 	public fun <init> ()V
 	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
@@ -744,6 +757,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -291,8 +291,7 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
 	public final fun observe ()Lkotlinx/coroutines/flow/Flow;
-	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
-	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
+	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setProvider (Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;)V
 	public static synthetic fun setProvider$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/FeatureProvider;Lkotlinx/coroutines/CoroutineDispatcher;Ldev/openfeature/kotlin/sdk/EvaluationContext;ILjava/lang/Object;)V

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -953,11 +953,13 @@ public final class dev/openfeature/kotlin/sdk/logging/NoOpLogger : dev/openfeatu
 public final class dev/openfeature/kotlin/sdk/multiprovider/FirstMatchStrategy : dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {
 	public fun <init> ()V
 	public fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun status (Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 
 public final class dev/openfeature/kotlin/sdk/multiprovider/FirstSuccessfulStrategy : dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {
 	public fun <init> ()V
 	public fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun status (Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 
 public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
@@ -972,7 +974,6 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider : dev/
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
-	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;
@@ -1005,5 +1006,10 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Compan
 
 public abstract interface class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy {
 	public abstract fun evaluate (Ljava/util/List;Ljava/lang/String;Ljava/lang/Object;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/jvm/functions/Function4;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun status (Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
+}
+
+public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy$DefaultImpls {
+	public static fun status (Ldev/openfeature/kotlin/sdk/multiprovider/MultiProvider$Strategy;Ljava/util/List;)Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 }
 

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -74,16 +74,16 @@ public abstract interface class dev/openfeature/kotlin/sdk/FeatureProvider {
 	public abstract fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public abstract fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public abstract fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public abstract fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public abstract fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public abstract fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun observe ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun observe ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun onContextSet (Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun shutdown ()V
 	public fun track (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
 }
 
 public final class dev/openfeature/kotlin/sdk/FeatureProvider$DefaultImpls {
-	public static fun observe (Ldev/openfeature/kotlin/sdk/FeatureProvider;)Lkotlinx/coroutines/flow/Flow;
 	public static fun track (Ldev/openfeature/kotlin/sdk/FeatureProvider;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
 }
 
@@ -252,6 +252,7 @@ public class dev/openfeature/kotlin/sdk/NoOpProvider : dev/openfeature/kotlin/sd
 	public fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;
@@ -287,9 +288,9 @@ public class dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance {
 	public final fun getHooks ()Ljava/util/List;
 	public final fun getProvider ()Ldev/openfeature/kotlin/sdk/FeatureProvider;
 	public final fun getProviderMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
-	public final fun getProvidersFlow ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun observe ()Lkotlinx/coroutines/flow/Flow;
 	public final fun setEvaluationContext (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public static synthetic fun setEvaluationContext$default (Ldev/openfeature/kotlin/sdk/OpenFeatureAPIInstance;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)V
 	public final fun setEvaluationContextAndWait (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -354,12 +355,16 @@ public abstract interface class dev/openfeature/kotlin/sdk/OpenFeatureStatus {
 
 public final class dev/openfeature/kotlin/sdk/OpenFeatureStatus$Error : dev/openfeature/kotlin/sdk/OpenFeatureStatus {
 	public fun <init> (Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;
+	public fun hashCode ()I
 }
 
 public final class dev/openfeature/kotlin/sdk/OpenFeatureStatus$Fatal : dev/openfeature/kotlin/sdk/OpenFeatureStatus {
 	public fun <init> (Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ldev/openfeature/kotlin/sdk/exceptions/OpenFeatureError;
+	public fun hashCode ()I
 }
 
 public final class dev/openfeature/kotlin/sdk/OpenFeatureStatus$NotReady : dev/openfeature/kotlin/sdk/OpenFeatureStatus {
@@ -966,6 +971,7 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider : dev/
 	public fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public final fun getStatusFlow ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -985,6 +991,7 @@ public final class dev/openfeature/kotlin/sdk/multiprovider/MultiProvider$ChildF
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public final fun getName ()Ljava/lang/String;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -409,6 +409,15 @@ public final class dev/openfeature/kotlin/sdk/ProviderMetadata$DefaultImpls {
 	public static fun getOriginalMetadata (Ldev/openfeature/kotlin/sdk/ProviderMetadata;)Ljava/util/Map;
 }
 
+public final class dev/openfeature/kotlin/sdk/ProviderStatusTracker {
+	public fun <init> ()V
+	public final fun getStatus ()Ldev/openfeature/kotlin/sdk/OpenFeatureStatus;
+	public final fun observe ()Lkotlinx/coroutines/flow/Flow;
+	public final fun reconciling (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reset ()V
+	public final fun send (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents;)V
+}
+
 public final class dev/openfeature/kotlin/sdk/Reason : java/lang/Enum {
 	public static final field CACHED Ldev/openfeature/kotlin/sdk/Reason;
 	public static final field DEFAULT Ldev/openfeature/kotlin/sdk/Reason;

--- a/kotlin-sdk/api/jvm/kotlin-sdk.api
+++ b/kotlin-sdk/api/jvm/kotlin-sdk.api
@@ -724,6 +724,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderContextChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderError : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
 	public fun <init> ()V
 	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
@@ -744,6 +757,19 @@ public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$P
 	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
 	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling : dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents {
+	public fun <init> ()V
+	public fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)V
+	public synthetic fun <init> (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
+	public final fun copy (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
+	public static synthetic fun copy$default (Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;ILjava/lang/Object;)Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$ProviderReconciling;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEventDetails ()Ldev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents$EventDetails;
 	public fun hashCode ()I

--- a/kotlin-sdk/build.gradle.kts
+++ b/kotlin-sdk/build.gradle.kts
@@ -86,9 +86,8 @@ android {
 
     testOptions {
         unitTests {
-            // Local unit tests run against a stub android.jar, where every method throws unless this
-            // is set. The SDK logs through android.util.Log, so any code path that logs would fail a
-            // unit test rather than the behaviour it is exercising.
+            // The SDK logs through android.util.Log, which throws in the stub android.jar unit tests
+            // run against.
             isReturnDefaultValues = true
         }
     }

--- a/kotlin-sdk/build.gradle.kts
+++ b/kotlin-sdk/build.gradle.kts
@@ -83,6 +83,15 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+
+    testOptions {
+        unitTests {
+            // Local unit tests run against a stub android.jar, where every method throws unless this
+            // is set. The SDK logs through android.util.Log, so any code path that logs would fail a
+            // unit test rather than the behaviour it is exercising.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 // Configure Dokka for documentation

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/EvaluationState.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/EvaluationState.kt
@@ -1,9 +1,11 @@
 package dev.openfeature.kotlin.sdk
 
 /**
- * Atomic snapshot of the provider and evaluation context used for flag evaluation and tracking.
+ * Atomic snapshot of the provider, evaluation context and hooks used for flag evaluation and
+ * tracking, so a single evaluation cannot observe half of a concurrent change.
  */
 internal data class EvaluationState(
     val provider: FeatureProvider,
-    val context: EvaluationContext?
+    val context: EvaluationContext?,
+    val hooks: List<Hook<*>> = listOf()
 )

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/EvaluationState.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/EvaluationState.kt
@@ -2,10 +2,10 @@ package dev.openfeature.kotlin.sdk
 
 /**
  * Atomic snapshot of the provider, evaluation context and hooks used for flag evaluation and
- * tracking, so a single evaluation cannot observe half of a concurrent change.
+ * tracking.
  */
 internal data class EvaluationState(
     val provider: FeatureProvider,
     val context: EvaluationContext?,
-    val hooks: List<Hook<*>> = listOf()
+    val hooks: List<Hook<*>>
 )

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/FeatureProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/FeatureProvider.kt
@@ -3,30 +3,99 @@ package dev.openfeature.kotlin.sdk
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * The interface implemented by upstream flag providers to resolve flags for their service.
+ *
+ * A provider is responsible for its own [status] and for emitting the events that explain it. The
+ * easiest way to satisfy both is to delegate to [ProviderStatusTracker]:
+ *
+ * ```kotlin
+ * class MyProvider : FeatureProvider {
+ *     private val statusTracker = ProviderStatusTracker()
+ *
+ *     override val status: OpenFeatureStatus get() = statusTracker.status
+ *     override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+ *
+ *     override suspend fun initialize(initialContext: EvaluationContext?) {
+ *         connect(initialContext)
+ *         statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
+ *     }
+ *
+ *     override suspend fun onContextSet(
+ *         oldContext: EvaluationContext?,
+ *         newContext: EvaluationContext
+ *     ) = statusTracker.reconciling { refresh(newContext) }
+ *
+ *     override fun shutdown() = statusTracker.reset()
+ *
+ *     // ... flag evaluation methods ...
+ * }
+ * ```
+ *
+ * [ProviderStatusTracker] keeps [status] in sync with the events sent through it, is safe to use
+ * from any thread, and replays the current status to a new subscriber.
+ */
 interface FeatureProvider {
     val hooks: List<Hook<*>>
     val metadata: ProviderMetadata
 
     /**
-     * Called by OpenFeatureAPI whenever the new Provider is registered
-     * This function should block until ready and throw exceptions if it fails to initialize
+     * The current lifecycle status of this provider.
+     *
+     * The provider alone is responsible for keeping this up to date. It must be
+     * [OpenFeatureStatus.NotReady] before [initialize] is called, and must reflect the most recently
+     * emitted event thereafter.
+     *
+     * This must be **thread-safe**: the SDK reads it from flag evaluation paths on any thread. The
+     * recommended way to satisfy that is to expose [ProviderStatusTracker.status] directly.
+     */
+    val status: OpenFeatureStatus
+
+    /**
+     * Called by OpenFeatureAPI when this provider is registered, to do whatever asynchronous setup it
+     * needs — fetching an initial flag configuration, opening a streaming connection.
+     *
+     * **Required status transition:** emit at least one event before returning, so that [status]
+     * moves away from [OpenFeatureStatus.NotReady]. [OpenFeatureProviderEvents.ProviderReady] on
+     * success and [OpenFeatureProviderEvents.ProviderError] on failure are the usual outcomes, but
+     * any other non-not-ready status is valid. Emitting before returning is what lets a caller of
+     * `setProviderAndWait` see the right status immediately.
+     *
+     * Throwing does **not** set a status: the SDK logs the failure and leaves [status] alone, so a
+     * provider that throws without emitting stays [OpenFeatureStatus.NotReady].
+     *
+     * Lifecycle calls are entered in the order they were made, but the SDK does not wait for one to
+     * finish before entering the next.
+     *
      * @param initialContext any initial context to be set before the provider is ready
      */
     @Throws(OpenFeatureError::class, CancellationException::class)
     suspend fun initialize(initialContext: EvaluationContext?)
 
     /**
-     * Called when the lifecycle of the OpenFeatureClient is over to release resources/threads
+     * Called when the lifecycle of the OpenFeatureClient is over to release resources/threads.
+     *
+     * A provider that can be registered again must return to [OpenFeatureStatus.NotReady] here —
+     * [ProviderStatusTracker.reset] does that — so a reused instance does not report the status it
+     * held before it was shut down.
      */
     fun shutdown()
 
     /**
      * Called by OpenFeatureAPI whenever the application sets the [EvaluationContext], including when
      * the new context is equal to or the same instance as the previous context.
-     * Implementations should suspend until the provider is ready again or throw an exception.
+     *
+     * Either return without emitting anything, where no reconciliation is needed, or emit
+     * [OpenFeatureProviderEvents.ProviderReconciling], do the work, and emit
+     * [OpenFeatureProviderEvents.ProviderContextChanged] or
+     * [OpenFeatureProviderEvents.ProviderError]. [ProviderStatusTracker.reconciling] does the latter,
+     * including collapsing overlapping invocations.
+     *
+     * Since the SDK does not wait for one lifecycle call to finish before entering the next, this can
+     * be entered while previous reconciliation work is still in flight; a provider reconciling
+     * asynchronously should handle that, for instance by cancelling the work it supersedes.
      *
      * @param oldContext The old EvaluationContext
      * @param newContext The new EvaluationContext
@@ -61,10 +130,10 @@ interface FeatureProvider {
     }
 
     /**
-     * Used by providers to expose internal events to the SDK or the application.
-     * This can be optionally implemented by the provider to expose a flow of internal events.
+     * The events this provider emits, for the SDK and the application.
+     *
+     * The SDK derives nothing from a provider's silence: every status transition must arrive here.
+     * Return [ProviderStatusTracker.observe] to get the required replay behaviour for free.
      */
-    fun observe(): Flow<OpenFeatureProviderEvents> {
-        return emptyFlow()
-    }
+    fun observe(): Flow<OpenFeatureProviderEvents>
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/FeatureProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/FeatureProvider.kt
@@ -8,63 +8,29 @@ import kotlin.coroutines.cancellation.CancellationException
 /**
  * The interface implemented by upstream flag providers to resolve flags for their service.
  *
- * A provider is responsible for its own [status] and for emitting the events that explain it. The
- * easiest way to satisfy both is to delegate to [ProviderStatusTracker]:
- *
- * ```kotlin
- * class MyProvider : FeatureProvider {
- *     private val statusTracker = ProviderStatusTracker()
- *
- *     override val status: OpenFeatureStatus get() = statusTracker.status
- *     override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
- *
- *     override suspend fun initialize(initialContext: EvaluationContext?) {
- *         connect(initialContext)
- *         statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
- *     }
- *
- *     override suspend fun onContextSet(
- *         oldContext: EvaluationContext?,
- *         newContext: EvaluationContext
- *     ) = statusTracker.reconciling { refresh(newContext) }
- *
- *     override fun shutdown() = statusTracker.reset()
- *
- *     // ... flag evaluation methods ...
- * }
- * ```
- *
- * [ProviderStatusTracker] keeps [status] in sync with the events sent through it, is safe to use
- * from any thread, and replays the current status to a new subscriber.
+ * A provider is responsible for its own [status] and for emitting the events that explain it, which
+ * [ProviderStatusTracker] does on its behalf. The README carries a worked example.
  */
 interface FeatureProvider {
     val hooks: List<Hook<*>>
     val metadata: ProviderMetadata
 
     /**
-     * The current lifecycle status of this provider.
-     *
-     * The provider alone is responsible for keeping this up to date. It must be
-     * [OpenFeatureStatus.NotReady] before [initialize] is called, and must reflect the most recently
-     * emitted event thereafter.
-     *
-     * This must be **thread-safe**: the SDK reads it from flag evaluation paths on any thread. The
-     * recommended way to satisfy that is to expose [ProviderStatusTracker.status] directly.
+     * The current lifecycle status of this provider, kept up to date by the provider alone. It must
+     * be [OpenFeatureStatus.NotReady] before [initialize] is called, must reflect the most recently
+     * emitted event thereafter, and must be thread-safe: the SDK reads it from flag evaluation paths
+     * on any thread.
      */
     val status: OpenFeatureStatus
 
     /**
-     * Called by OpenFeatureAPI when this provider is registered, to do whatever asynchronous setup it
-     * needs — fetching an initial flag configuration, opening a streaming connection.
+     * Called by OpenFeatureAPI when this provider is registered, to do whatever asynchronous setup
+     * it needs.
      *
-     * **Required status transition:** emit at least one event before returning, so that [status]
-     * moves away from [OpenFeatureStatus.NotReady]. [OpenFeatureProviderEvents.ProviderReady] on
-     * success and [OpenFeatureProviderEvents.ProviderError] on failure are the usual outcomes, but
-     * any other non-not-ready status is valid. Emitting before returning is what lets a caller of
-     * `setProviderAndWait` see the right status immediately.
-     *
-     * Throwing does **not** set a status: the SDK logs the failure and leaves [status] alone, so a
-     * provider that throws without emitting stays [OpenFeatureStatus.NotReady].
+     * Emit at least one event before returning, so that [status] moves away from
+     * [OpenFeatureStatus.NotReady] — usually [OpenFeatureProviderEvents.ProviderReady] or
+     * [OpenFeatureProviderEvents.ProviderError]. Throwing does not set a status: the SDK logs the
+     * failure and a provider that throws without emitting stays [OpenFeatureStatus.NotReady].
      *
      * Lifecycle calls are entered in the order they were made, but the SDK does not wait for one to
      * finish before entering the next.
@@ -77,9 +43,8 @@ interface FeatureProvider {
     /**
      * Called when the lifecycle of the OpenFeatureClient is over to release resources/threads.
      *
-     * A provider that can be registered again must return to [OpenFeatureStatus.NotReady] here —
-     * [ProviderStatusTracker.reset] does that — so a reused instance does not report the status it
-     * held before it was shut down.
+     * A provider that can be registered again must return to [OpenFeatureStatus.NotReady] here, so
+     * a reused instance does not report the status it held before it was shut down.
      */
     fun shutdown()
 
@@ -90,12 +55,12 @@ interface FeatureProvider {
      * Either return without emitting anything, where no reconciliation is needed, or emit
      * [OpenFeatureProviderEvents.ProviderReconciling], do the work, and emit
      * [OpenFeatureProviderEvents.ProviderContextChanged] or
-     * [OpenFeatureProviderEvents.ProviderError]. [ProviderStatusTracker.reconciling] does the latter,
-     * including collapsing overlapping invocations.
+     * [OpenFeatureProviderEvents.ProviderError]. [ProviderStatusTracker.reconciling] does the
+     * latter, including collapsing overlapping invocations.
      *
-     * Since the SDK does not wait for one lifecycle call to finish before entering the next, this can
-     * be entered while previous reconciliation work is still in flight; a provider reconciling
-     * asynchronously should handle that, for instance by cancelling the work it supersedes.
+     * This can be entered while previous reconciliation work is still in flight; a provider
+     * reconciling asynchronously should handle that, for instance by cancelling the work it
+     * supersedes.
      *
      * @param oldContext The old EvaluationContext
      * @param newContext The new EvaluationContext
@@ -130,10 +95,8 @@ interface FeatureProvider {
     }
 
     /**
-     * The events this provider emits, for the SDK and the application.
-     *
-     * The SDK derives nothing from a provider's silence: every status transition must arrive here.
-     * Return [ProviderStatusTracker.observe] to get the required replay behaviour for free.
+     * The events this provider emits, for the SDK and the application. The SDK derives nothing from
+     * a provider's silence: every status transition must arrive here.
      */
     fun observe(): Flow<OpenFeatureProviderEvents>
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/NoOpProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/NoOpProvider.kt
@@ -1,20 +1,31 @@
 package dev.openfeature.kotlin.sdk
 
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import kotlinx.coroutines.flow.Flow
+
+/** The default provider: it resolves every flag to the passed-in default and reports itself ready. */
 open class NoOpProvider(override val hooks: List<Hook<*>> = listOf()) : FeatureProvider {
+    private val statusTracker = ProviderStatusTracker()
+
     override val metadata: ProviderMetadata = NoOpProviderMetadata("No-op provider")
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     override suspend fun initialize(initialContext: EvaluationContext?) {
-        // no-op
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
     override fun shutdown() {
-        // no-op
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) {
-        // no-op
+        // Nothing is cached, so there is nothing to reconcile and nothing to report.
     }
 
     override fun getBooleanEvaluation(

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/NoOpProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/NoOpProvider.kt
@@ -25,7 +25,7 @@ open class NoOpProvider(override val hooks: List<Hook<*>> = listOf()) : FeatureP
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) {
-        // Nothing is cached, so there is nothing to reconcile and nothing to report.
+        // no-op
     }
 
     override fun getBooleanEvaluation(

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -37,9 +37,8 @@ private const val LOGGER_NAME = "OpenFeatureAPI"
  * global singleton [OpenFeatureAPI] is one such instance. To create isolated, independent instances
  * use [dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance].
  *
- * Status belongs to the registered provider, not to this instance: [getStatus] and [statusFlow] both
- * read [FeatureProvider.status], and the SDK never sets it. The one exception is shutdown, where the
- * SDK infers not-ready because it is the SDK that initiated the shutdown.
+ * Status belongs to the registered provider: [getStatus] and [statusFlow] both read
+ * [FeatureProvider.status], which the SDK never sets.
  *
  * @see OpenFeatureAPI
  * @see dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance
@@ -53,26 +52,15 @@ open class OpenFeatureAPIInstance internal constructor() {
     private class NoProvider : NoOpProvider()
 
     /**
-     * One registration of one provider, boxed so that [MutableStateFlow] never conflates two
-     * registrations of *different* providers: a fresh box is never equal to its predecessor, so the
-     * swap restarts the subscriptions derived from it, which is what keeps a retired provider's
-     * events out of its successor's stream.
-     *
-     * Re-registering the same provider instance deliberately reuses its box, so no restart happens.
-     * That is correct rather than an oversight — it is the same provider and the same tracker, its
-     * subscribers are still attached, and a re-emitted status would be swallowed by
-     * `distinctUntilChanged` anyway. Allocating a second box would instead put the provider's next
-     * lifecycle call on an unrelated serial dispatcher and cancel the scope it is still running on.
+     * One registration of one provider, boxed so that a swap restarts the subscriptions derived from
+     * it, which keeps a retired provider's events out of its successor's stream. Re-registering the
+     * same instance reuses its box, so nothing restarts.
      */
     private class ProviderRegistration(
         val provider: FeatureProvider,
         dispatcher: CoroutineDispatcher
     ) {
-        /**
-         * Serial, so this provider's lifecycle calls are entered one at a time and in the order they
-         * were made. A call that suspends releases the dispatcher, so the SDK never waits for one
-         * lifecycle call to finish before entering the next.
-         */
+        /** Serial, so this provider's lifecycle calls are entered in the order they were made. */
         @OptIn(ExperimentalCoroutinesApi::class)
         val scope = CoroutineScope(
             SupervisorJob() +
@@ -87,18 +75,17 @@ open class OpenFeatureAPIInstance internal constructor() {
     private var registration = ProviderRegistration(NoProvider(), Dispatchers.Default)
     private val providerRegistrations = MutableStateFlow(registration)
 
-    /**
-     * Runs retirements, and is never cancelled: dropping one leaks the provider it was meant to
-     * release. Independent of any registration's scope, which a swap cancels.
-     */
+    /** Never cancelled: a dropped retirement leaks the provider it was meant to release. */
     private val retirementScope = CoroutineScope(
         SupervisorJob() +
             Dispatchers.Default +
-            // Retiring one provider must not fail whoever registered the next one.
             CoroutineExceptionHandler { _, throwable ->
                 logger.warn({ "Retiring a replaced provider failed" }, throwable = throwable)
             }
     )
+
+    /** Retirements still in flight, so a provider registered again is ordered after its teardown. */
+    private val retirements = mutableListOf<Pair<FeatureProvider, Job>>()
 
     private var context: EvaluationContext? = null
 
@@ -108,20 +95,20 @@ open class OpenFeatureAPIInstance internal constructor() {
     /**
      * The status of the registered provider, and every transition it reports.
      *
-     * A projection of [FeatureProvider.status], so it can never disagree with [getStatus]. A
-     * provider that reports nothing yields exactly one [OpenFeatureStatus.NotReady].
+     * Derived from the provider's events, so it carries every transition the provider can express.
+     * [OpenFeatureStatus.NotReady] has no event: a provider that returns to it after registration —
+     * a [dev.openfeature.kotlin.sdk.multiprovider.MultiProvider] whose child was shut down behind
+     * its back, say — reports that through [getStatus] alone. A provider that reports nothing yields
+     * exactly one [OpenFeatureStatus.NotReady].
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     val statusFlow: Flow<OpenFeatureStatus> = providerRegistrations
         .flatMapLatest { current ->
             current.provider.observe()
                 .transform { event ->
-                    // The event's own status, not a re-read of provider.status: two transitions
-                    // reported back to back would otherwise both read the later one.
+                    // The event's own status: a re-read loses the earlier of two transitions.
                     val reported = event.toOpenFeatureStatus()
                     reported?.let { emit(it) }
-                    // Then catch up, so a subscriber whose buffer overflowed and lost an event still
-                    // converges on the truth at the next one rather than staying behind for good.
                     val live = current.provider.status
                     if (live != reported) emit(live)
                 }
@@ -135,9 +122,8 @@ open class OpenFeatureAPIInstance internal constructor() {
      * outgoing provider is shut down in the background, so this does not wait for its teardown.
      *
      * @param provider the provider to set
-     * @param dispatcher the dispatcher this provider's lifecycle calls run on. Registering a provider
-     * that is already registered keeps the dispatcher it was first registered with, since its
-     * lifecycle calls have to stay ordered against each other on one dispatcher.
+     * @param dispatcher the dispatcher this provider's lifecycle calls run on; a provider that is
+     * already registered keeps the dispatcher it was first registered with
      * @param initialContext the initial [EvaluationContext] for provider initialization
      */
     fun setProvider(
@@ -152,9 +138,8 @@ open class OpenFeatureAPIInstance internal constructor() {
      * Set the [FeatureProvider] for this instance, suspending until its `initialize` has terminated.
      *
      * A provider reports its own outcome, so this does not throw when initialization fails: the
-     * failure arrives as an [OpenFeatureProviderEvents.ProviderError] and as
-     * [OpenFeatureStatus.Error]. A provider that throws without reporting anything stays
-     * [OpenFeatureStatus.NotReady], and the failure is logged.
+     * failure arrives as an [OpenFeatureProviderEvents.ProviderError]. A provider that throws
+     * without reporting anything stays [OpenFeatureStatus.NotReady].
      *
      * @param provider the [FeatureProvider] to set
      * @param initialContext the initial [EvaluationContext] for provider initialization
@@ -167,14 +152,20 @@ open class OpenFeatureAPIInstance internal constructor() {
         dispatcher: CoroutineDispatcher? = null
     ) {
         val swap = swapProvider(provider, initialContext, dispatcher ?: callerDispatcher())
-        // The outgoing provider's teardown is awaited here, unlike on the fire-and-forget path: a
-        // suspending caller can be told that the provider it replaced is actually down.
         swap.retirement?.join()
         swap.initialization.joinPropagatingCancellation()
     }
 
     /** The two pieces of work a swap starts: initializing the new provider, retiring the old one. */
     private class Swap(val initialization: Job, val retirement: Job?)
+
+    /** What a swap decides under [stateLock], so the rest of it can run without holding the lock. */
+    private class Commit(
+        val current: ProviderRegistration,
+        val retired: ProviderRegistration?,
+        val initializationContext: EvaluationContext?,
+        val pendingRetirements: List<Job>
+    )
 
     private suspend fun callerDispatcher(): CoroutineDispatcher =
         currentCoroutineContext()[ContinuationInterceptor] as? CoroutineDispatcher ?: Dispatchers.Default
@@ -184,34 +175,38 @@ open class OpenFeatureAPIInstance internal constructor() {
         initialContext: EvaluationContext?,
         dispatcher: CoroutineDispatcher
     ): Swap {
-        trackProviderBinding(newProvider)
-
-        val (current, retired, initializationContext) = synchronized(stateLock) {
+        val commit = synchronized(stateLock) {
+            // Claimed under the lock that commits the swap, so a retirement of an earlier
+            // registration of this same provider cannot unbind what is about to be published.
+            trackProviderBinding(newProvider)
             val previous = registration
-            // Re-registering the same instance reuses its registration. Allocating a second one would
-            // put this initialize on an unrelated serial dispatcher, so it would not be ordered
-            // against the provider's own in-flight work, and would cancel the scope that work runs on.
+            // Reusing the registration keeps this initialize ordered against the provider's own
+            // in-flight work.
             val rebinding = previous.provider === newProvider
             val current = if (rebinding) previous else ProviderRegistration(newProvider, dispatcher)
             registration = current
             if (initialContext != null) context = initialContext
-            // Published under the same lock that commits the swap: otherwise two concurrent swaps can
-            // leave evaluations on one provider and statusFlow/observe() pinned to the other.
+            // Published under the lock that commits the swap, or two concurrent swaps can leave
+            // evaluations on one provider and statusFlow pinned to the other.
             providerRegistrations.value = current
-            Triple(current, previous.takeUnless { rebinding }, context)
+            Commit(
+                current = current,
+                retired = previous.takeUnless { rebinding },
+                initializationContext = context,
+                pendingRetirements = retirements.filter { it.first === newProvider }.map { it.second }
+            )
         }
 
-        // Retired here rather than from the successor's job: that job can be cancelled before it is
-        // ever dispatched, which would leave the outgoing provider running and never shut down.
-        val retirement = retired?.let { retire(it) }
+        // Not from the successor's job, which can be cancelled before it is ever dispatched.
+        val retirement = commit.retired?.let { retire(it) }
 
-        // A rebind cancels neither of the provider's jobs. Its in-flight work is its own to supersede,
-        // which is the contract in FeatureProvider: calls are entered in order, and the SDK does not
-        // wait for one to finish before entering the next.
-        val initialization = current.dispatchLifecycle("initialize") {
-            newProvider.initialize(initializationContext)
+        val initialization = commit.current.dispatchLifecycle("initialize") {
+            // A retirement of this provider that already committed to shutting it down is still
+            // running: initializing over it would race its teardown.
+            commit.pendingRetirements.forEach { it.join() }
+            newProvider.initialize(commit.initializationContext)
         }
-        synchronized(stateLock) { current.providerJob = initialization }
+        synchronized(stateLock) { commit.current.providerJob = initialization }
         return Swap(initialization, retirement)
     }
 
@@ -230,8 +225,7 @@ open class OpenFeatureAPIInstance internal constructor() {
     /**
      * Clear the current [FeatureProvider] and reset to a no-op provider.
      *
-     * Installs a provider that was never initialized, so the status is not-ready once this returns,
-     * as requirement 1.7.6 asks: the SDK initiated the shutdown, so no provider event is involved.
+     * Installs a provider that was never initialized, so the status is not-ready once this returns.
      */
     suspend fun clearProvider() {
         val next = ProviderRegistration(NoProvider(), Dispatchers.Default)
@@ -241,37 +235,41 @@ open class OpenFeatureAPIInstance internal constructor() {
             providerRegistrations.value = next
             previous
         }
-        // Awaited, unlike the fire-and-forget swap: this is a suspending call, so a caller asking for
-        // the provider to be cleared can be told when it actually has been.
         retire(previous).join()
     }
 
     /**
      * Retires a replaced registration: stops its lifecycle work, then unbinds and shuts its provider
-     * down away from the caller's thread.
-     *
-     * `shutdown` is documented as releasing resources and threads, and `MultiProvider` fans it out
-     * over every child, so running it inline would make registering a provider block on the outgoing
-     * one's whole teardown. The scope it runs on is never cancelled, because a retirement that is
-     * dropped leaks the provider it was meant to release.
+     * down away from the caller's thread, since `shutdown` releases resources and threads.
      */
     private fun retire(retired: ProviderRegistration): Job {
         val cause = CancellationException("Provider registration was replaced")
         retired.providerJob?.cancel(cause)
         retired.contextSetJob?.cancel(cause)
         retired.scope.cancel(cause)
-        return retirementScope.launch { retireProvider(retired.provider) }
+        val job = retirementScope.launch(start = CoroutineStart.LAZY) { retireProvider(retired.provider) }
+        // Recorded before it can run, so a swap committing meanwhile finds it and waits for it.
+        synchronized(stateLock) { retirements += retired.provider to job }
+        job.invokeOnCompletion {
+            synchronized(stateLock) { retirements.removeAll { (_, pending) -> pending === job } }
+        }
+        job.start()
+        return job
     }
 
     /**
      * Unbinds a provider and shuts it down.
      *
      * Only for a provider that is actually being dropped: re-registering the same instance must not
-     * shut it down. A `CancellationException` from `shutdown` is logged rather than rethrown — it
-     * belongs to the provider being retired, not to whoever asked for the swap.
+     * shut it down, whether the registration was reused or this retirement was simply outrun.
      */
     private fun retireProvider(provider: FeatureProvider) {
-        untrackProviderBinding(provider)
+        val reRegistered = synchronized(stateLock) {
+            val reRegistered = registration.provider === provider
+            if (!reRegistered) untrackProviderBinding(provider)
+            reRegistered
+        }
+        if (reRegistered) return
         try {
             provider.shutdown()
         } catch (e: Throwable) {
@@ -302,59 +300,55 @@ open class OpenFeatureAPIInstance internal constructor() {
      * @param evaluationContext the [EvaluationContext] to set
      */
     fun setEvaluationContext(evaluationContext: EvaluationContext) {
-        // Started lazily so that superseding the previous job and recording this one are one step:
-        // otherwise two concurrent calls can leave one of the two jobs untracked and uncancellable.
-        // Only the fire-and-forget path supersedes its predecessor — an awaited context set must not
-        // cancel another awaited one, since overlapping reconciliations are legal and the provider
-        // collapses them into a single reported transition.
-        val job = updateContext(evaluationContext, CoroutineStart.LAZY) { current, job ->
+        // Only this path supersedes the previous reconciliation: overlapping awaited ones are legal.
+        updateContext(evaluationContext) { current, job ->
             current.contextSetJob?.cancel(
                 CancellationException("Set context job was cancelled due to new context")
             )
             current.contextSetJob = job
         }
-        job.start()
     }
 
     private fun updateContext(
         newContext: EvaluationContext,
-        start: CoroutineStart = CoroutineStart.DEFAULT,
         record: (ProviderRegistration, Job) -> Unit = { _, _ -> }
-    ): Job = synchronized(stateLock) {
-        val current = registration
-        val oldContext = context
-        context = newContext
+    ): Job {
+        // Created lazily so that committing the context, superseding the previous job and recording
+        // this one are one step, and started outside the lock so that an immediate dispatcher runs
+        // the provider's onContextSet without stateLock held.
+        val job = synchronized(stateLock) {
+            val current = registration
+            val oldContext = context
+            context = newContext
 
-        val job = current.dispatchLifecycle("onContextSet", start) {
-            current.provider.onContextSet(oldContext, newContext)
+            val job = current.dispatchLifecycle("onContextSet", CoroutineStart.LAZY) {
+                current.provider.onContextSet(oldContext, newContext)
+            }
+            record(current, job)
+            job
         }
-        record(current, job)
-        job
+        job.start()
+        return job
     }
 
     /**
-     * Awaits a lifecycle call, cancelling it if the caller is cancelled.
-     *
-     * The call runs on the registration's own scope so that its ordering does not depend on the
-     * caller, which means cancelling the caller would otherwise leave it running.
+     * Awaits a lifecycle call, cancelling it if the caller is cancelled: the call runs on the
+     * registration's own scope, so cancelling the caller would otherwise leave it running.
      */
     private suspend fun Job.joinPropagatingCancellation() {
         try {
             join()
         } catch (e: CancellationException) {
             cancel(e)
-            // Awaited so the provider has finished unwinding — and reported the outcome it owes the
-            // reconciliation — before the caller sees the cancellation.
+            // Awaited so the provider has reported the outcome it owes before the caller returns.
             withContext(NonCancellable) { join() }
             throw e
         }
     }
 
     /**
-     * Runs one of [provider]'s lifecycle calls.
-     *
-     * A throw is not a status signal — the provider owns its status — so it is logged and the status
-     * left alone. Cancellation still propagates, so structured concurrency and timeouts work.
+     * Runs one of [provider]'s lifecycle calls, logging a throw rather than deriving a status from
+     * it. Cancellation still propagates.
      */
     private fun ProviderRegistration.dispatchLifecycle(
         operation: String,
@@ -425,9 +419,8 @@ open class OpenFeatureAPIInstance internal constructor() {
     /**
      * Observe the events emitted by the currently configured provider.
      *
-     * Switches to the new provider on a swap, so a retired provider's events stop arriving. To handle
-     * one event type, narrow with the reified [observe] overload or with
-     * [kotlinx.coroutines.flow.filterIsInstance].
+     * Switches to the new provider on a swap, so a retired provider's events stop arriving. Narrow
+     * to one event type with the reified [observe] overload.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<OpenFeatureProviderEvents> =
@@ -435,10 +428,6 @@ open class OpenFeatureAPIInstance internal constructor() {
 
     /**
      * Claims [provider] for this instance.
-     *
-     * Two instances driving one provider would drive one [ProviderStatusTracker], leaving its status
-     * undefined, so this is a programming error rather than a provider failure — and with status
-     * owned by the provider there is no status channel left to report it on.
      *
      * @throws IllegalStateException if another instance already owns [provider]
      */

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -53,9 +53,16 @@ open class OpenFeatureAPIInstance internal constructor() {
     private class NoProvider : NoOpProvider()
 
     /**
-     * One registration of one provider, boxed so that [MutableStateFlow] never conflates two of
-     * them: a fresh box is never equal to its predecessor, so every swap restarts the subscriptions
-     * derived from it, which is what keeps a retired provider's events out of its successor's stream.
+     * One registration of one provider, boxed so that [MutableStateFlow] never conflates two
+     * registrations of *different* providers: a fresh box is never equal to its predecessor, so the
+     * swap restarts the subscriptions derived from it, which is what keeps a retired provider's
+     * events out of its successor's stream.
+     *
+     * Re-registering the same provider instance deliberately reuses its box, so no restart happens.
+     * That is correct rather than an oversight — it is the same provider and the same tracker, its
+     * subscribers are still attached, and a re-emitted status would be swallowed by
+     * `distinctUntilChanged` anyway. Allocating a second box would instead put the provider's next
+     * lifecycle call on an unrelated serial dispatcher and cancel the scope it is still running on.
      */
     private class ProviderRegistration(
         val provider: FeatureProvider,
@@ -79,6 +86,19 @@ open class OpenFeatureAPIInstance internal constructor() {
 
     private var registration = ProviderRegistration(NoProvider(), Dispatchers.Default)
     private val providerRegistrations = MutableStateFlow(registration)
+
+    /**
+     * Runs retirements, and is never cancelled: dropping one leaks the provider it was meant to
+     * release. Independent of any registration's scope, which a swap cancels.
+     */
+    private val retirementScope = CoroutineScope(
+        SupervisorJob() +
+            Dispatchers.Default +
+            // Retiring one provider must not fail whoever registered the next one.
+            CoroutineExceptionHandler { _, throwable ->
+                logger.warn({ "Retiring a replaced provider failed" }, throwable = throwable)
+            }
+    )
 
     private var context: EvaluationContext? = null
 
@@ -111,10 +131,13 @@ open class OpenFeatureAPIInstance internal constructor() {
 
     /**
      * Set the [FeatureProvider] for this instance. Returns once the provider is registered, having
-     * started its initialization; the provider reports readiness itself through its events.
+     * started its initialization; the provider reports readiness itself through its events. The
+     * outgoing provider is shut down in the background, so this does not wait for its teardown.
      *
      * @param provider the provider to set
-     * @param dispatcher the dispatcher this provider's lifecycle calls run on
+     * @param dispatcher the dispatcher this provider's lifecycle calls run on. Registering a provider
+     * that is already registered keeps the dispatcher it was first registered with, since its
+     * lifecycle calls have to stay ordered against each other on one dispatcher.
      * @param initialContext the initial [EvaluationContext] for provider initialization
      */
     fun setProvider(
@@ -143,9 +166,15 @@ open class OpenFeatureAPIInstance internal constructor() {
         initialContext: EvaluationContext? = null,
         dispatcher: CoroutineDispatcher? = null
     ) {
-        swapProvider(provider, initialContext, dispatcher ?: callerDispatcher())
-            .joinPropagatingCancellation()
+        val swap = swapProvider(provider, initialContext, dispatcher ?: callerDispatcher())
+        // The outgoing provider's teardown is awaited here, unlike on the fire-and-forget path: a
+        // suspending caller can be told that the provider it replaced is actually down.
+        swap.retirement?.join()
+        swap.initialization.joinPropagatingCancellation()
     }
+
+    /** The two pieces of work a swap starts: initializing the new provider, retiring the old one. */
+    private class Swap(val initialization: Job, val retirement: Job?)
 
     private suspend fun callerDispatcher(): CoroutineDispatcher =
         currentCoroutineContext()[ContinuationInterceptor] as? CoroutineDispatcher ?: Dispatchers.Default
@@ -154,29 +183,36 @@ open class OpenFeatureAPIInstance internal constructor() {
         newProvider: FeatureProvider,
         initialContext: EvaluationContext?,
         dispatcher: CoroutineDispatcher
-    ): Job {
+    ): Swap {
         trackProviderBinding(newProvider)
 
-        val next = ProviderRegistration(newProvider, dispatcher)
-        val (previous, initializationContext) = synchronized(stateLock) {
+        val (current, retired, initializationContext) = synchronized(stateLock) {
             val previous = registration
-            registration = next
+            // Re-registering the same instance reuses its registration. Allocating a second one would
+            // put this initialize on an unrelated serial dispatcher, so it would not be ordered
+            // against the provider's own in-flight work, and would cancel the scope that work runs on.
+            val rebinding = previous.provider === newProvider
+            val current = if (rebinding) previous else ProviderRegistration(newProvider, dispatcher)
+            registration = current
             if (initialContext != null) context = initialContext
             // Published under the same lock that commits the swap: otherwise two concurrent swaps can
             // leave evaluations on one provider and statusFlow/observe() pinned to the other.
-            providerRegistrations.value = next
-            previous to context
+            providerRegistrations.value = current
+            Triple(current, previous.takeUnless { rebinding }, context)
         }
 
         // Retired here rather than from the successor's job: that job can be cancelled before it is
         // ever dispatched, which would leave the outgoing provider running and never shut down.
-        release(previous)
-        if (previous.provider !== newProvider) retireProvider(previous.provider)
+        val retirement = retired?.let { retire(it) }
 
-        next.providerJob = next.dispatchLifecycle("initialize") {
+        // A rebind cancels neither of the provider's jobs. Its in-flight work is its own to supersede,
+        // which is the contract in FeatureProvider: calls are entered in order, and the SDK does not
+        // wait for one to finish before entering the next.
+        val initialization = current.dispatchLifecycle("initialize") {
             newProvider.initialize(initializationContext)
         }
-        return requireNotNull(next.providerJob)
+        synchronized(stateLock) { current.providerJob = initialization }
+        return Swap(initialization, retirement)
     }
 
     /**
@@ -205,19 +241,26 @@ open class OpenFeatureAPIInstance internal constructor() {
             providerRegistrations.value = next
             previous
         }
-        release(previous)
-        retireProvider(previous.provider)
+        // Awaited, unlike the fire-and-forget swap: this is a suspending call, so a caller asking for
+        // the provider to be cleared can be told when it actually has been.
+        retire(previous).join()
     }
 
     /**
-     * Stops a registration's lifecycle work, which every swap owes its predecessor — including one
-     * that re-registers the same provider instance, whose scope would otherwise be left running.
+     * Retires a replaced registration: stops its lifecycle work, then unbinds and shuts its provider
+     * down away from the caller's thread.
+     *
+     * `shutdown` is documented as releasing resources and threads, and `MultiProvider` fans it out
+     * over every child, so running it inline would make registering a provider block on the outgoing
+     * one's whole teardown. The scope it runs on is never cancelled, because a retirement that is
+     * dropped leaks the provider it was meant to release.
      */
-    private fun release(retired: ProviderRegistration) {
+    private fun retire(retired: ProviderRegistration): Job {
         val cause = CancellationException("Provider registration was replaced")
         retired.providerJob?.cancel(cause)
         retired.contextSetJob?.cancel(cause)
         retired.scope.cancel(cause)
+        return retirementScope.launch { retireProvider(retired.provider) }
     }
 
     /**

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -342,8 +342,8 @@ open class OpenFeatureAPIInstance internal constructor() {
     }
 
     /**
-     * Runs one of [provider]'s lifecycle calls, logging a throw rather than deriving a status from
-     * it. Cancellation still propagates.
+     * Runs one of the provider's lifecycle calls, logging a throw rather than deriving a status
+     * from it. Cancellation still propagates.
      */
     private fun ProviderRegistration.dispatchLifecycle(
         operation: String,

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -1,85 +1,112 @@
 package dev.openfeature.kotlin.sdk
 
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
-import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
-import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
+import dev.openfeature.kotlin.sdk.logging.LoggerFactory
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.ContinuationInterceptor
+
+private const val LOGGER_NAME = "OpenFeatureAPI"
 
 /**
  * Core implementation of the OpenFeature API.
  *
- * Each instance maintains its own independent state: provider, evaluation context, hooks, status,
- * and events. The global singleton [OpenFeatureAPI] is one such instance. To create isolated,
- * independent instances use
- * [dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance].
+ * Each instance maintains its own independent state: provider, evaluation context and hooks. The
+ * global singleton [OpenFeatureAPI] is one such instance. To create isolated, independent instances
+ * use [dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance].
+ *
+ * Status belongs to the registered provider, not to this instance: [getStatus] and [statusFlow] both
+ * read [FeatureProvider.status], and the SDK never sets it. The one exception is shutdown, where the
+ * SDK infers not-ready because it is the SDK that initiated the shutdown.
  *
  * @see OpenFeatureAPI
  * @see dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance
  */
 @Suppress("TooManyFunctions")
 open class OpenFeatureAPIInstance internal constructor() {
-    private data class ContextReconciliation(
-        val oldContext: EvaluationContext?,
-        val provider: FeatureProvider,
-        val providerGeneration: Long
-    )
-
-    private var setProviderJob: Job? = null
-    private var setEvaluationContextJob: Job? = null
-    private var observeProviderEventsJob: Job? = null
-
-    private val providerMutex = Mutex()
-    private val contextReconciliationMutex = Mutex()
+    private val logger = LoggerFactory.getLogger(LOGGER_NAME)
     private val stateLock = SynchronizedObject()
-    private val noOpProvider = NoOpProvider()
-    private var provider: FeatureProvider = noOpProvider
-    private var providerGeneration: Long = 0
+
+    /** The provider installed when none has been registered, or once one has been cleared. */
+    private class NoProvider : NoOpProvider()
+
+    /**
+     * One registration of one provider, boxed so that [MutableStateFlow] never conflates two of
+     * them: a fresh box is never equal to its predecessor, so every swap restarts the subscriptions
+     * derived from it, which is what keeps a retired provider's events out of its successor's stream.
+     */
+    private class ProviderRegistration(
+        val provider: FeatureProvider,
+        dispatcher: CoroutineDispatcher
+    ) {
+        /**
+         * Serial, so this provider's lifecycle calls are entered one at a time and in the order they
+         * were made. A call that suspends releases the dispatcher, so the SDK never waits for one
+         * lifecycle call to finish before entering the next.
+         */
+        @OptIn(ExperimentalCoroutinesApi::class)
+        val scope = CoroutineScope(
+            SupervisorJob() +
+                dispatcher.limitedParallelism(1) +
+                CoroutineExceptionHandler { _, _ -> /* reported by dispatchLifecycle */ }
+        )
+
+        var providerJob: Job? = null
+        var contextSetJob: Job? = null
+    }
+
+    private var registration = ProviderRegistration(NoProvider(), Dispatchers.Default)
+    private val providerRegistrations = MutableStateFlow(registration)
+
     private var context: EvaluationContext? = null
-    private var contextReconciliationGeneration: Long? = null
-    private var activeContextReconciliations: Int = 0
-    private var contextReconciliationInitialStatus: OpenFeatureStatus? = null
-    private var contextReconciliationTerminalStatus: OpenFeatureStatus? = null
-    private var providerStatusGeneration: Long = 0
-    private var contextReconciliationTerminalProviderStatusGeneration: Long? = null
-    val providersFlow: MutableStateFlow<FeatureProvider> = MutableStateFlow(noOpProvider)
-
-    private val _statusFlow: MutableSharedFlow<OpenFeatureStatus> =
-        MutableSharedFlow<OpenFeatureStatus>(replay = 1, extraBufferCapacity = 5)
-            .apply {
-                tryEmit(OpenFeatureStatus.NotReady)
-            }
-
-    val statusFlow: Flow<OpenFeatureStatus> get() = _statusFlow.distinctUntilChanged()
 
     var hooks: List<Hook<*>> = listOf()
         private set
 
     /**
-     * Set the [FeatureProvider] for this instance. Returns immediately and initializes the provider
-     * in a coroutine scope. When successfully initialized, status transitions to Ready.
+     * The status of the registered provider, and every transition it reports.
+     *
+     * A projection of [FeatureProvider.status], so it can never disagree with [getStatus]. A
+     * provider that reports nothing yields exactly one [OpenFeatureStatus.NotReady].
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val statusFlow: Flow<OpenFeatureStatus> = providerRegistrations
+        .flatMapLatest { current ->
+            // Per event, not by re-reading provider.status: two transitions reported back to back
+            // would otherwise both read the later status, and the earlier one would be lost.
+            current.provider.observe()
+                .mapNotNull { it.toOpenFeatureStatus() }
+                .onStart { emit(current.provider.status) }
+        }
+        .distinctUntilChanged()
+
+    /**
+     * Set the [FeatureProvider] for this instance. Returns once the provider is registered, having
+     * started its initialization; the provider reports readiness itself through its events.
      *
      * @param provider the provider to set
-     * @param dispatcher the dispatcher for the initialization coroutine
+     * @param dispatcher the dispatcher this provider's lifecycle calls run on
      * @param initialContext the initial [EvaluationContext] for provider initialization
      */
     fun setProvider(
@@ -87,271 +114,197 @@ open class OpenFeatureAPIInstance internal constructor() {
         dispatcher: CoroutineDispatcher = Dispatchers.Default,
         initialContext: EvaluationContext? = null
     ) {
-        setProviderJob?.cancel(CancellationException("Provider set job was cancelled due to new provider"))
-        this.setProviderJob = CoroutineScope(SupervisorJob() + dispatcher).launch {
-            setProviderInternal(provider, dispatcher, initialContext)
-        }
+        swapProvider(provider, initialContext, dispatcher)
     }
 
     /**
-     * Set the [FeatureProvider] for this instance. Suspends until the provider is initialized.
+     * Set the [FeatureProvider] for this instance, suspending until its `initialize` has terminated.
+     *
+     * A provider reports its own outcome, so this does not throw when initialization fails: the
+     * failure arrives as an [OpenFeatureProviderEvents.ProviderError] and as
+     * [OpenFeatureStatus.Error]. A provider that throws without reporting anything stays
+     * [OpenFeatureStatus.NotReady], and the failure is logged.
      *
      * @param provider the [FeatureProvider] to set
      * @param initialContext the initial [EvaluationContext] for provider initialization
-     * @param dispatcher the dispatcher for event observation
+     * @param dispatcher the dispatcher this provider's lifecycle calls run on; the caller's own
+     * dispatcher by default, so that a caller controlling time controls the provider's lifecycle too
      */
     suspend fun setProviderAndWait(
         provider: FeatureProvider,
         initialContext: EvaluationContext? = null,
-        dispatcher: CoroutineDispatcher = Dispatchers.Default
+        dispatcher: CoroutineDispatcher? = null
     ) {
-        setProviderInternal(provider, dispatcher, initialContext)
+        swapProvider(provider, initialContext, dispatcher ?: callerDispatcher())
+            .joinPropagatingCancellation()
     }
 
-    private fun listenToProviderEvents(provider: FeatureProvider, dispatcher: CoroutineDispatcher) {
-        observeProviderEventsJob?.cancel(CancellationException("Provider job was cancelled due to new provider"))
-        this.observeProviderEventsJob = CoroutineScope(SupervisorJob() + dispatcher).launch {
-            provider.observe().collect(handleProviderEvents)
-        }
-    }
+    private suspend fun callerDispatcher(): CoroutineDispatcher =
+        currentCoroutineContext()[ContinuationInterceptor] as? CoroutineDispatcher ?: Dispatchers.Default
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private suspend fun setProviderInternal(
-        provider: FeatureProvider,
-        dispatcher: CoroutineDispatcher,
-        initialContext: EvaluationContext? = null
-    ) {
-        try {
-            trackProviderBinding(provider)
-        } catch (e: Throwable) {
-            _statusFlow.emit(
-                OpenFeatureStatus.Error(
-                    OpenFeatureError.GeneralError(e.message ?: "Unknown error")
-                )
+    private fun swapProvider(
+        newProvider: FeatureProvider,
+        initialContext: EvaluationContext?,
+        dispatcher: CoroutineDispatcher
+    ): Job {
+        trackProviderBinding(newProvider)
+
+        val next = ProviderRegistration(newProvider, dispatcher)
+        val (previous, initializationContext) = synchronized(stateLock) {
+            val previous = registration
+            previous.providerJob?.cancel(
+                CancellationException("Provider set job was cancelled due to new provider")
             )
-            return
+            registration = next
+            if (initialContext != null) context = initialContext
+            previous to context
         }
+        providerRegistrations.value = next
 
-        // Track whether the swap committed so a mid-flight cancellation can roll back the binding.
-        var swapCommitted = false
-        try {
-            // Atomically swap the old and new provider to prevent race conditions
-            val oldProvider = providerMutex.withLock {
-                synchronized(stateLock) {
-                    val current = this.provider
-                    this.provider = provider
-                    providerGeneration++
-                    providersFlow.value = provider
-                    if (initialContext != null) context = initialContext
-                    current
-                }
-            }
-            swapCommitted = true
-
-            // Emit NotReady status after swapping provider
-            _statusFlow.emit(OpenFeatureStatus.NotReady)
-
-            // Shutdown the previous provider outside the mutex
-            if (oldProvider !== provider) {
-                tryWithStatusEmitErrorHandling {
-                    untrackProviderBinding(oldProvider)
-                    oldProvider.shutdown()
-                }
-            }
-
-            // Initialize the new provider
-            tryWithStatusEmitErrorHandling {
-                listenToProviderEvents(provider, dispatcher)
-                val state = getEvaluationState()
-                state.provider.initialize(state.context)
-                _statusFlow.emit(OpenFeatureStatus.Ready)
-            }
-        } catch (e: CancellationException) {
-            // if cancellation hit before we committed the swap, release the binding we just claimed
-            // so the provider can be re-registered elsewhere.
-            if (!swapCommitted) {
-                withContext(NonCancellable) {
-                    untrackProviderBinding(provider)
-                }
-            }
-            throw e
+        next.providerJob = next.dispatchLifecycle("initialize") {
+            if (previous.provider !== newProvider) retire(previous)
+            newProvider.initialize(initializationContext)
         }
+        return requireNotNull(next.providerJob)
     }
 
     /**
      * Get the current [FeatureProvider] for this instance.
      */
-    fun getProvider(): FeatureProvider {
-        return synchronized(stateLock) { provider }
-    }
+    fun getProvider(): FeatureProvider = synchronized(stateLock) { registration.provider }
 
     /**
-     * Snapshot of the current provider and evaluation context for synchronous client operations.
+     * Snapshot of the provider, evaluation context and hooks for synchronous client operations.
      */
-    internal fun getEvaluationState(): EvaluationState {
-        return synchronized(stateLock) {
-            EvaluationState(provider, context)
-        }
+    internal fun getEvaluationState(): EvaluationState = synchronized(stateLock) {
+        EvaluationState(registration.provider, context, hooks)
     }
 
     /**
      * Clear the current [FeatureProvider] and reset to a no-op provider.
+     *
+     * Installs a provider that was never initialized, so the status is not-ready once this returns,
+     * as requirement 1.7.6 asks: the SDK initiated the shutdown, so no provider event is involved.
      */
     suspend fun clearProvider() {
-        val oldProvider = providerMutex.withLock {
-            synchronized(stateLock) {
-                val current = this.provider
-                this.provider = noOpProvider
-                providerGeneration++
-                providersFlow.value = noOpProvider
-                current
-            }
+        val next = ProviderRegistration(NoProvider(), Dispatchers.Default)
+        val previous = synchronized(stateLock) {
+            val previous = registration
+            previous.providerJob?.cancel(CancellationException("Provider set job was cancelled due to clearProvider"))
+            previous.contextSetJob?.cancel(
+                CancellationException("Set context job was cancelled due to clearProvider")
+            )
+            registration = next
+            previous
         }
-        untrackProviderBinding(oldProvider)
-        oldProvider.shutdown()
-        _statusFlow.emit(OpenFeatureStatus.NotReady)
+        providerRegistrations.value = next
+        retire(previous)
+    }
+
+    /** Releases a retired registration: unbinds it, shuts its provider down, and stops its scope. */
+    private fun retire(retired: ProviderRegistration) {
+        val provider = retired.provider
+        untrackProviderBinding(provider)
+        try {
+            provider.shutdown()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.warn({ "Provider ${provider.attributionName()} failed to shut down" }, throwable = e)
+        } finally {
+            retired.scope.cancel(CancellationException("Provider scope cancelled: provider was retired"))
+        }
     }
 
     /**
-     * Set the [EvaluationContext] for this instance. Suspends until the context is set and the
-     * provider has reconciled.
+     * Set the [EvaluationContext] for this instance, suspending until the provider's `onContextSet`
+     * has terminated.
+     *
+     * The provider reports the transitions around its own reconciliation, so a provider still
+     * reconciling in the background leaves the status [OpenFeatureStatus.Reconciling] when this
+     * returns.
      *
      * @param evaluationContext the [EvaluationContext] to set
      */
     suspend fun setEvaluationContextAndWait(evaluationContext: EvaluationContext) {
-        setEvaluationContextInternal(evaluationContext)
+        updateContext(evaluationContext).joinPropagatingCancellation()
     }
 
     /**
-     * Set the [EvaluationContext] for this instance. Returns immediately and sets the context
-     * in a coroutine scope.
+     * Set the [EvaluationContext] for this instance. Returns once the reconciliation has started.
      *
      * @param evaluationContext the [EvaluationContext] to set
-     * @param dispatcher the dispatcher for the context-set coroutine
+     * @param dispatcher unused: reconciliation runs on the dispatcher the provider was registered
+     * with, so that it is ordered against that provider's `initialize`
      */
+    @Suppress("UNUSED_PARAMETER")
     fun setEvaluationContext(
         evaluationContext: EvaluationContext,
         dispatcher: CoroutineDispatcher = Dispatchers.Default
     ) {
-        setEvaluationContextJob?.cancel(CancellationException("Set context job was cancelled due to new context"))
-        this.setEvaluationContextJob = CoroutineScope(SupervisorJob() + dispatcher).launch {
-            setEvaluationContextInternal(evaluationContext)
+        // Only the fire-and-forget path supersedes its predecessor. An awaited context set must not
+        // cancel another awaited one: overlapping reconciliations are legal, and the provider
+        // collapses them into a single reported transition.
+        synchronized(stateLock) {
+            registration.contextSetJob?.cancel(
+                CancellationException("Set context job was cancelled due to new context")
+            )
+        }
+        val job = updateContext(evaluationContext)
+        synchronized(stateLock) { registration.contextSetJob = job }
+    }
+
+    private fun updateContext(newContext: EvaluationContext): Job {
+        val (current, oldContext) = synchronized(stateLock) {
+            val current = registration
+            val oldContext = context
+            context = newContext
+            current to oldContext
+        }
+
+        return current.dispatchLifecycle("onContextSet") {
+            current.provider.onContextSet(oldContext, newContext)
         }
     }
 
-    private suspend fun setEvaluationContextInternal(evaluationContext: EvaluationContext) {
-        var reconciliation: ContextReconciliation? = null
-        var terminalStatus: OpenFeatureStatus? = null
+    /**
+     * Awaits a lifecycle call, cancelling it if the caller is cancelled.
+     *
+     * The call runs on the registration's own scope so that its ordering does not depend on the
+     * caller, which means cancelling the caller would otherwise leave it running.
+     */
+    private suspend fun Job.joinPropagatingCancellation() {
         try {
-            contextReconciliationMutex.withLock {
-                providerMutex.withLock {
-                    var shouldEmitReconciling = false
-                    synchronized(stateLock) {
-                        val oldContext = context
-                        context = evaluationContext
-                        if (provider !== noOpProvider) {
-                            reconciliation = ContextReconciliation(oldContext, provider, providerGeneration)
-                            if (contextReconciliationGeneration != providerGeneration) {
-                                contextReconciliationGeneration = providerGeneration
-                                activeContextReconciliations = 0
-                            }
-                            if (activeContextReconciliations == 0) {
-                                contextReconciliationInitialStatus = getStatus()
-                                contextReconciliationTerminalStatus = null
-                                contextReconciliationTerminalProviderStatusGeneration = null
-                            }
-                            activeContextReconciliations++
-                            shouldEmitReconciling = activeContextReconciliations == 1
-                        }
-                    }
-                    if (shouldEmitReconciling) {
-                        _statusFlow.emit(OpenFeatureStatus.Reconciling)
-                    }
-                }
-            }
-
-            val registeredReconciliation = reconciliation ?: return
-            registeredReconciliation.provider.onContextSet(
-                registeredReconciliation.oldContext,
-                evaluationContext
-            )
-            terminalStatus = OpenFeatureStatus.Ready
+            join()
         } catch (e: CancellationException) {
-            // This happens by design and shouldn't be treated as an error
-        } catch (e: OpenFeatureError) {
-            terminalStatus = OpenFeatureStatus.Error(e)
-        } catch (e: Throwable) {
-            terminalStatus = OpenFeatureStatus.Error(
-                OpenFeatureError.GeneralError(e.message ?: "Unknown error")
-            )
-        } finally {
-            val registeredReconciliation = reconciliation
-            if (registeredReconciliation != null) {
-                withContext(NonCancellable) {
-                    completeContextReconciliation(
-                        registeredReconciliation.provider,
-                        registeredReconciliation.providerGeneration,
-                        terminalStatus
-                    )
-                }
-            }
+            cancel(e)
+            // Awaited so the provider has finished unwinding — and reported the outcome it owes the
+            // reconciliation — before the caller sees the cancellation.
+            withContext(NonCancellable) { join() }
+            throw e
         }
     }
 
-    private suspend fun completeContextReconciliation(
-        reconciliationProvider: FeatureProvider,
-        reconciliationProviderGeneration: Long,
-        terminalStatus: OpenFeatureStatus?
-    ) {
-        contextReconciliationMutex.withLock {
-            if (contextReconciliationGeneration != reconciliationProviderGeneration) return
-
-            if (terminalStatus != null) {
-                contextReconciliationTerminalStatus = terminalStatus
-                contextReconciliationTerminalProviderStatusGeneration = providerStatusGeneration
-            }
-            activeContextReconciliations--
-            if (activeContextReconciliations == 0) {
-                val retainedTerminalStatus = contextReconciliationTerminalStatus
-                val statusToEmit = retainedTerminalStatus ?: contextReconciliationInitialStatus
-                val shouldEmitStatus = if (retainedTerminalStatus != null) {
-                    contextReconciliationTerminalProviderStatusGeneration == providerStatusGeneration
-                } else {
-                    getStatus() is OpenFeatureStatus.Reconciling
-                }
-                contextReconciliationInitialStatus = null
-                contextReconciliationTerminalStatus = null
-                contextReconciliationTerminalProviderStatusGeneration = null
-
-                providerMutex.withLock {
-                    if (
-                        synchronized(stateLock) { provider === reconciliationProvider } &&
-                        providerGeneration == reconciliationProviderGeneration &&
-                        statusToEmit != null &&
-                        shouldEmitStatus
-                    ) {
-                        _statusFlow.emit(statusToEmit)
-                    }
-                }
-            }
-        }
-    }
-
-    private suspend fun tryWithStatusEmitErrorHandling(function: suspend () -> Unit) {
+    /**
+     * Runs one of [provider]'s lifecycle calls.
+     *
+     * A throw is not a status signal — the provider owns its status — so it is logged and the status
+     * left alone. Cancellation still propagates, so structured concurrency and timeouts work.
+     */
+    private fun ProviderRegistration.dispatchLifecycle(
+        operation: String,
+        work: suspend () -> Unit
+    ): Job = scope.launch {
         try {
-            function()
+            work()
         } catch (e: CancellationException) {
-            // This happens by design and shouldn't be treated as an error
-        } catch (e: OpenFeatureError) {
-            _statusFlow.emit(OpenFeatureStatus.Error(e))
+            throw e
         } catch (e: Throwable) {
-            _statusFlow.emit(
-                OpenFeatureStatus.Error(
-                    OpenFeatureError.GeneralError(
-                        e.message ?: "Unknown error"
-                    )
-                )
-            )
+            logger.warn({
+                "Provider ${provider.attributionName()} failed during $operation. The SDK does not " +
+                    "derive status from a thrown exception: report the failure by emitting a " +
+                    "ProviderError event."
+            }, throwable = e)
         }
     }
 
@@ -380,14 +333,14 @@ open class OpenFeatureAPIInstance internal constructor() {
      * Add [Hook]s to this instance.
      */
     fun addHooks(hooks: List<Hook<*>>) {
-        this.hooks += hooks
+        synchronized(stateLock) { this.hooks += hooks }
     }
 
     /**
      * Clear all [Hook]s from this instance.
      */
     fun clearHooks() {
-        this.hooks = listOf()
+        synchronized(stateLock) { this.hooks = listOf() }
     }
 
     /**
@@ -395,59 +348,37 @@ open class OpenFeatureAPIInstance internal constructor() {
      */
     suspend fun shutdown() {
         clearHooks()
-        setEvaluationContextJob?.cancel(CancellationException("Set context job was cancelled due to shutdown"))
-        setProviderJob?.cancel(CancellationException("Provider set job was cancelled due to shutdown"))
-        observeProviderEventsJob?.cancel(
-            CancellationException("Provider event observe job was cancelled due to shutdown")
-        )
         clearProvider()
     }
 
     /**
-     * Get the current [OpenFeatureStatus] of this instance.
+     * Get the current [OpenFeatureStatus] of this instance, as reported by its provider.
      */
-    fun getStatus(): OpenFeatureStatus = _statusFlow.replayCache.first()
+    fun getStatus(): OpenFeatureStatus = getProvider().status
 
     /**
-     * Observe events from the currently configured Provider.
+     * Observe the events emitted by the currently configured provider.
+     *
+     * Switches to the new provider on a swap, so a retired provider's events stop arriving. To handle
+     * one event type, narrow with the reified [observe] overload or with
+     * [kotlinx.coroutines.flow.filterIsInstance].
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    inline fun <reified T : OpenFeatureProviderEvents> observe(): Flow<T> = providersFlow
-        .flatMapLatest { it.observe() }.filterIsInstance()
+    fun observe(): Flow<OpenFeatureProviderEvents> =
+        providerRegistrations.flatMapLatest { it.provider.observe() }
 
     /**
-     * Aligning the state management to
-     * https://openfeature.dev/specification/sections/events#requirement-535
+     * Claims [provider] for this instance.
+     *
+     * Two instances driving one provider would drive one [ProviderStatusTracker], leaving its status
+     * undefined, so this is a programming error rather than a provider failure — and with status
+     * owned by the provider there is no status channel left to report it on.
+     *
+     * @throws IllegalStateException if another instance already owns [provider]
      */
-    private val handleProviderEvents: FlowCollector<OpenFeatureProviderEvents> = FlowCollector { providerEvent ->
-        when (providerEvent) {
-            is OpenFeatureProviderEvents.ProviderReady -> {
-                emitProviderStatus(OpenFeatureStatus.Ready)
-            }
-
-            is OpenFeatureProviderEvents.ProviderStale -> {
-                emitProviderStatus(OpenFeatureStatus.Stale)
-            }
-
-            is OpenFeatureProviderEvents.ProviderError -> {
-                emitProviderStatus(providerEvent.toOpenFeatureStatusError())
-            }
-
-            else -> { // All other states should not be emitted from here
-            }
-        }
-    }
-
-    private suspend fun emitProviderStatus(status: OpenFeatureStatus) {
-        contextReconciliationMutex.withLock {
-            providerStatusGeneration++
-            _statusFlow.emit(status)
-        }
-    }
-
-    private suspend fun trackProviderBinding(provider: FeatureProvider) {
-        if (provider === noOpProvider) return
-        bindingMutex.withLock {
+    private fun trackProviderBinding(provider: FeatureProvider) {
+        if (provider is NoProvider) return
+        synchronized(bindingLock) {
             val existingOwner = boundProviders.findOwner(provider)
             if (existingOwner != null && existingOwner !== this) {
                 throw IllegalStateException(
@@ -459,9 +390,9 @@ open class OpenFeatureAPIInstance internal constructor() {
         }
     }
 
-    private suspend fun untrackProviderBinding(provider: FeatureProvider) {
-        if (provider === noOpProvider) return
-        bindingMutex.withLock {
+    private fun untrackProviderBinding(provider: FeatureProvider) {
+        if (provider is NoProvider) return
+        synchronized(bindingLock) {
             if (boundProviders.findOwner(provider) === this) {
                 boundProviders.removeProvider(provider)
             }
@@ -475,7 +406,7 @@ open class OpenFeatureAPIInstance internal constructor() {
          * when providers implement equals/hashCode.
          */
         private val boundProviders = IdentityRegistry()
-        private val bindingMutex = Mutex()
+        private val bindingLock = SynchronizedObject()
 
         /**
          * Clear all provider bindings. Intended for test isolation only.
@@ -485,6 +416,17 @@ open class OpenFeatureAPIInstance internal constructor() {
         }
     }
 }
+
+/**
+ * Observe one type of event from the currently configured provider.
+ *
+ * The unparameterised [OpenFeatureAPIInstance.observe] yields every event; this narrows it.
+ */
+inline fun <reified T : OpenFeatureProviderEvents> OpenFeatureAPIInstance.observe(): Flow<T> =
+    observe().filterIsInstance()
+
+/** Provider name for a log line, or null: naming a provider must never fail a registration. */
+internal fun FeatureProvider.attributionName(): String? = runCatching { metadata.name }.getOrNull()
 
 /**
  * Simple identity-based registry. All lookups use referential equality (===) so that

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -21,8 +22,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.ContinuationInterceptor
@@ -93,10 +94,17 @@ open class OpenFeatureAPIInstance internal constructor() {
     @OptIn(ExperimentalCoroutinesApi::class)
     val statusFlow: Flow<OpenFeatureStatus> = providerRegistrations
         .flatMapLatest { current ->
-            // Per event, not by re-reading provider.status: two transitions reported back to back
-            // would otherwise both read the later status, and the earlier one would be lost.
             current.provider.observe()
-                .mapNotNull { it.toOpenFeatureStatus() }
+                .transform { event ->
+                    // The event's own status, not a re-read of provider.status: two transitions
+                    // reported back to back would otherwise both read the later one.
+                    val reported = event.toOpenFeatureStatus()
+                    reported?.let { emit(it) }
+                    // Then catch up, so a subscriber whose buffer overflowed and lost an event still
+                    // converges on the truth at the next one rather than staying behind for good.
+                    val live = current.provider.status
+                    if (live != reported) emit(live)
+                }
                 .onStart { emit(current.provider.status) }
         }
         .distinctUntilChanged()
@@ -152,17 +160,20 @@ open class OpenFeatureAPIInstance internal constructor() {
         val next = ProviderRegistration(newProvider, dispatcher)
         val (previous, initializationContext) = synchronized(stateLock) {
             val previous = registration
-            previous.providerJob?.cancel(
-                CancellationException("Provider set job was cancelled due to new provider")
-            )
             registration = next
             if (initialContext != null) context = initialContext
+            // Published under the same lock that commits the swap: otherwise two concurrent swaps can
+            // leave evaluations on one provider and statusFlow/observe() pinned to the other.
+            providerRegistrations.value = next
             previous to context
         }
-        providerRegistrations.value = next
+
+        // Retired here rather than from the successor's job: that job can be cancelled before it is
+        // ever dispatched, which would leave the outgoing provider running and never shut down.
+        release(previous)
+        if (previous.provider !== newProvider) retireProvider(previous.provider)
 
         next.providerJob = next.dispatchLifecycle("initialize") {
-            if (previous.provider !== newProvider) retire(previous)
             newProvider.initialize(initializationContext)
         }
         return requireNotNull(next.providerJob)
@@ -190,29 +201,38 @@ open class OpenFeatureAPIInstance internal constructor() {
         val next = ProviderRegistration(NoProvider(), Dispatchers.Default)
         val previous = synchronized(stateLock) {
             val previous = registration
-            previous.providerJob?.cancel(CancellationException("Provider set job was cancelled due to clearProvider"))
-            previous.contextSetJob?.cancel(
-                CancellationException("Set context job was cancelled due to clearProvider")
-            )
             registration = next
+            providerRegistrations.value = next
             previous
         }
-        providerRegistrations.value = next
-        retire(previous)
+        release(previous)
+        retireProvider(previous.provider)
     }
 
-    /** Releases a retired registration: unbinds it, shuts its provider down, and stops its scope. */
-    private fun retire(retired: ProviderRegistration) {
-        val provider = retired.provider
+    /**
+     * Stops a registration's lifecycle work, which every swap owes its predecessor — including one
+     * that re-registers the same provider instance, whose scope would otherwise be left running.
+     */
+    private fun release(retired: ProviderRegistration) {
+        val cause = CancellationException("Provider registration was replaced")
+        retired.providerJob?.cancel(cause)
+        retired.contextSetJob?.cancel(cause)
+        retired.scope.cancel(cause)
+    }
+
+    /**
+     * Unbinds a provider and shuts it down.
+     *
+     * Only for a provider that is actually being dropped: re-registering the same instance must not
+     * shut it down. A `CancellationException` from `shutdown` is logged rather than rethrown — it
+     * belongs to the provider being retired, not to whoever asked for the swap.
+     */
+    private fun retireProvider(provider: FeatureProvider) {
         untrackProviderBinding(provider)
         try {
             provider.shutdown()
-        } catch (e: CancellationException) {
-            throw e
         } catch (e: Throwable) {
             logger.warn({ "Provider ${provider.attributionName()} failed to shut down" }, throwable = e)
-        } finally {
-            retired.scope.cancel(CancellationException("Provider scope cancelled: provider was retired"))
         }
     }
 
@@ -233,38 +253,40 @@ open class OpenFeatureAPIInstance internal constructor() {
     /**
      * Set the [EvaluationContext] for this instance. Returns once the reconciliation has started.
      *
+     * Reconciliation runs on the dispatcher the provider was registered with, so that it is ordered
+     * against that provider's `initialize`.
+     *
      * @param evaluationContext the [EvaluationContext] to set
-     * @param dispatcher unused: reconciliation runs on the dispatcher the provider was registered
-     * with, so that it is ordered against that provider's `initialize`
      */
-    @Suppress("UNUSED_PARAMETER")
-    fun setEvaluationContext(
-        evaluationContext: EvaluationContext,
-        dispatcher: CoroutineDispatcher = Dispatchers.Default
-    ) {
-        // Only the fire-and-forget path supersedes its predecessor. An awaited context set must not
-        // cancel another awaited one: overlapping reconciliations are legal, and the provider
+    fun setEvaluationContext(evaluationContext: EvaluationContext) {
+        // Started lazily so that superseding the previous job and recording this one are one step:
+        // otherwise two concurrent calls can leave one of the two jobs untracked and uncancellable.
+        // Only the fire-and-forget path supersedes its predecessor — an awaited context set must not
+        // cancel another awaited one, since overlapping reconciliations are legal and the provider
         // collapses them into a single reported transition.
-        synchronized(stateLock) {
-            registration.contextSetJob?.cancel(
+        val job = updateContext(evaluationContext, CoroutineStart.LAZY) { current, job ->
+            current.contextSetJob?.cancel(
                 CancellationException("Set context job was cancelled due to new context")
             )
+            current.contextSetJob = job
         }
-        val job = updateContext(evaluationContext)
-        synchronized(stateLock) { registration.contextSetJob = job }
+        job.start()
     }
 
-    private fun updateContext(newContext: EvaluationContext): Job {
-        val (current, oldContext) = synchronized(stateLock) {
-            val current = registration
-            val oldContext = context
-            context = newContext
-            current to oldContext
-        }
+    private fun updateContext(
+        newContext: EvaluationContext,
+        start: CoroutineStart = CoroutineStart.DEFAULT,
+        record: (ProviderRegistration, Job) -> Unit = { _, _ -> }
+    ): Job = synchronized(stateLock) {
+        val current = registration
+        val oldContext = context
+        context = newContext
 
-        return current.dispatchLifecycle("onContextSet") {
+        val job = current.dispatchLifecycle("onContextSet", start) {
             current.provider.onContextSet(oldContext, newContext)
         }
+        record(current, job)
+        job
     }
 
     /**
@@ -293,8 +315,9 @@ open class OpenFeatureAPIInstance internal constructor() {
      */
     private fun ProviderRegistration.dispatchLifecycle(
         operation: String,
+        start: CoroutineStart = CoroutineStart.DEFAULT,
         work: suspend () -> Unit
-    ): Job = scope.launch {
+    ): Job = scope.launch(start = start) {
         try {
             work()
         } catch (e: CancellationException) {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureAPIInstance.kt
@@ -159,13 +159,8 @@ open class OpenFeatureAPIInstance internal constructor() {
     /** The two pieces of work a swap starts: initializing the new provider, retiring the old one. */
     private class Swap(val initialization: Job, val retirement: Job?)
 
-    /** What a swap decides under [stateLock], so the rest of it can run without holding the lock. */
-    private class Commit(
-        val current: ProviderRegistration,
-        val retired: ProviderRegistration?,
-        val initializationContext: EvaluationContext?,
-        val pendingRetirements: List<Job>
-    )
+    /** What a swap decides under [stateLock], so retirement can run without holding the lock. */
+    private class Commit(val current: ProviderRegistration, val retired: ProviderRegistration?)
 
     private suspend fun callerDispatcher(): CoroutineDispatcher =
         currentCoroutineContext()[ContinuationInterceptor] as? CoroutineDispatcher ?: Dispatchers.Default
@@ -175,6 +170,7 @@ open class OpenFeatureAPIInstance internal constructor() {
         initialContext: EvaluationContext?,
         dispatcher: CoroutineDispatcher
     ): Swap {
+        lateinit var initialization: Job
         val commit = synchronized(stateLock) {
             // Claimed under the lock that commits the swap, so a retirement of an earlier
             // registration of this same provider cannot unbind what is about to be published.
@@ -189,24 +185,23 @@ open class OpenFeatureAPIInstance internal constructor() {
             // Published under the lock that commits the swap, or two concurrent swaps can leave
             // evaluations on one provider and statusFlow pinned to the other.
             providerRegistrations.value = current
-            Commit(
-                current = current,
-                retired = previous.takeUnless { rebinding },
-                initializationContext = context,
-                pendingRetirements = retirements.filter { it.first === newProvider }.map { it.second }
-            )
+            val initializationContext = context
+            val pendingRetirements = retirements.filter { it.first === newProvider }.map { it.second }
+            // Dispatched before the lock is released, or a setEvaluationContext that acquires the
+            // lock right after this one could queue onContextSet ahead of initialize on the
+            // registration's serial scope.
+            initialization = current.dispatchLifecycle("initialize") {
+                // A retirement of this provider that already committed to shutting it down is still
+                // running: initializing over it would race its teardown.
+                pendingRetirements.forEach { it.join() }
+                newProvider.initialize(initializationContext)
+            }
+            current.providerJob = initialization
+            Commit(current = current, retired = previous.takeUnless { rebinding })
         }
 
         // Not from the successor's job, which can be cancelled before it is ever dispatched.
         val retirement = commit.retired?.let { retire(it) }
-
-        val initialization = commit.current.dispatchLifecycle("initialize") {
-            // A retirement of this provider that already committed to shutting it down is still
-            // running: initializing over it would race its teardown.
-            commit.pendingRetirements.forEach { it.join() }
-            newProvider.initialize(commit.initializationContext)
-        }
-        synchronized(stateLock) { commit.current.providerJob = initialization }
         return Swap(initialization, retirement)
     }
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
@@ -10,7 +10,6 @@ import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.GeneralError
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 
 private val typeMatchingException =
@@ -30,7 +29,6 @@ class OpenFeatureClient(
 
     override val statusFlow = openFeatureAPI.statusFlow
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     override fun observe(): Flow<OpenFeatureProviderEvents> = openFeatureAPI.observe()
 
     override fun getBooleanValue(key: String, defaultValue: Boolean): Boolean {

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureClient.kt
@@ -31,8 +31,7 @@ class OpenFeatureClient(
     override val statusFlow = openFeatureAPI.statusFlow
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun observe(): Flow<OpenFeatureProviderEvents> =
-        openFeatureAPI.observe<OpenFeatureProviderEvents>()
+    override fun observe(): Flow<OpenFeatureProviderEvents> = openFeatureAPI.observe()
 
     override fun getBooleanValue(key: String, defaultValue: Boolean): Boolean {
         return getBooleanDetails(key, defaultValue).value
@@ -213,7 +212,8 @@ class OpenFeatureClient(
         var details = FlagEvaluationDetails(key, defaultValue)
         val state = openFeatureAPI.getEvaluationState()
         val provider = state.provider
-        val mergedHooks: List<Hook<*>> = provider.hooks + options.hooks + hooks + openFeatureAPI.hooks
+        // One snapshot, so a concurrent addHooks cannot be observed half-applied mid-evaluation.
+        val mergedHooks: List<Hook<*>> = provider.hooks + options.hooks + hooks + state.hooks
         val context = state.context
         val hooksWithContext: List<Pair<Hook<*>, HookContext<T>>> =
             mergedHooks
@@ -231,7 +231,6 @@ class OpenFeatureClient(
                 }
         try {
             hookSupport.beforeHooks(flagValueType, hooksWithContext, hints)
-            shortCircuitIfNotReady()
             val providerEval = createProviderEvaluation(
                 flagValueType,
                 key,
@@ -258,15 +257,6 @@ class OpenFeatureClient(
         }
         hookSupport.afterAllHooks(flagValueType, details, hooksWithContext, hints)
         return details
-    }
-
-    private fun shortCircuitIfNotReady() {
-        val providerStatus = openFeatureAPI.getStatus()
-        if (providerStatus == OpenFeatureStatus.NotReady) {
-            throw OpenFeatureError.ProviderNotReadyError()
-        } else if (providerStatus is OpenFeatureStatus.Fatal) {
-            throw OpenFeatureError.ProviderFatalError()
-        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureStatus.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureStatus.kt
@@ -15,13 +15,27 @@ sealed interface OpenFeatureStatus {
 
     /**
      * The provider is in an error state and unable to evaluate flags.
+     *
+     * Compared by the failure it describes rather than by identity, so that the same failure
+     * reported twice — a live event and the status replayed to a late subscriber, say — is one
+     * status rather than two.
      */
-    class Error(val error: OpenFeatureError) : OpenFeatureStatus
+    class Error(val error: OpenFeatureError) : OpenFeatureStatus {
+        override fun equals(other: Any?): Boolean = other is Error && describesSameError(error, other.error)
+
+        override fun hashCode(): Int = errorHashCode(error)
+    }
 
     /**
      * The provider has entered an irrecoverable error state.
+     *
+     * Compared by the failure it describes, as [Error] is.
      */
-    class Fatal(val error: OpenFeatureError) : OpenFeatureStatus
+    class Fatal(val error: OpenFeatureError) : OpenFeatureStatus {
+        override fun equals(other: Any?): Boolean = other is Fatal && describesSameError(error, other.error)
+
+        override fun hashCode(): Int = errorHashCode(error)
+    }
 
     /**
      * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
@@ -33,3 +47,9 @@ sealed interface OpenFeatureStatus {
      */
     object Reconciling : OpenFeatureStatus
 }
+
+private fun describesSameError(left: OpenFeatureError, right: OpenFeatureError): Boolean =
+    left.errorCode() == right.errorCode() && left.message == right.message
+
+private fun errorHashCode(error: OpenFeatureError): Int =
+    31 * error.errorCode().hashCode() + error.message.hashCode()

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureStatus.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/OpenFeatureStatus.kt
@@ -16,9 +16,7 @@ sealed interface OpenFeatureStatus {
     /**
      * The provider is in an error state and unable to evaluate flags.
      *
-     * Compared by the failure it describes rather than by identity, so that the same failure
-     * reported twice — a live event and the status replayed to a late subscriber, say — is one
-     * status rather than two.
+     * Compared by the failure it describes, so the same failure reported twice is one status.
      */
     class Error(val error: OpenFeatureError) : OpenFeatureStatus {
         override fun equals(other: Any?): Boolean = other is Error && describesSameError(error, other.error)
@@ -28,8 +26,6 @@ sealed interface OpenFeatureStatus {
 
     /**
      * The provider has entered an irrecoverable error state.
-     *
-     * Compared by the failure it describes, as [Error] is.
      */
     class Fatal(val error: OpenFeatureError) : OpenFeatureStatus {
         override fun equals(other: Any?): Boolean = other is Fatal && describesSameError(error, other.error)

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
@@ -1,0 +1,242 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.toCurrentStateEvent
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.withContext
+
+private const val EVENT_BUFFER_CAPACITY = 64
+
+/** Sequence stamped on a replayed event, below every real one so it is never fenced. */
+private const val REPLAY_SEQUENCE = Long.MIN_VALUE
+
+/**
+ * Processes the [OpenFeatureProviderEvents] a provider emits, updates [status] accordingly, and
+ * republishes the events to subscribers.
+ *
+ * ## Event to status mapping
+ *
+ * | Event                                        | Resulting status |
+ * |----------------------------------------------|------------------|
+ * | `ProviderReady`                              | `Ready`          |
+ * | `ProviderError`                              | `Error`          |
+ * | `ProviderError` with `errorCode` `PROVIDER_FATAL` | `Fatal`     |
+ * | `ProviderStale`                              | `Stale`          |
+ * | `ProviderReconciling`                        | `Reconciling`    |
+ * | `ProviderContextChanged`                     | `Ready`          |
+ * | `ProviderConfigurationChanged`               | *(no change)*    |
+ *
+ * ## Status replay
+ *
+ * A new subscriber receives one synthetic event reflecting the current status, so attaching does not
+ * race the first live event. Nothing is replayed while the provider is [OpenFeatureStatus.NotReady],
+ * which has no corresponding event type.
+ *
+ * ## Recommended usage
+ *
+ * ```kotlin
+ * class MyProvider : FeatureProvider {
+ *     private val statusTracker = ProviderStatusTracker()
+ *
+ *     override val status: OpenFeatureStatus get() = statusTracker.status
+ *     override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+ *
+ *     override suspend fun initialize(initialContext: EvaluationContext?) {
+ *         connect(initialContext)
+ *         statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
+ *     }
+ *
+ *     override suspend fun onContextSet(
+ *         oldContext: EvaluationContext?,
+ *         newContext: EvaluationContext
+ *     ) = statusTracker.reconciling { refresh(newContext) }
+ *
+ *     override fun shutdown() = statusTracker.reset()
+ * }
+ * ```
+ *
+ * Do not collect [observe] on [kotlinx.coroutines.Dispatchers.Unconfined], and do not call [send]
+ * from inside a collector: delivery would then run inline under the lock that orders events, and the
+ * order subscribers see would no longer match the order they were sent in.
+ */
+class ProviderStatusTracker {
+    // Orders event handling in send(), and provides the snapshot a new subscriber fences against, so
+    // that no event is missed or duplicated between reading the status and installing the collector.
+    private val lock = SynchronizedObject()
+
+    private var currentStatus: OpenFeatureStatus = OpenFeatureStatus.NotReady
+    private var sequence: Long = 0
+
+    /** Sequence of the last published event that carried a status, for [reconciling]'s mark. */
+    private var statusSequence: Long = 0
+
+    private val reconciliations = Reconciliations()
+
+    private val events = MutableSharedFlow<Emission>(
+        replay = 0,
+        extraBufferCapacity = EVENT_BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    private class Emission(val sequence: Long, val event: OpenFeatureProviderEvents)
+
+    /** The status implied by the most recent event, safe to read from any thread. */
+    val status: OpenFeatureStatus get() = synchronized(lock) { currentStatus }
+
+    /** Reports [event], updating [status] and publishing it to [observe]'s subscribers. */
+    fun send(event: OpenFeatureProviderEvents) {
+        synchronized(lock) {
+            val status = event.toOpenFeatureStatus()
+            sequence++
+            if (status != null) {
+                currentStatus = status
+                statusSequence = sequence
+            }
+            events.tryEmit(Emission(sequence, event))
+        }
+    }
+
+    /** Stream to return from [FeatureProvider.observe]. */
+    fun observe(): Flow<OpenFeatureProviderEvents> = flow {
+        // Per collection, so each subscriber fences against its own snapshot.
+        var fence = 0L
+        emitAll(
+            events
+                .onSubscription {
+                    // Runs once this collector is registered, so nothing sent from here on is missed.
+                    val replayed = synchronized(lock) {
+                        fence = sequence
+                        currentStatus
+                    }
+                    replayed.toCurrentStateEvent()?.let { emit(Emission(REPLAY_SEQUENCE, it)) }
+                }
+                .filter {
+                    // A status-carrying event from before the snapshot is already folded into the
+                    // replay. An event carrying no status is not, so it is never fenced.
+                    it.sequence == REPLAY_SEQUENCE ||
+                        it.sequence > fence ||
+                        it.event.toOpenFeatureStatus() == null
+                }
+                .map { it.event }
+        )
+    }
+
+    /**
+     * Runs [block] as a context reconciliation, reporting the transitions around it.
+     *
+     * Sends [OpenFeatureProviderEvents.ProviderReconciling] on entry, then
+     * [OpenFeatureProviderEvents.ProviderContextChanged] on success or
+     * [OpenFeatureProviderEvents.ProviderError] on failure, and rethrows whatever [block] threw.
+     *
+     * Overlapping invocations are collapsed: reconciliation is reported once, and the outcome
+     * reported is that of the last invocation to terminate, as requirements 5.3.4.2 and 5.3.4.3 ask.
+     * Where every invocation was cancelled, the status preceding reconciliation is reported again
+     * rather than leaving the provider reconciling forever. Where [block] reported a status of its
+     * own, that report stands and no outcome is synthesised over it.
+     */
+    suspend fun reconciling(block: suspend () -> Unit) {
+        val first = reconciliations.begin(status)
+        if (first) send(OpenFeatureProviderEvents.ProviderReconciling())
+        val mark = synchronized(lock) { statusSequence }
+
+        var outcome: OpenFeatureProviderEvents? = null
+        try {
+            block()
+            outcome = OpenFeatureProviderEvents.ProviderContextChanged()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            outcome = e.toProviderErrorEvent()
+            throw e
+        } finally {
+            // A cancelled invocation still owes the reconciliation an outcome or a restoration.
+            withContext(NonCancellable) {
+                val reportedByBlock = synchronized(lock) { statusSequence > mark }
+                reconciliations.end(outcome, reportedByBlock)?.let { send(it) }
+            }
+        }
+    }
+
+    /**
+     * Returns the tracker to [OpenFeatureStatus.NotReady].
+     *
+     * Call this from [FeatureProvider.shutdown] where the provider can be registered again, so a
+     * reused instance does not report the status it held before it was shut down.
+     */
+    fun reset() {
+        synchronized(lock) {
+            currentStatus = OpenFeatureStatus.NotReady
+            sequence++
+            statusSequence = sequence
+        }
+        reconciliations.reset()
+    }
+
+    /**
+     * Collapses overlapping reconciliations into one reported transition.
+     *
+     * The outcome belongs to the reconciliation rather than to the invocation that produced it: an
+     * invocation that terminated normally still owns it when a later, overlapping one is cancelled.
+     */
+    private class Reconciliations {
+        private val lock = SynchronizedObject()
+        private var active = 0
+        private var restore: OpenFeatureStatus? = null
+        private var terminal: OpenFeatureProviderEvents? = null
+        private var reportedByBlock = false
+
+        /** Registers an invocation, returning whether it should report that reconciliation began. */
+        fun begin(restoreTo: OpenFeatureStatus): Boolean = synchronized(lock) {
+            if (active == 0) {
+                restore = restoreTo
+                terminal = null
+                reportedByBlock = false
+            }
+            ++active == 1
+        }
+
+        /** Registers an invocation's outcome, returning what to report if it was the last in flight. */
+        fun end(
+            outcome: OpenFeatureProviderEvents?,
+            reportedByBlock: Boolean
+        ): OpenFeatureProviderEvents? = synchronized(lock) {
+            if (reportedByBlock) this.reportedByBlock = true
+            if (outcome != null) terminal = outcome
+            if (--active > 0) return@synchronized null
+
+            val reported = this.reportedByBlock
+            val result = if (reported) null else terminal ?: restore?.toCurrentStateEvent()
+            restore = null
+            terminal = null
+            this.reportedByBlock = false
+            result
+        }
+
+        fun reset() = synchronized(lock) {
+            active = 0
+            restore = null
+            terminal = null
+            reportedByBlock = false
+        }
+    }
+}
+
+private fun Throwable.toProviderErrorEvent() = OpenFeatureProviderEvents.ProviderError(
+    OpenFeatureProviderEvents.EventDetails(
+        message = message ?: "Context reconciliation failed",
+        errorCode = (this as? OpenFeatureError)?.errorCode()
+    )
+)

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
@@ -97,16 +97,21 @@ class ProviderStatusTracker {
     val status: OpenFeatureStatus get() = synchronized(lock) { currentStatus }
 
     /** Reports [event], updating [status] and publishing it to [observe]'s subscribers. */
-    fun send(event: OpenFeatureProviderEvents) {
-        synchronized(lock) {
-            val status = event.toOpenFeatureStatus()
-            sequence++
-            if (status != null) {
-                currentStatus = status
-                statusSequence = sequence
-            }
-            events.tryEmit(Emission(sequence, event))
+    fun send(event: OpenFeatureProviderEvents) = synchronized(lock) { record(event) }
+
+    /**
+     * Publishes [event] and applies its status. The caller must hold [lock]: deciding what to report
+     * and reporting it have to be one step, or a reconciliation starting in between reads a status
+     * that is about to be replaced and captures it as the one to restore.
+     */
+    private fun record(event: OpenFeatureProviderEvents) {
+        val status = event.toOpenFeatureStatus()
+        sequence++
+        if (status != null) {
+            currentStatus = status
+            statusSequence = sequence
         }
+        events.tryEmit(Emission(sequence, event))
     }
 
     /** Stream to return from [FeatureProvider.observe]. */
@@ -148,9 +153,19 @@ class ProviderStatusTracker {
      * own, that report stands and no outcome is synthesised over it.
      */
     suspend fun reconciling(block: suspend () -> Unit) {
-        val first = reconciliations.begin(status)
-        if (first) send(OpenFeatureProviderEvents.ProviderReconciling())
-        val mark = synchronized(lock) { statusSequence }
+        // One critical section: registering, reporting that reconciliation began, and taking the mark
+        // have to be atomic, or an overlapping invocation reads its mark before this send bumps the
+        // sequence and mistakes that send for a report of its own.
+        val registration = synchronized(lock) {
+            val registration = reconciliations.begin(currentStatus)
+            // Nothing to reconcile from while not ready, and nothing to restore to either, so the
+            // transition is not reported. Requirement 5.3.4.1 asks that RECONCILING handlers run while
+            // onContextSet executes, not that a not-ready provider announce one.
+            if (registration.first && currentStatus != OpenFeatureStatus.NotReady) {
+                record(OpenFeatureProviderEvents.ProviderReconciling())
+            }
+            registration.copy(mark = statusSequence)
+        }
 
         var outcome: OpenFeatureProviderEvents? = null
         try {
@@ -164,8 +179,10 @@ class ProviderStatusTracker {
         } finally {
             // A cancelled invocation still owes the reconciliation an outcome or a restoration.
             withContext(NonCancellable) {
-                val reportedByBlock = synchronized(lock) { statusSequence > mark }
-                reconciliations.end(outcome, reportedByBlock)?.let { send(it) }
+                synchronized(lock) {
+                    val reportedByBlock = statusSequence > registration.mark
+                    reconciliations.end(registration, outcome, reportedByBlock)?.let { record(it) }
+                }
             }
         }
     }
@@ -176,12 +193,10 @@ class ProviderStatusTracker {
      * Call this from [FeatureProvider.shutdown] where the provider can be registered again, so a
      * reused instance does not report the status it held before it was shut down.
      */
-    fun reset() {
-        synchronized(lock) {
-            currentStatus = OpenFeatureStatus.NotReady
-            sequence++
-            statusSequence = sequence
-        }
+    fun reset() = synchronized(lock) {
+        currentStatus = OpenFeatureStatus.NotReady
+        sequence++
+        statusSequence = sequence
         reconciliations.reset()
     }
 
@@ -192,40 +207,51 @@ class ProviderStatusTracker {
      * invocation that terminated normally still owns it when a later, overlapping one is cancelled.
      */
     private class Reconciliations {
-        private val lock = SynchronizedObject()
+        private var generation = 0L
         private var active = 0
         private var restore: OpenFeatureStatus? = null
         private var terminal: OpenFeatureProviderEvents? = null
         private var reportedByBlock = false
 
-        /** Registers an invocation, returning whether it should report that reconciliation began. */
-        fun begin(restoreTo: OpenFeatureStatus): Boolean = synchronized(lock) {
+        /** One invocation's place in a reconciliation, so a stale one cannot disturb a newer one. */
+        data class Registration(val generation: Long, val first: Boolean, val mark: Long = 0)
+
+        /** Registers an invocation, reporting whether it is the one that opens the reconciliation. */
+        fun begin(restoreTo: OpenFeatureStatus): Registration {
             if (active == 0) {
                 restore = restoreTo
                 terminal = null
                 reportedByBlock = false
             }
-            ++active == 1
+            return Registration(generation, ++active == 1)
         }
 
-        /** Registers an invocation's outcome, returning what to report if it was the last in flight. */
+        /**
+         * Registers an invocation's outcome, returning what to report if it was the last in flight.
+         *
+         * An invocation from a superseded generation reports nothing and disturbs nothing: counting it
+         * out would let it clear the state of the reconciliation that replaced it.
+         */
         fun end(
+            registration: Registration,
             outcome: OpenFeatureProviderEvents?,
             reportedByBlock: Boolean
-        ): OpenFeatureProviderEvents? = synchronized(lock) {
+        ): OpenFeatureProviderEvents? {
+            if (registration.generation != generation) return null
             if (reportedByBlock) this.reportedByBlock = true
             if (outcome != null) terminal = outcome
-            if (--active > 0) return@synchronized null
+            if (--active > 0) return null
 
             val reported = this.reportedByBlock
             val result = if (reported) null else terminal ?: restore?.toCurrentStateEvent()
             restore = null
             terminal = null
             this.reportedByBlock = false
-            result
+            return result
         }
 
-        fun reset() = synchronized(lock) {
+        fun reset() {
+            generation++
             active = 0
             restore = null
             terminal = null

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
@@ -20,14 +20,12 @@ import kotlinx.coroutines.withContext
 
 private const val EVENT_BUFFER_CAPACITY = 64
 
-/** Sequence stamped on a replayed event, below every real one so it is never fenced. */
+/** Stamped on a replayed event, below every real one so it is never fenced. */
 private const val REPLAY_SEQUENCE = Long.MIN_VALUE
 
 /**
  * Processes the [OpenFeatureProviderEvents] a provider emits, updates [status] accordingly, and
  * republishes the events to subscribers.
- *
- * ## Event to status mapping
  *
  * | Event                                        | Resulting status |
  * |----------------------------------------------|------------------|
@@ -39,48 +37,19 @@ private const val REPLAY_SEQUENCE = Long.MIN_VALUE
  * | `ProviderContextChanged`                     | `Ready`          |
  * | `ProviderConfigurationChanged`               | *(no change)*    |
  *
- * ## Status replay
- *
  * A new subscriber receives one synthetic event reflecting the current status, so attaching does not
  * race the first live event. Nothing is replayed while the provider is [OpenFeatureStatus.NotReady],
  * which has no corresponding event type.
  *
- * ## Recommended usage
- *
- * ```kotlin
- * class MyProvider : FeatureProvider {
- *     private val statusTracker = ProviderStatusTracker()
- *
- *     override val status: OpenFeatureStatus get() = statusTracker.status
- *     override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
- *
- *     override suspend fun initialize(initialContext: EvaluationContext?) {
- *         connect(initialContext)
- *         statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
- *     }
- *
- *     override suspend fun onContextSet(
- *         oldContext: EvaluationContext?,
- *         newContext: EvaluationContext
- *     ) = statusTracker.reconciling { refresh(newContext) }
- *
- *     override fun shutdown() = statusTracker.reset()
- * }
- * ```
- *
- * Do not collect [observe] on [kotlinx.coroutines.Dispatchers.Unconfined], and do not call [send]
- * from inside a collector: delivery would then run inline under the lock that orders events, and the
- * order subscribers see would no longer match the order they were sent in.
+ * A provider delegates [FeatureProvider.status] and [FeatureProvider.observe] to this. Do not
+ * collect [observe] on [kotlinx.coroutines.Dispatchers.Unconfined], and do not call [send] from
+ * inside a collector: delivery would then run inline under the lock that orders events.
  */
 class ProviderStatusTracker {
-    // Orders event handling in send(), and provides the snapshot a new subscriber fences against, so
-    // that no event is missed or duplicated between reading the status and installing the collector.
     private val lock = SynchronizedObject()
 
     private var currentStatus: OpenFeatureStatus = OpenFeatureStatus.NotReady
     private var sequence: Long = 0
-
-    /** Sequence of the last published event that carried a status, for [reconciling]'s mark. */
     private var statusSequence: Long = 0
 
     private val reconciliations = Reconciliations()
@@ -100,9 +69,8 @@ class ProviderStatusTracker {
     fun send(event: OpenFeatureProviderEvents) = synchronized(lock) { record(event) }
 
     /**
-     * Publishes [event] and applies its status. The caller must hold [lock]: deciding what to report
-     * and reporting it have to be one step, or a reconciliation starting in between reads a status
-     * that is about to be replaced and captures it as the one to restore.
+     * Publishes [event] and applies its status. The caller must hold [lock]: a reconciliation
+     * starting between the decision and the report would capture a status that is already replaced.
      */
     private fun record(event: OpenFeatureProviderEvents) {
         val status = event.toOpenFeatureStatus()
@@ -116,12 +84,10 @@ class ProviderStatusTracker {
 
     /** Stream to return from [FeatureProvider.observe]. */
     fun observe(): Flow<OpenFeatureProviderEvents> = flow {
-        // Per collection, so each subscriber fences against its own snapshot.
         var fence = 0L
         emitAll(
             events
                 .onSubscription {
-                    // Runs once this collector is registered, so nothing sent from here on is missed.
                     val replayed = synchronized(lock) {
                         fence = sequence
                         currentStatus
@@ -129,8 +95,8 @@ class ProviderStatusTracker {
                     replayed.toCurrentStateEvent()?.let { emit(Emission(REPLAY_SEQUENCE, it)) }
                 }
                 .filter {
-                    // A status-carrying event from before the snapshot is already folded into the
-                    // replay. An event carrying no status is not, so it is never fenced.
+                    // A status-carrying event from before the snapshot is already in the replay; one
+                    // carrying no status is not, so it is never fenced.
                     it.sequence == REPLAY_SEQUENCE ||
                         it.sequence > fence ||
                         it.event.toOpenFeatureStatus() == null
@@ -148,24 +114,18 @@ class ProviderStatusTracker {
      *
      * Overlapping invocations are collapsed: reconciliation is reported once, and the outcome
      * reported is that of the last invocation to terminate, as requirements 5.3.4.2 and 5.3.4.3 ask.
-     * Where every invocation was cancelled, the status preceding reconciliation is reported again
-     * rather than leaving the provider reconciling forever. Where [block] reported a status of its
-     * own, that report stands and no outcome is synthesised over it.
+     * Where every invocation was cancelled, the status preceding reconciliation is reported again.
+     * Where [block] reported a status of its own, that report stands.
      *
-     * A reconciliation that begins while the provider is [OpenFeatureStatus.NotReady] reports nothing
-     * at all — not the transition, not the outcome. Readiness is [FeatureProvider.initialize]'s to
-     * report, so reconciling a context cannot confer it, and there is no earlier status to restore.
-     * A provider that does become usable during [block] can still say so itself.
+     * A reconciliation that begins while the provider is [OpenFeatureStatus.NotReady] reports
+     * nothing at all: readiness is [FeatureProvider.initialize]'s to report, and there is no earlier
+     * status to restore. A provider that does become usable during [block] can still say so itself.
      */
     suspend fun reconciling(block: suspend () -> Unit) {
-        // One critical section: registering, reporting that reconciliation began, and taking the mark
-        // have to be atomic, or an overlapping invocation reads its mark before this send bumps the
-        // sequence and mistakes that send for a report of its own.
+        // One critical section: an overlapping invocation would otherwise read its mark before this
+        // send bumps the sequence, and mistake that send for a report of its own.
         val registration = synchronized(lock) {
             val registration = reconciliations.begin(currentStatus)
-            // Nothing to reconcile from while not ready, and nothing to restore to either, so the
-            // transition is not reported. Requirement 5.3.4.1 asks that RECONCILING handlers run while
-            // onContextSet executes, not that a not-ready provider announce one.
             if (registration.first && currentStatus != OpenFeatureStatus.NotReady) {
                 record(OpenFeatureProviderEvents.ProviderReconciling())
             }
@@ -200,16 +160,12 @@ class ProviderStatusTracker {
      */
     fun reset() = synchronized(lock) {
         currentStatus = OpenFeatureStatus.NotReady
-        sequence++
-        statusSequence = sequence
         reconciliations.reset()
     }
 
     /**
-     * Collapses overlapping reconciliations into one reported transition.
-     *
-     * The outcome belongs to the reconciliation rather than to the invocation that produced it: an
-     * invocation that terminated normally still owns it when a later, overlapping one is cancelled.
+     * Collapses overlapping reconciliations into one reported transition. The outcome belongs to the
+     * reconciliation rather than to the invocation that produced it.
      */
     private class Reconciliations {
         private var generation = 0L
@@ -218,7 +174,6 @@ class ProviderStatusTracker {
         private var terminal: OpenFeatureProviderEvents? = null
         private var reportedByBlock = false
 
-        /** One invocation's place in a reconciliation, so a stale one cannot disturb a newer one. */
         data class Registration(val generation: Long, val first: Boolean, val mark: Long = 0)
 
         /** Registers an invocation, reporting whether it is the one that opens the reconciliation. */
@@ -233,41 +188,30 @@ class ProviderStatusTracker {
 
         /**
          * Registers an invocation's outcome, returning what to report if it was the last in flight.
-         *
-         * An invocation from a superseded generation reports nothing and disturbs nothing: counting it
-         * out would let it clear the state of the reconciliation that replaced it.
+         * An invocation from a superseded generation reports nothing and disturbs nothing.
          */
         fun end(
             registration: Registration,
             outcome: OpenFeatureProviderEvents?,
-            reportedByBlock: Boolean
+            blockReported: Boolean
         ): OpenFeatureProviderEvents? {
             if (registration.generation != generation) return null
-            if (reportedByBlock) this.reportedByBlock = true
+            if (blockReported) reportedByBlock = true
             if (outcome != null) terminal = outcome
             if (--active > 0) return null
 
-            // Decided only once the last invocation is out, so the counter is always decremented:
-            // returning earlier would strand it above zero and no later reconciliation would resolve.
-            val result = when {
-                // The block spoke for itself, so nothing is synthesised over it.
+            // Decided only after the counter is decremented: returning earlier would strand it above
+            // zero and no later reconciliation would resolve.
+            return when {
                 reportedByBlock -> null
-                // Nothing was ready when this began, so nothing is concluded from it having ended.
                 restore == OpenFeatureStatus.NotReady -> null
                 else -> terminal ?: restore?.toCurrentStateEvent()
             }
-            restore = null
-            terminal = null
-            this.reportedByBlock = false
-            return result
         }
 
         fun reset() {
             generation++
             active = 0
-            restore = null
-            terminal = null
-            reportedByBlock = false
         }
     }
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTracker.kt
@@ -151,6 +151,11 @@ class ProviderStatusTracker {
      * Where every invocation was cancelled, the status preceding reconciliation is reported again
      * rather than leaving the provider reconciling forever. Where [block] reported a status of its
      * own, that report stands and no outcome is synthesised over it.
+     *
+     * A reconciliation that begins while the provider is [OpenFeatureStatus.NotReady] reports nothing
+     * at all — not the transition, not the outcome. Readiness is [FeatureProvider.initialize]'s to
+     * report, so reconciling a context cannot confer it, and there is no earlier status to restore.
+     * A provider that does become usable during [block] can still say so itself.
      */
     suspend fun reconciling(block: suspend () -> Unit) {
         // One critical section: registering, reporting that reconciliation began, and taking the mark
@@ -242,8 +247,15 @@ class ProviderStatusTracker {
             if (outcome != null) terminal = outcome
             if (--active > 0) return null
 
-            val reported = this.reportedByBlock
-            val result = if (reported) null else terminal ?: restore?.toCurrentStateEvent()
+            // Decided only once the last invocation is out, so the counter is always decremented:
+            // returning earlier would strand it above zero and no later reconciliation would resolve.
+            val result = when {
+                // The block spoke for itself, so nothing is synthesised over it.
+                reportedByBlock -> null
+                // Nothing was ready when this began, so nothing is concluded from it having ended.
+                restore == OpenFeatureStatus.NotReady -> null
+                else -> terminal ?: restore?.toCurrentStateEvent()
+            }
             restore = null
             terminal = null
             this.reportedByBlock = false

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
@@ -78,11 +78,6 @@ internal fun OpenFeatureProviderEvents.ProviderError.toOpenFeatureStatusError():
     }
 }
 
-/**
- * Status implied by this event, per the event/status association table in the specification.
- *
- * Returns null for [OpenFeatureProviderEvents.ProviderConfigurationChanged], which carries no status.
- */
 internal fun OpenFeatureProviderEvents.toOpenFeatureStatus(): OpenFeatureStatus? = when (this) {
     is OpenFeatureProviderEvents.ProviderReady -> OpenFeatureStatus.Ready
     is OpenFeatureProviderEvents.ProviderStale -> OpenFeatureStatus.Stale
@@ -92,12 +87,6 @@ internal fun OpenFeatureProviderEvents.toOpenFeatureStatus(): OpenFeatureStatus?
     is OpenFeatureProviderEvents.ProviderConfigurationChanged -> null
 }
 
-/**
- * Event representing this status, so a subscriber attaching once the provider is already in a given
- * state is told about it immediately.
- *
- * Returns null for [OpenFeatureStatus.NotReady], which has no corresponding event type.
- */
 internal fun OpenFeatureStatus.toCurrentStateEvent(): OpenFeatureProviderEvents? = when (this) {
     is OpenFeatureStatus.NotReady -> null
     is OpenFeatureStatus.Ready -> OpenFeatureProviderEvents.ProviderReady()

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/events/OpenFeatureProviderEvents.kt
@@ -45,6 +45,22 @@ sealed class OpenFeatureProviderEvents {
     data class ProviderStale(
         override val eventDetails: EventDetails? = null
     ) : OpenFeatureProviderEvents()
+
+    /**
+     * The provider started reconciling its state with a new [dev.openfeature.kotlin.sdk.EvaluationContext].
+     * [eventDetails] may supply [EventDetails.flagsChanged], [EventDetails.message], [EventDetails.errorCode], and [EventDetails.eventMetadata] as applicable.
+     */
+    data class ProviderReconciling(
+        override val eventDetails: EventDetails? = null
+    ) : OpenFeatureProviderEvents()
+
+    /**
+     * The provider finished reconciling its state with a new [dev.openfeature.kotlin.sdk.EvaluationContext].
+     * [eventDetails] may supply [EventDetails.flagsChanged], [EventDetails.message], [EventDetails.errorCode], and [EventDetails.eventMetadata] as applicable.
+     */
+    data class ProviderContextChanged(
+        override val eventDetails: EventDetails? = null
+    ) : OpenFeatureProviderEvents()
 }
 
 internal fun OpenFeatureProviderEvents.ProviderError.toOpenFeatureStatusError(): OpenFeatureStatus {
@@ -60,4 +76,40 @@ internal fun OpenFeatureProviderEvents.ProviderError.toOpenFeatureStatusError():
     } else {
         OpenFeatureStatus.Error(openFeatureError)
     }
+}
+
+/**
+ * Status implied by this event, per the event/status association table in the specification.
+ *
+ * Returns null for [OpenFeatureProviderEvents.ProviderConfigurationChanged], which carries no status.
+ */
+internal fun OpenFeatureProviderEvents.toOpenFeatureStatus(): OpenFeatureStatus? = when (this) {
+    is OpenFeatureProviderEvents.ProviderReady -> OpenFeatureStatus.Ready
+    is OpenFeatureProviderEvents.ProviderStale -> OpenFeatureStatus.Stale
+    is OpenFeatureProviderEvents.ProviderError -> toOpenFeatureStatusError()
+    is OpenFeatureProviderEvents.ProviderReconciling -> OpenFeatureStatus.Reconciling
+    is OpenFeatureProviderEvents.ProviderContextChanged -> OpenFeatureStatus.Ready
+    is OpenFeatureProviderEvents.ProviderConfigurationChanged -> null
+}
+
+/**
+ * Event representing this status, so a subscriber attaching once the provider is already in a given
+ * state is told about it immediately.
+ *
+ * Returns null for [OpenFeatureStatus.NotReady], which has no corresponding event type.
+ */
+internal fun OpenFeatureStatus.toCurrentStateEvent(): OpenFeatureProviderEvents? = when (this) {
+    is OpenFeatureStatus.NotReady -> null
+    is OpenFeatureStatus.Ready -> OpenFeatureProviderEvents.ProviderReady()
+    is OpenFeatureStatus.Stale -> OpenFeatureProviderEvents.ProviderStale()
+    is OpenFeatureStatus.Reconciling -> OpenFeatureProviderEvents.ProviderReconciling()
+    is OpenFeatureStatus.Error -> OpenFeatureProviderEvents.ProviderError(
+        OpenFeatureProviderEvents.EventDetails(message = error.message, errorCode = error.errorCode())
+    )
+    is OpenFeatureStatus.Fatal -> OpenFeatureProviderEvents.ProviderError(
+        OpenFeatureProviderEvents.EventDetails(
+            message = error.message,
+            errorCode = ErrorCode.PROVIDER_FATAL
+        )
+    )
 }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -125,6 +125,8 @@ class MultiProvider(
         }
     }
 
+    override val status: OpenFeatureStatus get() = _statusFlow.value
+
     private val _statusFlow = MutableStateFlow<OpenFeatureStatus>(OpenFeatureStatus.NotReady)
     val statusFlow = _statusFlow.asStateFlow()
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -10,16 +10,16 @@ import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
-import dev.openfeature.kotlin.sdk.events.toCurrentStateEvent
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -150,7 +150,7 @@ class MultiProvider(
         }
     }
 
-    private var watchChildrenJob: Job? = null
+    private var watchScope: CoroutineScope? = null
 
     /**
      * @return Number of unique providers
@@ -171,10 +171,32 @@ class MultiProvider(
             // child's status so a late watcher would still converge, but a configuration change a
             // child reports while initializing carries no status and could not be recovered.
             watchChildren()
-            childFeatureProviders
-                .map { async { it.initialize(initialContext) } }
-                .awaitAll()
-            updateStatus()
+            try {
+                childFeatureProviders
+                    .map { child -> async { child.reportingItsOwnFailure { initialize(initialContext) } } }
+                    .awaitAll()
+            } finally {
+                updateStatus()
+            }
+        }
+    }
+
+    /**
+     * Runs one of [this] child's lifecycle calls, leaving the failure to the child.
+     *
+     * A child that fails reports its own error event and the aggregate reads it from the child's
+     * status, so one failing child must not cancel the siblings that structured concurrency would
+     * otherwise take down with it.
+     */
+    private suspend fun ChildFeatureProvider.reportingItsOwnFailure(
+        work: suspend ChildFeatureProvider.() -> Unit
+    ) {
+        try {
+            work()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // Reported by the child, observed through its status.
         }
     }
 
@@ -187,11 +209,14 @@ class MultiProvider(
      * outlives the call, since the children keep reporting after initialization.
      */
     private fun CoroutineScope.watchChildren() {
-        watchChildrenJob?.cancel(
-            cause = CancellationException("Observe provider events job cancelled due to new initialize call")
-        )
-        val watchScope = CoroutineScope(coroutineContext + SupervisorJob())
-        watchChildrenJob = watchScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        // The scope is replaced, not just the job inside it: a fresh SupervisorJob per initialize
+        // that is never cancelled leaves one root job behind each time. It deliberately is not a
+        // child of initialize's scope — that would either make initialize hang waiting for the
+        // collectors or stop them the moment it returned — but it does inherit its dispatcher.
+        watchScope?.cancel(CancellationException("Child provider watch replaced by a new initialize call"))
+        val scope = CoroutineScope(coroutineContext + SupervisorJob())
+        watchScope = scope
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
             childFeatureProviders.forEach { child ->
                 launch(start = CoroutineStart.UNDISPATCHED) {
                     child.observe().collect { handleChildEvent(it) }
@@ -210,6 +235,10 @@ class MultiProvider(
     private fun handleChildEvent(event: OpenFeatureProviderEvents) {
         if (event.toOpenFeatureStatus() == null) {
             statusTracker.send(event)
+            // Re-aggregated on any child activity, not only on a status-carrying event: a child's
+            // status can move without one, since shutting a child down resets it and not-ready has
+            // no event to report.
+            updateStatus()
         } else {
             updateStatus(event)
         }
@@ -219,39 +248,60 @@ class MultiProvider(
     private fun updateStatus(trigger: OpenFeatureProviderEvents? = null) {
         val aggregate = strategy.status(childFeatureProviders)
         val details = trigger?.eventDetails
+        val current = statusTracker.status
+
+        if (aggregate is OpenFeatureStatus.NotReady) {
+            // No event describes not-ready, so the status is established directly. It therefore
+            // reaches getStatus() but not observe() or statusFlow, which have no event to carry.
+            if (current != OpenFeatureStatus.NotReady) statusTracker.reset()
+            return
+        }
+
+        // A reconciliation in flight owns its own resolution. Reporting readiness here on the first
+        // child's behalf would publish the outcome before the others had finished, and the real
+        // outcome would then look like no change at all.
+        if (aggregate is OpenFeatureStatus.Ready && current is OpenFeatureStatus.Reconciling) return
+
         val event = when (aggregate) {
-            // NotReady has no event to report, so the aggregate simply stays where it was.
-            is OpenFeatureStatus.NotReady -> null
-            is OpenFeatureStatus.Ready ->
-                if (statusTracker.status is OpenFeatureStatus.Reconciling) {
-                    OpenFeatureProviderEvents.ProviderContextChanged(details)
-                } else {
-                    OpenFeatureProviderEvents.ProviderReady(details)
-                }
+            is OpenFeatureStatus.Ready -> OpenFeatureProviderEvents.ProviderReady(details)
             is OpenFeatureStatus.Stale -> OpenFeatureProviderEvents.ProviderStale(details)
             is OpenFeatureStatus.Reconciling -> OpenFeatureProviderEvents.ProviderReconciling(details)
-            is OpenFeatureStatus.Error, is OpenFeatureStatus.Fatal ->
-                aggregate.toCurrentStateEvent()
+            // The child's details are kept, as the appendix asks, with the aggregate's error over
+            // the top: rebuilding from the status alone would drop flagsChanged and eventMetadata.
+            is OpenFeatureStatus.Error -> OpenFeatureProviderEvents.ProviderError(
+                details.describing(aggregate.error)
+            )
+            is OpenFeatureStatus.Fatal -> OpenFeatureProviderEvents.ProviderError(
+                details.describing(aggregate.error, ErrorCode.PROVIDER_FATAL)
+            )
+            is OpenFeatureStatus.NotReady -> return
         }
-        if (event != null && event.toOpenFeatureStatus() != statusTracker.status) {
-            statusTracker.send(event)
-        }
+        if (event.toOpenFeatureStatus() != current) statusTracker.send(event)
     }
+
+    private fun OpenFeatureProviderEvents.EventDetails?.describing(
+        error: OpenFeatureError,
+        errorCode: ErrorCode = error.errorCode()
+    ) = (this ?: OpenFeatureProviderEvents.EventDetails()).copy(
+        message = error.message,
+        errorCode = errorCode
+    )
 
     /**
      * Shuts down all underlying providers.
      * This allows providers to clean up resources and complete any pending operations.
      */
     override fun shutdown() {
-        watchChildrenJob?.cancel(
-            cause = CancellationException("Observe provider events job cancelled due to shutdown")
-        )
+        watchScope?.cancel(CancellationException("Child provider watch cancelled due to shutdown"))
+        watchScope = null
         statusTracker.reset()
 
         val shutdownErrors = mutableListOf<Pair<String, Throwable>>()
         childFeatureProviders.forEach { provider ->
             try {
                 provider.shutdown()
+            } catch (e: CancellationException) {
+                throw e
             } catch (t: Throwable) {
                 shutdownErrors += provider.name to t
             }
@@ -278,13 +328,14 @@ class MultiProvider(
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
-    ) {
-        statusTracker.send(OpenFeatureProviderEvents.ProviderReconciling())
+    ) = statusTracker.reconciling {
+        // The tracker owns the transitions: it reports reconciliation once across overlapping
+        // context sets, reports only the outcome of the last one to terminate, and restores the
+        // preceding status if they were all cancelled. Hand-rolling that here left the aggregate
+        // stuck at Reconciling whenever a context set was cancelled.
         coroutineScope {
-            // A child that fails reports its own error event; the aggregate picks it up from the
-            // child's status, so one failing child does not fail the group.
             childFeatureProviders
-                .map { async { runCatching { it.onContextSet(oldContext, newContext) } } }
+                .map { child -> async { child.reportingItsOwnFailure { onContextSet(oldContext, newContext) } } }
                 .awaitAll()
         }
         updateStatus()
@@ -383,6 +434,8 @@ class MultiProvider(
         childFeatureProviders.forEach { provider ->
             try {
                 provider.track(trackingEventName, context, details)
+            } catch (e: CancellationException) {
+                throw e
             } catch (t: Throwable) {
                 trackingErrors += provider.name to t
             }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -6,26 +6,22 @@ import dev.openfeature.kotlin.sdk.Hook
 import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.toCurrentStateEvent
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
@@ -92,17 +88,16 @@ class MultiProvider(
             evaluationContext: EvaluationContext?,
             flagEval: FlagEval<T>
         ): ProviderEvaluation<T>
-    }
 
-    private val OpenFeatureStatus.precedence: Int
-        get() = when (this) {
-            is OpenFeatureStatus.Fatal -> 5
-            is OpenFeatureStatus.NotReady -> 4
-            is OpenFeatureStatus.Error -> 3
-            is OpenFeatureStatus.Reconciling -> 2 // Not specified in precedence; treat similar to Stale
-            is OpenFeatureStatus.Stale -> 2
-            is OpenFeatureStatus.Ready -> 1
-        }
+        /**
+         * Aggregates the statuses of [providers] into the MultiProvider's own status.
+         *
+         * The default reports the most severe, which is the order the specification's Multi-Provider
+         * appendix defines: Fatal, then NotReady, then Error, then Stale, then Ready.
+         */
+        fun status(providers: List<FeatureProvider>): OpenFeatureStatus =
+            providers.map { it.status }.maxByOrNull { it.severity } ?: OpenFeatureStatus.NotReady
+    }
 
     // TODO: Support hooks
     override val hooks: List<Hook<*>> = emptyList()
@@ -125,16 +120,9 @@ class MultiProvider(
         }
     }
 
-    override val status: OpenFeatureStatus get() = _statusFlow.value
+    private val statusTracker = ProviderStatusTracker()
 
-    private val _statusFlow = MutableStateFlow<OpenFeatureStatus>(OpenFeatureStatus.NotReady)
-    val statusFlow = _statusFlow.asStateFlow()
-
-    private val eventFlow = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
-
-    // Track individual provider statuses, initial state of all providers is NotReady
-    private val childProviderStatuses: MutableMap<ChildFeatureProvider, OpenFeatureStatus> =
-        childFeatureProviders.associateWithTo(mutableMapOf()) { OpenFeatureStatus.NotReady }
+    override val status: OpenFeatureStatus get() = statusTracker.status
 
     private fun List<FeatureProvider>.toChildFeatureProviders(): List<ChildFeatureProvider> {
         // Extract a stable base name per provider, falling back for unnamed providers
@@ -162,14 +150,14 @@ class MultiProvider(
         }
     }
 
-    private var observeProviderEventsJob: Job? = null
+    private var watchChildrenJob: Job? = null
 
     /**
      * @return Number of unique providers
      */
     internal fun getProviderCount(): Int = childFeatureProviders.size
 
-    override fun observe(): Flow<OpenFeatureProviderEvents> = eventFlow.asSharedFlow()
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
 
     /**
      * Initializes all underlying providers with the given context.
@@ -179,51 +167,75 @@ class MultiProvider(
      */
     override suspend fun initialize(initialContext: EvaluationContext?) {
         coroutineScope {
-            observeProviderEventsJob?.cancel(
-                cause = CancellationException("Observe provider events job cancelled due to new initialize call")
-            )
-            observeProviderEventsJob = CoroutineScope(this.coroutineContext + SupervisorJob()).launch {
-                // Listen to events emitted by providers to emit our own set of events
-                // according to https://openfeature.dev/specification/appendix-a/#status-and-event-handling
-                childFeatureProviders.forEach { provider ->
-                    provider.observe()
-                        .onEach { event ->
-                            handleProviderEvent(provider, event)
-                        }
-                        .launchIn(this)
+            // Started before the children, not after: the terminal updateStatus() re-reads every
+            // child's status so a late watcher would still converge, but a configuration change a
+            // child reports while initializing carries no status and could not be recovered.
+            watchChildren()
+            childFeatureProviders
+                .map { async { it.initialize(initialContext) } }
+                .awaitAll()
+            updateStatus()
+        }
+    }
+
+    /**
+     * Subscribes to every child's events, synchronously.
+     *
+     * Undispatched, so each subscription is established before this returns: merely launching the
+     * collectors would let a child report and finish before anyone was listening, and a child's
+     * replay only carries its current status, so the transitions in between would be lost. The scope
+     * outlives the call, since the children keep reporting after initialization.
+     */
+    private fun CoroutineScope.watchChildren() {
+        watchChildrenJob?.cancel(
+            cause = CancellationException("Observe provider events job cancelled due to new initialize call")
+        )
+        val watchScope = CoroutineScope(coroutineContext + SupervisorJob())
+        watchChildrenJob = watchScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            childFeatureProviders.forEach { child ->
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    child.observe().collect { handleChildEvent(it) }
                 }
             }
-
-            launch {
-                // State updates captured by observing individual Feature Flag providers
-                childFeatureProviders
-                    .map { async { it.initialize(initialContext) } }
-                    .awaitAll()
-            }
         }
     }
 
-    private suspend fun handleProviderEvent(provider: ChildFeatureProvider, event: OpenFeatureProviderEvents) {
-        // An event carrying no status is re-emitted as-is; ProviderConfigurationChanged is the only one.
-        val newChildStatus = event.toOpenFeatureStatus() ?: run {
-            eventFlow.emit(event)
-            return
-        }
-
-        val previousStatus = _statusFlow.value
-        childProviderStatuses[provider] = newChildStatus
-        val newStatus = calculateAggregateStatus()
-
-        if (previousStatus != newStatus) {
-            _statusFlow.update { newStatus }
-            // Re-emit the original event that triggered the aggregate status change
-            eventFlow.emit(event)
+    /**
+     * A child's event either changes the aggregate status or is a configuration change.
+     *
+     * The specification's Multi-Provider appendix asks for a configuration change to be re-emitted
+     * whenever any provider reports one, and for an aggregate transition to carry the details of the
+     * child event that triggered it.
+     */
+    private fun handleChildEvent(event: OpenFeatureProviderEvents) {
+        if (event.toOpenFeatureStatus() == null) {
+            statusTracker.send(event)
+        } else {
+            updateStatus(event)
         }
     }
 
-    private fun calculateAggregateStatus(): OpenFeatureStatus {
-        val highestPrecedenceStatus = childProviderStatuses.values.maxBy { it.precedence }
-        return highestPrecedenceStatus
+    /** Reports the aggregate status, carrying [trigger]'s details where one triggered the change. */
+    private fun updateStatus(trigger: OpenFeatureProviderEvents? = null) {
+        val aggregate = strategy.status(childFeatureProviders)
+        val details = trigger?.eventDetails
+        val event = when (aggregate) {
+            // NotReady has no event to report, so the aggregate simply stays where it was.
+            is OpenFeatureStatus.NotReady -> null
+            is OpenFeatureStatus.Ready ->
+                if (statusTracker.status is OpenFeatureStatus.Reconciling) {
+                    OpenFeatureProviderEvents.ProviderContextChanged(details)
+                } else {
+                    OpenFeatureProviderEvents.ProviderReady(details)
+                }
+            is OpenFeatureStatus.Stale -> OpenFeatureProviderEvents.ProviderStale(details)
+            is OpenFeatureStatus.Reconciling -> OpenFeatureProviderEvents.ProviderReconciling(details)
+            is OpenFeatureStatus.Error, is OpenFeatureStatus.Fatal ->
+                aggregate.toCurrentStateEvent()
+        }
+        if (event != null && event.toOpenFeatureStatus() != statusTracker.status) {
+            statusTracker.send(event)
+        }
     }
 
     /**
@@ -231,9 +243,10 @@ class MultiProvider(
      * This allows providers to clean up resources and complete any pending operations.
      */
     override fun shutdown() {
-        observeProviderEventsJob?.cancel(
+        watchChildrenJob?.cancel(
             cause = CancellationException("Observe provider events job cancelled due to shutdown")
         )
+        statusTracker.reset()
 
         val shutdownErrors = mutableListOf<Pair<String, Throwable>>()
         childFeatureProviders.forEach { provider ->
@@ -266,13 +279,15 @@ class MultiProvider(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) {
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReconciling())
         coroutineScope {
-            // If any of these fail, they should individually bubble up their fail
-            // event and that is handled by handleProviderEvent()
+            // A child that fails reports its own error event; the aggregate picks it up from the
+            // child's status, so one failing child does not fail the group.
             childFeatureProviders
-                .map { async { it.onContextSet(oldContext, newContext) } }
+                .map { async { runCatching { it.onContextSet(oldContext, newContext) } } }
                 .awaitAll()
         }
+        updateStatus()
     }
 
     override fun getBooleanEvaluation(
@@ -396,3 +411,15 @@ class MultiProvider(
         private const val UNDEFINED_PROVIDER_NAME = "<unnamed>"
     }
 }
+
+/** Most severe wins, per the specification's Multi-Provider appendix. */
+private val OpenFeatureStatus.severity: Int
+    get() = when (this) {
+        is OpenFeatureStatus.Fatal -> 5
+        is OpenFeatureStatus.NotReady -> 4
+        is OpenFeatureStatus.Error -> 3
+        // Not in the appendix's list; treated as Stale is, since both mean "usable but not current".
+        is OpenFeatureStatus.Reconciling -> 2
+        is OpenFeatureStatus.Stale -> 2
+        is OpenFeatureStatus.Ready -> 1
+    }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -300,9 +300,11 @@ class MultiProvider(
         childFeatureProviders.forEach { provider ->
             try {
                 provider.shutdown()
-            } catch (e: CancellationException) {
-                throw e
             } catch (t: Throwable) {
+                // Every failure is collected, including a CancellationException: this is not a
+                // suspending function, so one from a child is an ordinary exception rather than
+                // cooperative cancellation to propagate. Rethrowing it would abandon every child
+                // after this one and swallow the aggregate error.
                 shutdownErrors += provider.name to t
             }
         }
@@ -434,9 +436,9 @@ class MultiProvider(
         childFeatureProviders.forEach { provider ->
             try {
                 provider.track(trackingEventName, context, details)
-            } catch (e: CancellationException) {
-                throw e
             } catch (t: Throwable) {
+                // Collected rather than rethrown, for the same reason as in shutdown: tracking is
+                // not suspending, so one child must not stop the others from being told.
                 trackingErrors += provider.name to t
             }
         }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -13,6 +13,8 @@ import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -90,10 +92,8 @@ class MultiProvider(
         ): ProviderEvaluation<T>
 
         /**
-         * Aggregates the statuses of [providers] into the MultiProvider's own status.
-         *
-         * The default reports the most severe, which is the order the specification's Multi-Provider
-         * appendix defines: Fatal, then NotReady, then Error, then Stale, then Ready.
+         * Aggregates the statuses of [providers] into the MultiProvider's own status. The default
+         * reports the most severe, in the order the specification's Multi-Provider appendix defines.
          */
         fun status(providers: List<FeatureProvider>): OpenFeatureStatus =
             providers.map { it.status }.maxByOrNull { it.severity } ?: OpenFeatureStatus.NotReady
@@ -150,7 +150,11 @@ class MultiProvider(
         }
     }
 
+    private val watchLock = SynchronizedObject()
     private var watchScope: CoroutineScope? = null
+
+    private val statusLock = SynchronizedObject()
+    private var openReconciliations = 0
 
     /**
      * @return Number of unique providers
@@ -168,8 +172,7 @@ class MultiProvider(
     override suspend fun initialize(initialContext: EvaluationContext?) {
         coroutineScope {
             // Started before the children, not after: the terminal updateStatus() re-reads every
-            // child's status so a late watcher would still converge, but a configuration change a
-            // child reports while initializing carries no status and could not be recovered.
+            // child's status so a late watcher would still converge.
             watchChildren()
             try {
                 childFeatureProviders
@@ -182,11 +185,8 @@ class MultiProvider(
     }
 
     /**
-     * Runs one of [this] child's lifecycle calls, leaving the failure to the child.
-     *
-     * A child that fails reports its own error event and the aggregate reads it from the child's
-     * status, so one failing child must not cancel the siblings that structured concurrency would
-     * otherwise take down with it.
+     * Runs one of [this] child's lifecycle calls, leaving the failure to the child: it reports its
+     * own error event, so one failing child must not cancel the siblings.
      */
     private suspend fun ChildFeatureProvider.reportingItsOwnFailure(
         work: suspend ChildFeatureProvider.() -> Unit
@@ -201,21 +201,22 @@ class MultiProvider(
     }
 
     /**
-     * Subscribes to every child's events, synchronously.
-     *
-     * Undispatched, so each subscription is established before this returns: merely launching the
-     * collectors would let a child report and finish before anyone was listening, and a child's
-     * replay only carries its current status, so the transitions in between would be lost. The scope
-     * outlives the call, since the children keep reporting after initialization.
+     * Subscribes to every child's events, undispatched so each subscription is established before
+     * this returns: a child could otherwise report and finish before anyone was listening, and its
+     * replay only carries the status it settled on.
      */
     private fun CoroutineScope.watchChildren() {
-        // The scope is replaced, not just the job inside it: a fresh SupervisorJob per initialize
-        // that is never cancelled leaves one root job behind each time. It deliberately is not a
-        // child of initialize's scope — that would either make initialize hang waiting for the
-        // collectors or stop them the moment it returned — but it does inherit its dispatcher.
-        watchScope?.cancel(CancellationException("Child provider watch replaced by a new initialize call"))
+        // Not a child of initialize's scope, which would either make initialize hang waiting for the
+        // collectors or stop them the moment it returned, but it does inherit its dispatcher.
         val scope = CoroutineScope(coroutineContext + SupervisorJob())
-        watchScope = scope
+        // Installed under the lock because shutdown runs on the retirement scope, not on the
+        // dispatcher initialize was entered on, and has to see the scope it must cancel.
+        val replaced = synchronized(watchLock) {
+            val replaced = watchScope
+            watchScope = scope
+            replaced
+        }
+        replaced?.cancel(CancellationException("Child provider watch replaced by a new initialize call"))
         scope.launch(start = CoroutineStart.UNDISPATCHED) {
             childFeatureProviders.forEach { child ->
                 launch(start = CoroutineStart.UNDISPATCHED) {
@@ -226,55 +227,53 @@ class MultiProvider(
     }
 
     /**
-     * A child's event either changes the aggregate status or is a configuration change.
-     *
-     * The specification's Multi-Provider appendix asks for a configuration change to be re-emitted
-     * whenever any provider reports one, and for an aggregate transition to carry the details of the
-     * child event that triggered it.
+     * A child's event either changes the aggregate status or is a configuration change, which the
+     * specification's Multi-Provider appendix asks to be re-emitted whenever a child reports one.
      */
     private fun handleChildEvent(event: OpenFeatureProviderEvents) {
-        if (event.toOpenFeatureStatus() == null) {
-            statusTracker.send(event)
-            // Re-aggregated on any child activity, not only on a status-carrying event: a child's
-            // status can move without one, since shutting a child down resets it and not-ready has
-            // no event to report.
-            updateStatus()
-        } else {
-            updateStatus(event)
-        }
+        // Re-aggregated on any child activity, a stateless event included: shutting a child down
+        // moves its status to not-ready, which has no event to report.
+        updateStatus(event)
+        // Forwarded after the aggregate has settled, so a subscriber that re-reads the status on
+        // this event sees the aggregate it triggered rather than the one it replaced.
+        if (event.toOpenFeatureStatus() == null) statusTracker.send(event)
     }
 
-    /** Reports the aggregate status, carrying [trigger]'s details where one triggered the change. */
-    private fun updateStatus(trigger: OpenFeatureProviderEvents? = null) {
+    /**
+     * Reports the aggregate status, carrying [trigger]'s details where one triggered the change.
+     *
+     * Aggregating and reporting are one critical section: two children transitioning concurrently
+     * would otherwise let the thread holding the older aggregate report last.
+     */
+    private fun updateStatus(trigger: OpenFeatureProviderEvents? = null) = synchronized(statusLock) {
         val aggregate = strategy.status(childFeatureProviders)
         val details = trigger?.eventDetails
         val current = statusTracker.status
 
         if (aggregate is OpenFeatureStatus.NotReady) {
-            // No event describes not-ready, so the status is established directly. It therefore
-            // reaches getStatus() but not observe() or statusFlow, which have no event to carry.
+            // No event describes not-ready, so it reaches getStatus() but not observe().
             if (current != OpenFeatureStatus.NotReady) statusTracker.reset()
-            return
+            return@synchronized
         }
 
-        // A reconciliation in flight owns its own resolution. Reporting readiness here on the first
-        // child's behalf would publish the outcome before the others had finished, and the real
-        // outcome would then look like no change at all.
-        if (aggregate is OpenFeatureStatus.Ready && current is OpenFeatureStatus.Reconciling) return
+        // Only this provider's own reconciliation owns its resolution, and it reports the outcome
+        // itself once every child has finished. A child reconciling on its own account has no such
+        // resolution to wait for, so its return to readiness must be reported here.
+        if (aggregate is OpenFeatureStatus.Ready && openReconciliations > 0) return@synchronized
 
         val event = when (aggregate) {
             is OpenFeatureStatus.Ready -> OpenFeatureProviderEvents.ProviderReady(details)
             is OpenFeatureStatus.Stale -> OpenFeatureProviderEvents.ProviderStale(details)
             is OpenFeatureStatus.Reconciling -> OpenFeatureProviderEvents.ProviderReconciling(details)
-            // The child's details are kept, as the appendix asks, with the aggregate's error over
-            // the top: rebuilding from the status alone would drop flagsChanged and eventMetadata.
+            // The child's details are kept with the aggregate's error over the top: rebuilding from
+            // the status alone would drop flagsChanged and eventMetadata.
             is OpenFeatureStatus.Error -> OpenFeatureProviderEvents.ProviderError(
                 details.describing(aggregate.error)
             )
             is OpenFeatureStatus.Fatal -> OpenFeatureProviderEvents.ProviderError(
                 details.describing(aggregate.error, ErrorCode.PROVIDER_FATAL)
             )
-            is OpenFeatureStatus.NotReady -> return
+            is OpenFeatureStatus.NotReady -> return@synchronized
         }
         if (event.toOpenFeatureStatus() != current) statusTracker.send(event)
     }
@@ -292,8 +291,12 @@ class MultiProvider(
      * This allows providers to clean up resources and complete any pending operations.
      */
     override fun shutdown() {
-        watchScope?.cancel(CancellationException("Child provider watch cancelled due to shutdown"))
-        watchScope = null
+        val watching = synchronized(watchLock) {
+            val watching = watchScope
+            watchScope = null
+            watching
+        }
+        watching?.cancel(CancellationException("Child provider watch cancelled due to shutdown"))
         statusTracker.reset()
 
         val shutdownErrors = mutableListOf<Pair<String, Throwable>>()
@@ -301,10 +304,8 @@ class MultiProvider(
             try {
                 provider.shutdown()
             } catch (t: Throwable) {
-                // Every failure is collected, including a CancellationException: this is not a
-                // suspending function, so one from a child is an ordinary exception rather than
-                // cooperative cancellation to propagate. Rethrowing it would abandon every child
-                // after this one and swallow the aggregate error.
+                // A CancellationException too: this is not a suspending function, so one from a
+                // child is an ordinary failure, and rethrowing it would abandon the children after.
                 shutdownErrors += provider.name to t
             }
         }
@@ -330,17 +331,24 @@ class MultiProvider(
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
-    ) = statusTracker.reconciling {
-        // The tracker owns the transitions: it reports reconciliation once across overlapping
-        // context sets, reports only the outcome of the last one to terminate, and restores the
-        // preceding status if they were all cancelled. Hand-rolling that here left the aggregate
-        // stuck at Reconciling whenever a context set was cancelled.
-        coroutineScope {
-            childFeatureProviders
-                .map { child -> async { child.reportingItsOwnFailure { onContextSet(oldContext, newContext) } } }
-                .awaitAll()
+    ) {
+        synchronized(statusLock) { openReconciliations++ }
+        try {
+            statusTracker.reconciling {
+                coroutineScope {
+                    childFeatureProviders
+                        .map { child ->
+                            async { child.reportingItsOwnFailure { onContextSet(oldContext, newContext) } }
+                        }
+                        .awaitAll()
+                }
+                updateStatus()
+            }
+        } finally {
+            // Dropped only once the tracker has reported the outcome, which its own finally does
+            // before this one runs.
+            synchronized(statusLock) { openReconciliations-- }
         }
-        updateStatus()
     }
 
     override fun getBooleanEvaluation(
@@ -437,8 +445,7 @@ class MultiProvider(
             try {
                 provider.track(trackingEventName, context, details)
             } catch (t: Throwable) {
-                // Collected rather than rethrown, for the same reason as in shutdown: tracking is
-                // not suspending, so one child must not stop the others from being told.
+                // Collected rather than rethrown, for the same reason as in shutdown.
                 trackingErrors += provider.name to t
             }
         }

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -13,6 +13,7 @@ import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.logging.LoggerFactory
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
@@ -122,6 +123,8 @@ class MultiProvider(
 
     private val statusTracker = ProviderStatusTracker()
 
+    private val logger = LoggerFactory.getLogger(MULTIPROVIDER_NAME)
+
     override val status: OpenFeatureStatus get() = statusTracker.status
 
     private fun List<FeatureProvider>.toChildFeatureProviders(): List<ChildFeatureProvider> {
@@ -196,7 +199,8 @@ class MultiProvider(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            // Reported by the child, observed through its status.
+            // Status is still reported by the child; this only keeps the failure diagnosable.
+            logger.warn({ "Child provider $name threw during a lifecycle call" }, throwable = e)
         }
     }
 

--- a/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
+++ b/kotlin-sdk/src/commonMain/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProvider.kt
@@ -9,7 +9,7 @@ import dev.openfeature.kotlin.sdk.ProviderMetadata
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
-import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatusError
+import dev.openfeature.kotlin.sdk.events.toOpenFeatureStatus
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -202,16 +202,10 @@ class MultiProvider(
     }
 
     private suspend fun handleProviderEvent(provider: ChildFeatureProvider, event: OpenFeatureProviderEvents) {
-        val newChildStatus = when (event) {
-            // ProviderConfigurationChanged events should always re-emit
-            is OpenFeatureProviderEvents.ProviderConfigurationChanged -> {
-                eventFlow.emit(event)
-                return
-            }
-
-            is OpenFeatureProviderEvents.ProviderReady -> OpenFeatureStatus.Ready
-            is OpenFeatureProviderEvents.ProviderStale -> OpenFeatureStatus.Stale
-            is OpenFeatureProviderEvents.ProviderError -> event.toOpenFeatureStatusError()
+        // An event carrying no status is re-emitted as-is; ProviderConfigurationChanged is the only one.
+        val newChildStatus = event.toOpenFeatureStatus() ?: run {
+            eventFlow.emit(event)
+            return
         }
 
         val previousStatus = _statusFlow.value

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
@@ -152,7 +152,8 @@ class DeveloperExperienceTests {
         val job = CoroutineScope(dispatcher).launch {
             OpenFeatureAPI.setProviderAndWait(
                 SlowProvider(dispatcher = dispatcher),
-                ImmutableContext()
+                ImmutableContext(),
+                dispatcher = dispatcher
             )
         }
         testScheduler.advanceTimeBy(1) // Make sure setProviderAndWait is called
@@ -232,13 +233,13 @@ class DeveloperExperienceTests {
         OpenFeatureAPI.shutdown()
         testScheduler.advanceUntilIdle()
         job.cancelAndJoin()
-        assertEquals(5, emittedStatuses.size)
+        // BrokenInitProvider reports its failure and then reconciles without reporting anything, so
+        // the context set contributes no transition: the SDK no longer invents one on its behalf.
+        assertEquals(3, emittedStatuses.size, "collected $emittedStatuses")
         assertTrue(emittedStatuses[0] is OpenFeatureStatus.NotReady)
         assertTrue(emittedStatuses[1] is OpenFeatureStatus.Error)
         assertTrue((emittedStatuses[1] as OpenFeatureStatus.Error).error is OpenFeatureError.ProviderNotReadyError)
-        assertTrue(emittedStatuses[2] is OpenFeatureStatus.Reconciling)
-        assertTrue(emittedStatuses[3] is OpenFeatureStatus.Ready)
-        assertTrue(emittedStatuses[4] is OpenFeatureStatus.NotReady)
+        assertTrue(emittedStatuses[2] is OpenFeatureStatus.NotReady)
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/DeveloperExperienceTests.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -244,19 +245,32 @@ class DeveloperExperienceTests {
     fun testProviderThatErrorsButHealsThenReady() = runTest {
         val healDelayMillis: Long = 100
         val healing = AutoHealingProvider(healDelay = healDelayMillis)
+        val statuses = mutableListOf<OpenFeatureStatus>()
+        val collector = launch { OpenFeatureAPI.statusFlow.collect { statuses.add(it) } }
+        runCurrent()
+
+        // A test dispatcher, so the SDK's subscription to the provider is established before
+        // initialize emits: on Dispatchers.Default the error is raced away and never observed.
         val job = async {
-            OpenFeatureAPI.setProviderAndWait(healing, ImmutableContext())
-        }
-        waitAssert {
-            assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())
-        }
-        waitAssert {
-            assertTrue(OpenFeatureAPI.getStatus() is OpenFeatureStatus.Error)
+            OpenFeatureAPI.setProviderAndWait(
+                healing,
+                ImmutableContext(),
+                dispatcher = StandardTestDispatcher(testScheduler)
+            )
         }
         waitAssert {
             assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
         }
         job.cancelAndJoin()
+        collector.cancelAndJoin()
+
+        // The error is transient — the provider heals after healDelayMillis — so it is only visible
+        // in the collected sequence, not by polling getStatus().
+        assertTrue(
+            statuses.any { it is OpenFeatureStatus.Error },
+            "expected the provider to report an error before healing, collected $statuses"
+        )
+        assertEquals(OpenFeatureStatus.Ready, statuses.last())
         OpenFeatureAPI.shutdown()
         advanceUntilIdle()
     }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/IsolatedAPIInstanceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/IsolatedAPIInstanceTests.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -157,9 +158,13 @@ class IsolatedAPIInstanceTests {
         val sharedProvider = DoSomethingProvider()
 
         OpenFeatureAPI.setProviderAndWait(sharedProvider, ImmutableContext())
-        instance.setProviderAndWait(sharedProvider, ImmutableContext())
 
-        assertTrue(instance.getStatus() is OpenFeatureStatus.Error)
+        // A double binding is a programming error, and with status owned by the provider there is
+        // no status channel left to report it on, so registration fails loudly instead.
+        assertFailsWith<IllegalStateException> {
+            instance.setProviderAndWait(sharedProvider, ImmutableContext())
+        }
+        assertEquals(OpenFeatureStatus.NotReady, instance.getStatus())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -170,10 +175,13 @@ class IsolatedAPIInstanceTests {
         val sharedProvider = DoSomethingProvider()
 
         OpenFeatureAPI.setProviderAndWait(sharedProvider, ImmutableContext())
-        instance.setProvider(sharedProvider, dispatcher = testDispatcher)
+
+        assertFailsWith<IllegalStateException> {
+            instance.setProvider(sharedProvider, dispatcher = testDispatcher)
+        }
         advanceUntilIdle()
 
-        assertTrue(instance.getStatus() is OpenFeatureStatus.Error)
+        assertEquals(OpenFeatureStatus.NotReady, instance.getStatus())
     }
 
     @Test
@@ -300,11 +308,13 @@ class IsolatedAPIInstanceTests {
         }
 
         instance1.setProviderAndWait(sharedSubclass, ImmutableContext())
-        instance2.setProviderAndWait(sharedSubclass, ImmutableContext())
 
         // The subclass is not the instance's private fallback, so the guard must fire
+        assertFailsWith<IllegalStateException> {
+            instance2.setProviderAndWait(sharedSubclass, ImmutableContext())
+        }
         assertEquals(OpenFeatureStatus.Ready, instance1.getStatus())
-        assertTrue(instance2.getStatus() is OpenFeatureStatus.Error)
+        assertEquals(OpenFeatureStatus.NotReady, instance2.getStatus())
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/IsolatedAPIInstanceTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/IsolatedAPIInstanceTests.kt
@@ -159,8 +159,7 @@ class IsolatedAPIInstanceTests {
 
         OpenFeatureAPI.setProviderAndWait(sharedProvider, ImmutableContext())
 
-        // A double binding is a programming error, and with status owned by the provider there is
-        // no status channel left to report it on, so registration fails loudly instead.
+        // A double binding is a programming error, so registration fails loudly.
         assertFailsWith<IllegalStateException> {
             instance.setProviderAndWait(sharedProvider, ImmutableContext())
         }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/LoggingIntegrationTests.kt
@@ -4,7 +4,6 @@ import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.hooks.LoggingHook
 import dev.openfeature.kotlin.sdk.logging.TestLogger
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -19,16 +18,20 @@ class LoggingIntegrationTests {
     private val testProvider = object : FeatureProvider {
         override val metadata: ProviderMetadata = TestProviderMetadata()
         override val hooks: List<Hook<*>> = listOf()
-        private val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
+        private val statusTracker = ProviderStatusTracker()
+
+        override val status: OpenFeatureStatus get() = statusTracker.status
+
+        override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
 
         override suspend fun initialize(initialContext: EvaluationContext?) {
-            events.emit(OpenFeatureProviderEvents.ProviderReady())
+            statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
         }
 
         override fun shutdown() {}
 
         override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-            events.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+            statusTracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
         }
 
         override fun getBooleanEvaluation(
@@ -85,10 +88,6 @@ class LoggingIntegrationTests {
             context: EvaluationContext?
         ): ProviderEvaluation<Value> {
             return ProviderEvaluation(value = defaultValue)
-        }
-
-        override fun observe(): Flow<OpenFeatureProviderEvents> {
-            return events
         }
     }
 
@@ -277,10 +276,14 @@ class LoggingIntegrationTests {
         val errorProvider = object : FeatureProvider {
             override val metadata: ProviderMetadata = TestProviderMetadata("error-provider")
             override val hooks: List<Hook<*>> = listOf()
-            private val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
+            private val statusTracker = ProviderStatusTracker()
+
+            override val status: OpenFeatureStatus get() = statusTracker.status
+
+            override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
 
             override suspend fun initialize(initialContext: EvaluationContext?) {
-                events.emit(OpenFeatureProviderEvents.ProviderReady())
+                statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
             }
 
             override fun shutdown() {}
@@ -333,10 +336,6 @@ class LoggingIntegrationTests {
                 context: EvaluationContext?
             ): ProviderEvaluation<Value> {
                 return ProviderEvaluation(value = defaultValue)
-            }
-
-            override fun observe(): Flow<OpenFeatureProviderEvents> {
-                return events
             }
         }
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
@@ -73,9 +73,7 @@ class ProviderEventingTests {
         waitAssert {
             assertEquals(3, statusList.size, "collected $statusList")
         }
-        // The provider reports readiness, then an error, then a configuration change. A
-        // configuration change carries no status, so it no longer clears the error: the SDK reports
-        // what the provider reported rather than concluding the reconciliation succeeded.
+        // A configuration change carries no status, so it no longer clears the error.
         assertEquals(OpenFeatureStatus.Ready, statusList[0])
         assertTrue(statusList[1] is OpenFeatureStatus.Error)
         assertEquals(OpenFeatureStatus.NotReady, statusList[2])

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderEventingTests.kt
@@ -8,8 +8,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.toCollection
 import kotlinx.coroutines.launch
@@ -33,16 +31,15 @@ class ProviderEventingTests {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val healDelayMillis = 1000L
         val provider = object : DoSomethingProvider() {
-            val flow = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
             override suspend fun initialize(initialContext: EvaluationContext?) {
-                // no-op
+                statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
             }
 
             override suspend fun onContextSet(
                 oldContext: EvaluationContext?,
                 newContext: EvaluationContext
             ) {
-                flow.emit(
+                statusTracker.send(
                     OpenFeatureProviderEvents.ProviderError(
                         OpenFeatureProviderEvents.EventDetails(
                             message = "test error",
@@ -51,12 +48,8 @@ class ProviderEventingTests {
                     )
                 )
                 delay(healDelayMillis)
-                flow.emit(
-                    OpenFeatureProviderEvents.ProviderConfigurationChanged()
-                )
+                statusTracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
             }
-
-            override fun observe(): Flow<OpenFeatureProviderEvents> = flow
         }
         val statusList = mutableListOf<OpenFeatureStatus>()
         val j = async(testDispatcher) {
@@ -78,13 +71,14 @@ class ProviderEventingTests {
         testScheduler.advanceUntilIdle()
         j.cancelAndJoin()
         waitAssert {
-            assertEquals(5, statusList.size)
+            assertEquals(3, statusList.size, "collected $statusList")
         }
+        // The provider reports readiness, then an error, then a configuration change. A
+        // configuration change carries no status, so it no longer clears the error: the SDK reports
+        // what the provider reported rather than concluding the reconciliation succeeded.
         assertEquals(OpenFeatureStatus.Ready, statusList[0])
-        assertEquals(OpenFeatureStatus.Reconciling, statusList[1])
-        assertTrue(statusList[2] is OpenFeatureStatus.Error)
-        assertEquals(OpenFeatureStatus.Ready, statusList[3])
-        assertEquals(OpenFeatureStatus.NotReady, statusList[4])
+        assertTrue(statusList[1] is OpenFeatureStatus.Error)
+        assertEquals(OpenFeatureStatus.NotReady, statusList[2])
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleTests.kt
@@ -6,6 +6,7 @@ import dev.openfeature.kotlin.sdk.helpers.SpyProvider
 import dev.openfeature.kotlin.sdk.isolated.ExperimentalIsolatedApi
 import dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -103,9 +104,12 @@ class ProviderLifecycleTests {
         instance.setProvider(superseded, dispatcher = dispatcher)
         instance.setProvider(NoOpProvider(), dispatcher = dispatcher)
         instance.setProvider(NoOpProvider(), dispatcher = dispatcher)
-        advanceUntilIdle()
 
-        assertEquals(1, superseded.shutdownCalls.value, "a dropped provider must still be shut down")
+        // Polled rather than advanced: a fire-and-forget swap retires its predecessor off the
+        // caller's thread, so the teardown does not run on this test's virtual clock.
+        waitAssert {
+            assertEquals(1, superseded.shutdownCalls.value, "a dropped provider must still be shut down")
+        }
 
         // ...and must have been released from the registry, so another instance can take it on.
         val other = createOpenFeatureAPIInstance()
@@ -125,5 +129,80 @@ class ProviderLifecycleTests {
 
         assertEquals(0, provider.shutdownCalls.value)
         assertEquals(OpenFeatureStatus.Ready, instance.getStatus())
+    }
+
+    /** Blocks in whichever lifecycle method is gated, and records the ones that ran to completion. */
+    private class GatedProvider(
+        private val gateInitialize: Boolean = false,
+        private val gateContextSet: Boolean = false
+    ) : NoOpProvider() {
+        private val statusTracker = ProviderStatusTracker()
+
+        val completed = mutableListOf<String>()
+        val initializeStarted = Channel<Unit>(Channel.UNLIMITED)
+        val releaseInitialize = Channel<Unit>(Channel.UNLIMITED)
+        val contextSetStarted = Channel<Unit>(Channel.UNLIMITED)
+        val releaseContextSet = Channel<Unit>(Channel.UNLIMITED)
+
+        override val status: OpenFeatureStatus get() = statusTracker.status
+
+        override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            if (gateInitialize) {
+                initializeStarted.send(Unit)
+                releaseInitialize.receive()
+            }
+            statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
+            completed += "initialize"
+        }
+
+        override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+            if (gateContextSet) {
+                contextSetStarted.send(Unit)
+                releaseContextSet.receive()
+            }
+            completed += "onContextSet"
+        }
+
+        override fun shutdown() = statusTracker.reset()
+    }
+
+    @Test
+    fun reRegisteringTheSameProviderDoesNotCancelItsInFlightInitialize() = runTest {
+        val instance = createOpenFeatureAPIInstance()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val provider = GatedProvider(gateInitialize = true)
+
+        instance.setProvider(provider, dispatcher = dispatcher)
+        provider.initializeStarted.receive()
+
+        // Re-registering keeps the registration, so the work already running on its scope survives.
+        instance.setProvider(provider, dispatcher = dispatcher)
+        provider.releaseInitialize.send(Unit)
+        provider.releaseInitialize.send(Unit)
+        advanceUntilIdle()
+
+        assertEquals(listOf("initialize", "initialize"), provider.completed)
+    }
+
+    @Test
+    fun reRegisteringTheSameProviderDoesNotCancelItsInFlightReconciliation() = runTest {
+        val instance = createOpenFeatureAPIInstance()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val provider = GatedProvider(gateContextSet = true)
+
+        instance.setProviderAndWait(provider, dispatcher = dispatcher)
+        instance.setEvaluationContext(ImmutableContext("ctx"))
+        provider.contextSetStarted.receive()
+
+        instance.setProvider(provider, dispatcher = dispatcher)
+        provider.releaseContextSet.send(Unit)
+        advanceUntilIdle()
+
+        assertTrue(
+            provider.completed.contains("onContextSet"),
+            "the reconciliation was cancelled by the rebind: ${provider.completed}"
+        )
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleTests.kt
@@ -18,9 +18,8 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
- * The provider lifecycle contracts the SDK owes a provider that reports its own status: what it does
- * with a report made mid-`initialize`, with a provider that reports nothing at all, and with a
- * registration that is superseded before it ever runs.
+ * The lifecycle contracts the SDK owes a provider that reports its own status: a report made
+ * mid-`initialize`, a provider that reports nothing, a registration superseded before it runs.
  */
 @OptIn(ExperimentalIsolatedApi::class, ExperimentalCoroutinesApi::class)
 class ProviderLifecycleTests {

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleTests.kt
@@ -1,0 +1,129 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.helpers.SpyProvider
+import dev.openfeature.kotlin.sdk.isolated.ExperimentalIsolatedApi
+import dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The provider lifecycle contracts the SDK owes a provider that reports its own status: what it does
+ * with a report made mid-`initialize`, with a provider that reports nothing at all, and with a
+ * registration that is superseded before it ever runs.
+ */
+@OptIn(ExperimentalIsolatedApi::class, ExperimentalCoroutinesApi::class)
+class ProviderLifecycleTests {
+
+    @AfterTest
+    fun tearDown() {
+        OpenFeatureAPIInstance.clearBoundProviders()
+    }
+
+    /** Reports [eventsOnInitialize] from inside `initialize`, then optionally throws. */
+    private class ReportingProvider(
+        private val eventsOnInitialize: List<OpenFeatureProviderEvents> = emptyList(),
+        private val initializeFailure: Throwable? = null
+    ) : NoOpProvider() {
+        private val statusTracker = ProviderStatusTracker()
+
+        override val status: OpenFeatureStatus get() = statusTracker.status
+
+        override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            eventsOnInitialize.forEach { statusTracker.send(it) }
+            initializeFailure?.let { throw it }
+        }
+
+        override fun shutdown() = statusTracker.reset()
+    }
+
+    @Test
+    fun readinessReportedDuringInitializeIsNotOverwrittenWhenItReturns() = runTest {
+        val instance = createOpenFeatureAPIInstance()
+        // The provider decides it is stale while initializing, and says nothing further.
+        val provider = ReportingProvider(listOf(OpenFeatureProviderEvents.ProviderStale()))
+
+        instance.setProviderAndWait(provider)
+        advanceUntilIdle()
+
+        // The SDK concludes nothing from initialize having returned: the provider's own report stands.
+        assertEquals(OpenFeatureStatus.Stale, instance.getStatus())
+    }
+
+    @Test
+    fun aProviderThatThrowsWithoutReportingStaysNotReady() = runTest {
+        val instance = createOpenFeatureAPIInstance()
+        val provider = ReportingProvider(initializeFailure = OpenFeatureError.GeneralError("no connection"))
+
+        // The failure is logged, not rethrown: a provider reports its own status, and this one did not.
+        instance.setProviderAndWait(provider)
+        advanceUntilIdle()
+
+        assertEquals(OpenFeatureStatus.NotReady, instance.getStatus())
+    }
+
+    @Test
+    fun aProviderThatThrowsAfterReportingKeepsTheStatusItReported() = runTest {
+        val instance = createOpenFeatureAPIInstance()
+        val provider = ReportingProvider(
+            eventsOnInitialize = listOf(
+                OpenFeatureProviderEvents.ProviderError(
+                    OpenFeatureProviderEvents.EventDetails(message = "handshake rejected")
+                )
+            ),
+            initializeFailure = OpenFeatureError.GeneralError("handshake rejected")
+        )
+
+        instance.setProviderAndWait(provider)
+        advanceUntilIdle()
+
+        val status = assertIs<OpenFeatureStatus.Error>(instance.getStatus())
+        assertEquals("handshake rejected", status.error.message)
+    }
+
+    @Test
+    fun aProviderSupersededBeforeItsRegistrationRanIsStillRetired() = runTest {
+        val instance = createOpenFeatureAPIInstance()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val superseded = SpyProvider()
+
+        // Three fire-and-forget swaps with no chance to run in between: the middle registration's job
+        // is cancelled before it is ever dispatched, so retiring must not depend on that job running.
+        instance.setProvider(superseded, dispatcher = dispatcher)
+        instance.setProvider(NoOpProvider(), dispatcher = dispatcher)
+        instance.setProvider(NoOpProvider(), dispatcher = dispatcher)
+        advanceUntilIdle()
+
+        assertEquals(1, superseded.shutdownCalls.value, "a dropped provider must still be shut down")
+
+        // ...and must have been released from the registry, so another instance can take it on.
+        val other = createOpenFeatureAPIInstance()
+        other.setProviderAndWait(superseded)
+        advanceUntilIdle()
+        assertTrue(other.getProvider() === superseded)
+    }
+
+    @Test
+    fun reRegisteringTheSameProviderDoesNotShutItDown() = runTest {
+        val instance = createOpenFeatureAPIInstance()
+        val provider = SpyProvider()
+
+        instance.setProviderAndWait(provider)
+        instance.setProviderAndWait(provider)
+        advanceUntilIdle()
+
+        assertEquals(0, provider.shutdownCalls.value)
+        assertEquals(OpenFeatureStatus.Ready, instance.getStatus())
+    }
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
@@ -346,6 +346,80 @@ class ProviderStatusTrackerTests {
     }
 
     @Test
+    fun aNotReadyProviderDoesNotReportReconciling() = runTest {
+        val tracker = ProviderStatusTracker()
+
+        val received = record(tracker)
+        tracker.reconciling { }
+        advanceUntilIdle()
+        received.stop()
+
+        // Nothing to reconcile from, so nothing is announced; the outcome still applies.
+        assertEquals(
+            listOf(OpenFeatureProviderEvents.ProviderContextChanged::class),
+            received.map { it::class }
+        )
+        assertEquals(OpenFeatureStatus.Ready, tracker.status)
+    }
+
+    @Test
+    fun aCancelledReconciliationOnANotReadyProviderLeavesItNotReady() = runTest {
+        val tracker = ProviderStatusTracker()
+
+        val job = launch { tracker.reconciling { awaitCancellation() } }
+        runCurrent()
+        job.cancelAndJoin()
+        advanceUntilIdle()
+
+        // Reconciling was never announced, so there is nothing to restore and nothing to get stuck on.
+        assertEquals(OpenFeatureStatus.NotReady, tracker.status)
+    }
+
+    @Test
+    fun aReconciliationSupersededByResetCannotReportOverTheNextOne() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+        val staleStarted = CompletableDeferred<Unit>()
+        val releaseStale = CompletableDeferred<Unit>()
+        val freshStarted = CompletableDeferred<Unit>()
+        val releaseFresh = CompletableDeferred<Unit>()
+
+        val stale = launch {
+            tracker.reconciling {
+                staleStarted.complete(Unit)
+                releaseStale.await()
+            }
+        }
+        staleStarted.await()
+        tracker.reset()
+        assertEquals(OpenFeatureStatus.NotReady, tracker.status)
+
+        // A reconciliation belonging to the generation that replaced the superseded one.
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+        val fresh = launch {
+            runCatching {
+                tracker.reconciling {
+                    freshStarted.complete(Unit)
+                    releaseFresh.await()
+                    throw OpenFeatureError.GeneralError("fresh reconciliation failed")
+                }
+            }
+        }
+        freshStarted.await()
+
+        // The superseded invocation terminates while the fresh one is still in flight. Counting it
+        // out would make it look like the last in flight and hand it the fresh one's outcome.
+        releaseStale.complete(Unit)
+        stale.join()
+        releaseFresh.complete(Unit)
+        fresh.join()
+        advanceUntilIdle()
+
+        val status = assertIs<OpenFeatureStatus.Error>(tracker.status)
+        assertEquals("fresh reconciliation failed", status.error.message)
+    }
+
+    @Test
     fun aReconciliationCancelledThroughoutRestoresThePrecedingStatus() = runTest {
         val tracker = ProviderStatusTracker()
         tracker.send(OpenFeatureProviderEvents.ProviderStale())

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
@@ -398,9 +398,8 @@ class ProviderStatusTrackerTests {
     @Test
     fun aReconciliationAfterANotReadyOneStillResolves() = runTest {
         val tracker = ProviderStatusTracker()
-        // Reports nothing, but must still count itself out. Deciding before the invocation count is
-        // decremented strands it above zero, and every later reconciliation then reads the stale
-        // not-ready restore point and reports nothing either.
+        // Reports nothing, but must still count itself out: a stranded counter leaves every later
+        // reconciliation reading the stale not-ready restore point.
         tracker.reconciling { }
         tracker.send(OpenFeatureProviderEvents.ProviderReady())
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
@@ -1,0 +1,373 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ProviderStatusTracker]'s status transitions, its replay-on-subscribe contract, and the
+ * reconciliation coalescing that requirements 5.3.4.2 and 5.3.4.3 describe.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProviderStatusTrackerTests {
+
+    private class Recording(private val events: MutableList<OpenFeatureProviderEvents>, private val job: Job) :
+        List<OpenFeatureProviderEvents> by events {
+        suspend fun stop() = job.cancelAndJoin()
+    }
+
+    /** Collects from [tracker], returning once the subscription is established. */
+    private fun TestScope.record(tracker: ProviderStatusTracker): Recording {
+        val received = mutableListOf<OpenFeatureProviderEvents>()
+        val job = launch { tracker.observe().collect { received.add(it) } }
+        testScheduler.runCurrent()
+        return Recording(received, job)
+    }
+
+    // MARK: status transitions
+
+    @Test
+    fun aFreshTrackerIsNotReady() {
+        assertEquals(OpenFeatureStatus.NotReady, ProviderStatusTracker().status)
+    }
+
+    @Test
+    fun aProviderErrorCarryingProviderFatalBecomesFatal() {
+        val tracker = ProviderStatusTracker()
+        tracker.send(
+            OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(errorCode = ErrorCode.PROVIDER_FATAL)
+            )
+        )
+        assertIs<OpenFeatureStatus.Fatal>(tracker.status)
+    }
+
+    @Test
+    fun aProviderErrorWithoutProviderFatalBecomesError() {
+        val tracker = ProviderStatusTracker()
+        tracker.send(
+            OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(message = "boom")
+            )
+        )
+        val status = assertIs<OpenFeatureStatus.Error>(tracker.status)
+        assertEquals("boom", status.error.message)
+    }
+
+    @Test
+    fun contextChangedBecomesReady() {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderContextChanged())
+        assertEquals(OpenFeatureStatus.Ready, tracker.status)
+    }
+
+    @Test
+    fun configurationChangedLeavesTheStatusAlone() {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderStale())
+        tracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        assertEquals(OpenFeatureStatus.Stale, tracker.status)
+    }
+
+    @Test
+    fun resetReturnsTheTrackerToNotReady() {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+        tracker.reset()
+        assertEquals(OpenFeatureStatus.NotReady, tracker.status)
+    }
+
+    // MARK: replay on subscribe
+
+    @Test
+    fun nothingIsReplayedWhileNotReady() = runTest {
+        val tracker = ProviderStatusTracker()
+        val received = record(tracker)
+        advanceUntilIdle()
+        received.stop()
+
+        assertEquals(emptyList(), received.map { it::class.simpleName })
+    }
+
+    @Test
+    fun theCurrentStatusIsReplayedOnceToANewSubscriber() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderStale())
+
+        val received = record(tracker)
+        advanceUntilIdle()
+        received.stop()
+
+        assertEquals(listOf(OpenFeatureProviderEvents.ProviderStale::class), received.map { it::class })
+    }
+
+    @Test
+    fun aFatalStatusIsReplayedAsAnErrorCarryingProviderFatal() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(
+            OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(
+                    message = "unrecoverable",
+                    errorCode = ErrorCode.PROVIDER_FATAL
+                )
+            )
+        )
+
+        val received = record(tracker)
+        advanceUntilIdle()
+        received.stop()
+
+        val replayed = assertIs<OpenFeatureProviderEvents.ProviderError>(received.single())
+        assertEquals(ErrorCode.PROVIDER_FATAL, replayed.eventDetails?.errorCode)
+        assertEquals("unrecoverable", replayed.eventDetails?.message)
+    }
+
+    @Test
+    fun theReplayIsFollowedByTheLiveStreamWithoutGapsOrDuplicates() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+        val received = record(tracker)
+        tracker.send(OpenFeatureProviderEvents.ProviderStale())
+        tracker.send(OpenFeatureProviderEvents.ProviderReconciling())
+        advanceUntilIdle()
+        received.stop()
+
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class,
+                OpenFeatureProviderEvents.ProviderReconciling::class
+            ),
+            received.map { it::class }
+        )
+    }
+
+    @Test
+    fun aStatelessEventIsDeliveredButNeverReplayed() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+        // Sent before anyone subscribes: it carries no status, so there is nothing to replay it in.
+        tracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+
+        val received = record(tracker)
+        tracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        advanceUntilIdle()
+        received.stop()
+
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderConfigurationChanged::class
+            ),
+            received.map { it::class }
+        )
+    }
+
+    @Test
+    fun subscribersReplayIndependently() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+        val first = record(tracker)
+
+        tracker.send(OpenFeatureProviderEvents.ProviderStale())
+        advanceUntilIdle()
+        val second = record(tracker)
+        advanceUntilIdle()
+
+        first.stop()
+        second.stop()
+
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderStale::class
+            ),
+            first.map { it::class }
+        )
+        assertEquals(listOf(OpenFeatureProviderEvents.ProviderStale::class), second.map { it::class })
+    }
+
+    @Test
+    fun aCancelledSubscriberStopsReceivingEvents() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+        val received = record(tracker)
+        advanceUntilIdle()
+        received.stop()
+
+        tracker.send(OpenFeatureProviderEvents.ProviderStale())
+        advanceUntilIdle()
+
+        assertEquals(listOf(OpenFeatureProviderEvents.ProviderReady::class), received.map { it::class })
+    }
+
+    @Test
+    fun theStatusIsCurrentByTheTimeASubscriberSeesTheEvent() = runTest {
+        val tracker = ProviderStatusTracker()
+        val seen = mutableListOf<OpenFeatureStatus>()
+        val job = launch { tracker.observe().collect { seen.add(tracker.status) } }
+        testScheduler.runCurrent()
+
+        tracker.send(OpenFeatureProviderEvents.ProviderStale())
+        advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertEquals(listOf<OpenFeatureStatus>(OpenFeatureStatus.Stale), seen)
+    }
+
+    // MARK: reconciliation
+
+    @Test
+    fun aReconciliationReportsReconcilingThenContextChanged() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+        val received = record(tracker)
+        tracker.reconciling { }
+        advanceUntilIdle()
+        received.stop()
+
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderReconciling::class,
+                OpenFeatureProviderEvents.ProviderContextChanged::class
+            ),
+            received.map { it::class }
+        )
+        assertEquals(OpenFeatureStatus.Ready, tracker.status)
+    }
+
+    @Test
+    fun aFailedReconciliationReportsAnErrorAndRethrows() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+        val received = record(tracker)
+        var thrown: Throwable? = null
+        try {
+            tracker.reconciling { throw OpenFeatureError.GeneralError("reconcile failed") }
+        } catch (e: Throwable) {
+            thrown = e
+        }
+        advanceUntilIdle()
+        received.stop()
+
+        assertIs<OpenFeatureError.GeneralError>(thrown)
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderReconciling::class,
+                OpenFeatureProviderEvents.ProviderError::class
+            ),
+            received.map { it::class }
+        )
+        val status = assertIs<OpenFeatureStatus.Error>(tracker.status)
+        assertEquals("reconcile failed", status.error.message)
+    }
+
+    @Test
+    fun aBlockThatReportsItsOwnFailureIsNotReportedForTwice() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+        val received = record(tracker)
+        try {
+            tracker.reconciling {
+                tracker.send(
+                    OpenFeatureProviderEvents.ProviderError(
+                        OpenFeatureProviderEvents.EventDetails(message = "reported by the provider")
+                    )
+                )
+                throw OpenFeatureError.GeneralError("thrown as well")
+            }
+        } catch (_: Throwable) {
+            // Reported through the event stream; the throw is the provider's own to see.
+        }
+        advanceUntilIdle()
+        received.stop()
+
+        val errors = received.filterIsInstance<OpenFeatureProviderEvents.ProviderError>()
+        assertEquals(1, errors.size, "collected ${received.map { it::class.simpleName }}")
+        assertEquals("reported by the provider", errors.single().eventDetails?.message)
+    }
+
+    @Test
+    fun overlappingReconciliationsReportReconcilingOnceAndTheLastOutcome() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+        val firstStarted = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+
+        val received = record(tracker)
+        val first = launch {
+            tracker.reconciling {
+                firstStarted.complete(Unit)
+                releaseFirst.await()
+            }
+        }
+        firstStarted.await()
+        val second = launch { tracker.reconciling { } }
+        runCurrent()
+
+        // The second finished, but the first is still in flight, so no outcome is reported yet.
+        assertEquals(OpenFeatureStatus.Reconciling, tracker.status)
+
+        releaseFirst.complete(Unit)
+        first.join()
+        second.join()
+        advanceUntilIdle()
+        received.stop()
+
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReady::class,
+                OpenFeatureProviderEvents.ProviderReconciling::class,
+                OpenFeatureProviderEvents.ProviderContextChanged::class
+            ),
+            received.map { it::class }
+        )
+    }
+
+    @Test
+    fun aReconciliationCancelledThroughoutRestoresThePrecedingStatus() = runTest {
+        val tracker = ProviderStatusTracker()
+        tracker.send(OpenFeatureProviderEvents.ProviderStale())
+
+        val received = record(tracker)
+        val job = launch { tracker.reconciling { awaitCancellation() } }
+        runCurrent()
+        assertEquals(OpenFeatureStatus.Reconciling, tracker.status)
+
+        job.cancelAndJoin()
+        advanceUntilIdle()
+        received.stop()
+
+        assertEquals(OpenFeatureStatus.Stale, tracker.status)
+        assertTrue(
+            received.map { it::class }.containsAll(
+                listOf(
+                    OpenFeatureProviderEvents.ProviderReconciling::class,
+                    OpenFeatureProviderEvents.ProviderStale::class
+                )
+            ),
+            "collected ${received.map { it::class.simpleName }}"
+        )
+    }
+}

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerTests.kt
@@ -346,7 +346,7 @@ class ProviderStatusTrackerTests {
     }
 
     @Test
-    fun aNotReadyProviderDoesNotReportReconciling() = runTest {
+    fun aReconciliationOnANotReadyProviderReportsNothing() = runTest {
         val tracker = ProviderStatusTracker()
 
         val received = record(tracker)
@@ -354,12 +354,65 @@ class ProviderStatusTrackerTests {
         advanceUntilIdle()
         received.stop()
 
-        // Nothing to reconcile from, so nothing is announced; the outcome still applies.
+        // Readiness is initialize's to report, so reconciling a context cannot confer it.
+        assertEquals(emptyList(), received.map { it::class.simpleName })
+        assertEquals(OpenFeatureStatus.NotReady, tracker.status)
+    }
+
+    @Test
+    fun aFailedReconciliationOnANotReadyProviderReportsNothingAndStillThrows() = runTest {
+        val tracker = ProviderStatusTracker()
+
+        val received = record(tracker)
+        var thrown: Throwable? = null
+        try {
+            tracker.reconciling { throw OpenFeatureError.GeneralError("reconcile failed") }
+        } catch (e: Throwable) {
+            thrown = e
+        }
+        advanceUntilIdle()
+        received.stop()
+
+        assertIs<OpenFeatureError.GeneralError>(thrown)
+        assertEquals(emptyList(), received.map { it::class.simpleName })
+        assertEquals(OpenFeatureStatus.NotReady, tracker.status)
+    }
+
+    @Test
+    fun aNotReadyProviderThatReportsFromInsideTheBlockIsBelieved() = runTest {
+        val tracker = ProviderStatusTracker()
+
+        val received = record(tracker)
+        // The gate suppresses what the SDK would synthesise, not the provider's own voice.
+        tracker.reconciling { tracker.send(OpenFeatureProviderEvents.ProviderReady()) }
+        advanceUntilIdle()
+        received.stop()
+
         assertEquals(
-            listOf(OpenFeatureProviderEvents.ProviderContextChanged::class),
+            listOf(OpenFeatureProviderEvents.ProviderReady::class),
             received.map { it::class }
         )
         assertEquals(OpenFeatureStatus.Ready, tracker.status)
+    }
+
+    @Test
+    fun aReconciliationAfterANotReadyOneStillResolves() = runTest {
+        val tracker = ProviderStatusTracker()
+        // Reports nothing, but must still count itself out. Deciding before the invocation count is
+        // decremented strands it above zero, and every later reconciliation then reads the stale
+        // not-ready restore point and reports nothing either.
+        tracker.reconciling { }
+        tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+        try {
+            tracker.reconciling { throw OpenFeatureError.GeneralError("later reconcile failed") }
+        } catch (_: Throwable) {
+            // Reported through the event stream; the throw is the provider's own to see.
+        }
+        advanceUntilIdle()
+
+        val status = assertIs<OpenFeatureStatus.Error>(tracker.status)
+        assertEquals("later reconcile failed", status.error.message)
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
@@ -5,6 +5,7 @@ import dev.openfeature.kotlin.sdk.helpers.BrokenInitProvider
 import dev.openfeature.kotlin.sdk.helpers.DoSomethingProvider
 import dev.openfeature.kotlin.sdk.helpers.SlowProvider
 import dev.openfeature.kotlin.sdk.helpers.SpyProvider
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
@@ -94,11 +95,17 @@ class StatusTests {
         OpenFeatureAPI.setProviderAndWait(DoSomethingProvider())
         waitAssert { assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus()) }
         OpenFeatureAPI.setEvaluationContextAndWait(ImmutableContext("some value"))
-        waitAssert { assertEquals(OpenFeatureStatus.Reconciling, OpenFeatureAPI.getStatus()) }
-        waitAssert {
-            assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
-        }
+        advanceUntilIdle()
         job.cancelAndJoin()
+
+        // Reconciling is transient: it has already been superseded by the time the call returns, so
+        // it can only be observed in the collected sequence, not by polling getStatus().
+        assertTrue(
+            statuses.contains(OpenFeatureStatus.Reconciling),
+            "expected a Reconciling transition, collected $statuses"
+        )
+        assertEquals(OpenFeatureStatus.Ready, statuses.last())
+        assertEquals(OpenFeatureStatus.Ready, OpenFeatureAPI.getStatus())
     }
 
     @Test
@@ -342,14 +349,18 @@ private class CancellationRaceProvider : NoOpProvider() {
 
 private fun Duration.Companion.randomMs(min: Int, max: Int): Duration = Random.nextInt(min, max + 1).milliseconds
 
+/** Retries [function] until it passes, rethrowing its last failure once [timeoutMs] is exhausted. */
 @OptIn(ExperimentalCoroutinesApi::class)
 suspend fun TestScope.waitAssert(timeoutMs: Long = 5000, function: () -> Unit) {
     var timeWaited = 0L
-    while (timeWaited < timeoutMs) {
+    while (true) {
         try {
             function()
             return
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Throwable) {
+            if (timeWaited >= timeoutMs) throw e
             delay(10)
             timeWaited += 10
             advanceUntilIdle()

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
@@ -81,6 +81,7 @@ class StatusTests {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun testProviderTransitionsToReconcilingOnContextSet() = runTest {
         waitAssert {
             assertEquals(OpenFeatureStatus.NotReady, OpenFeatureAPI.getStatus())

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
@@ -157,9 +157,9 @@ class StatusTests {
         // The registration's dispatcher is what runs its reconciliations, so virtual time needs it.
         OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
 
-        OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"), dispatcher)
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"))
         provider.firstContextSetStarted.receive()
-        OpenFeatureAPI.setEvaluationContext(ImmutableContext("replacement"), dispatcher)
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("replacement"))
         provider.firstContextSetCancellationStarted.receive()
         provider.replacementContextSetCompleted.receive()
         runCurrent()
@@ -179,9 +179,9 @@ class StatusTests {
         OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
         runCurrent()
 
-        OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"), dispatcher)
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"))
         provider.firstContextSetStarted.receive()
-        OpenFeatureAPI.setEvaluationContext(ImmutableContext("replacement"), dispatcher)
+        OpenFeatureAPI.setEvaluationContext(ImmutableContext("replacement"))
         provider.firstContextSetCancellationStarted.receive()
         provider.replacementContextSetCompleted.receive()
         runCurrent()

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/StatusTests.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -155,7 +154,8 @@ class StatusTests {
     fun testCancelledContextSetFinishingLastUsesReplacementStatus() = runTest {
         val provider = CancellationRaceProvider()
         val dispatcher = StandardTestDispatcher(testScheduler)
-        OpenFeatureAPI.setProviderAndWait(provider)
+        // The registration's dispatcher is what runs its reconciliations, so virtual time needs it.
+        OpenFeatureAPI.setProviderAndWait(provider, dispatcher = dispatcher)
 
         OpenFeatureAPI.setEvaluationContext(ImmutableContext("first"), dispatcher)
         provider.firstContextSetStarted.receive()
@@ -303,15 +303,30 @@ class StatusTests {
 }
 
 private class ControllableContextProvider : NoOpProvider() {
+    private val statusTracker = ProviderStatusTracker()
+
     val contextSetStarted = Channel<Unit>(Channel.UNLIMITED)
     val allowContextSetToComplete = Channel<Unit>(Channel.UNLIMITED)
     val contextSetCompleted = Channel<Unit>(Channel.UNLIMITED)
 
-    override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
+    override suspend fun initialize(initialContext: EvaluationContext?) {
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
+    }
+
+    override suspend fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) = statusTracker.reconciling {
         contextSetStarted.send(Unit)
         allowContextSetToComplete.receive()
         contextSetCompleted.send(Unit)
     }
+
+    override fun shutdown() = statusTracker.reset()
 }
 
 private class CancellationRaceProvider : NoOpProvider() {
@@ -320,16 +335,27 @@ private class CancellationRaceProvider : NoOpProvider() {
     val allowFirstContextSetToFinish = Channel<Unit>(Channel.UNLIMITED)
     val replacementContextSetCompleted = Channel<Unit>(Channel.UNLIMITED)
 
-    private val events = MutableSharedFlow<OpenFeatureProviderEvents>(extraBufferCapacity = 1)
+    private val statusTracker = ProviderStatusTracker()
     private var contextSetCalls = 0
 
-    override fun observe(): Flow<OpenFeatureProviderEvents> = events
+    override val status: OpenFeatureStatus get() = statusTracker.status
 
-    fun emitStale() {
-        events.tryEmit(OpenFeatureProviderEvents.ProviderStale())
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
+    override suspend fun initialize(initialContext: EvaluationContext?) {
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
-    override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+    override fun shutdown() = statusTracker.reset()
+
+    fun emitStale() {
+        statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
+    }
+
+    override suspend fun onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) = statusTracker.reconciling {
         contextSetCalls++
         if (contextSetCalls == 1) {
             firstContextSetStarted.send(Unit)

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/AutoHealingProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/AutoHealingProvider.kt
@@ -11,6 +11,7 @@ import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 
@@ -21,7 +22,10 @@ class AutoHealingProvider(
     override val metadata: ProviderMetadata = object : ProviderMetadata {
         override val name: String = "AutoHealingProvider"
     }
-    private var ready = false
+    private val readyState = atomic(false)
+    private var ready: Boolean
+        get() = readyState.value
+        set(value) { readyState.value = value }
 
     private val statusTracker = ProviderStatusTracker()
 
@@ -40,8 +44,8 @@ class AutoHealingProvider(
             )
         )
         delay(healDelay)
-        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
         ready = true
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
     override fun shutdown() {

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/AutoHealingProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/AutoHealingProvider.kt
@@ -3,15 +3,16 @@ package dev.openfeature.kotlin.sdk.helpers
 import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 
 class AutoHealingProvider(
     val healDelay: Long = 1000L,
@@ -21,10 +22,16 @@ class AutoHealingProvider(
         override val name: String = "AutoHealingProvider"
     }
     private var ready = false
-    private val _events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
+
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     override suspend fun initialize(initialContext: EvaluationContext?) {
         ready = false
-        _events.emit(
+        statusTracker.send(
             OpenFeatureProviderEvents.ProviderError(
                 OpenFeatureProviderEvents.EventDetails(
                     message = "AutoHealingProvider got an error. trying to heal",
@@ -33,12 +40,13 @@ class AutoHealingProvider(
             )
         )
         delay(healDelay)
-        _events.emit(OpenFeatureProviderEvents.ProviderReady())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
         ready = true
     }
 
     override fun shutdown() {
-        // no-op
+        ready = false
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(
@@ -100,9 +108,5 @@ class AutoHealingProvider(
     ): ProviderEvaluation<Value> {
         if (!ready) throw OpenFeatureError.FlagNotFoundError(key)
         return ProviderEvaluation(Value.Null)
-    }
-
-    override fun observe(): Flow<OpenFeatureProviderEvents> {
-        return _events
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/BrokenInitProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/BrokenInitProvider.kt
@@ -24,7 +24,6 @@ class BrokenInitProvider(
     override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
-        // Reported before throwing: the SDK derives no status from a thrown exception.
         val error = OpenFeatureError.ProviderNotReadyError("test error from $this")
         statusTracker.send(
             OpenFeatureProviderEvents.ProviderError(

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/BrokenInitProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/BrokenInitProvider.kt
@@ -3,23 +3,42 @@ package dev.openfeature.kotlin.sdk.helpers
 import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError.FlagNotFoundError
+import kotlinx.coroutines.flow.Flow
 
 class BrokenInitProvider(
     override var hooks: List<Hook<*>> = listOf(),
     override var metadata: ProviderMetadata = AlwaysBrokenProviderMetadata()
-) :
-    FeatureProvider {
+) : FeatureProvider {
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     override suspend fun initialize(initialContext: EvaluationContext?) {
-        throw OpenFeatureError.ProviderNotReadyError("test error from $this")
+        // Reported before throwing: the SDK derives no status from a thrown exception.
+        val error = OpenFeatureError.ProviderNotReadyError("test error from $this")
+        statusTracker.send(
+            OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(
+                    message = error.message,
+                    errorCode = error.errorCode()
+                )
+            )
+        )
+        throw error
     }
 
     override fun shutdown() {
-        // no-op
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/DoSomethingProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/DoSomethingProvider.kt
@@ -4,20 +4,23 @@ import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.EvaluationMetadata
 import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 
 open class DoSomethingProvider(
     override val hooks: List<Hook<*>> = listOf(),
     override val metadata: ProviderMetadata = DoSomethingProviderMetadata()
 ) : FeatureProvider {
-    protected val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 5)
+    protected val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
     companion object {
         val evaluationMetadata = EvaluationMetadata.builder()
             .putString("key1", "value1")
@@ -27,19 +30,19 @@ open class DoSomethingProvider(
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
         delay(1000)
-        events.emit(OpenFeatureProviderEvents.ProviderReady())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
     override fun shutdown() {
-        // no-op
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
-    ) {
+    ) = statusTracker.reconciling {
         delay(500)
-        events.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
     }
 
     override fun getBooleanEvaluation(
@@ -95,9 +98,7 @@ open class DoSomethingProvider(
 
     class DoSomethingProviderMetadata(override val name: String? = "something") : ProviderMetadata
 
-    override fun observe(): Flow<OpenFeatureProviderEvents> {
-        return events
-    }
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
 }
 
 class OverlyEmittingProvider(name: String) : DoSomethingProvider(
@@ -109,8 +110,8 @@ class OverlyEmittingProvider(name: String) : DoSomethingProvider(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) {
-        events.emit(OpenFeatureProviderEvents.ProviderStale())
-        events.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
     }
 
     override fun track(
@@ -119,8 +120,8 @@ class OverlyEmittingProvider(name: String) : DoSomethingProvider(
         details: TrackingEventDetails?
     ) {
         super.track(trackingEventName, context, details)
-        events.tryEmit(OpenFeatureProviderEvents.ProviderStale())
-        events.tryEmit(OpenFeatureProviderEvents.ProviderStale())
-        events.tryEmit(OpenFeatureProviderEvents.ProviderStale())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
     }
 }

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/RecordingBooleanProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/RecordingBooleanProvider.kt
@@ -35,7 +35,7 @@ class RecordingBooleanProvider(
     }
 
     override fun shutdown() {
-        // no-op
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/RecordingBooleanProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/RecordingBooleanProvider.kt
@@ -3,14 +3,24 @@ package dev.openfeature.kotlin.sdk.helpers
 import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import kotlinx.coroutines.flow.Flow
 
 class RecordingBooleanProvider(
     private val name: String,
     private val behavior: () -> ProviderEvaluation<Boolean>
 ) : FeatureProvider {
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     override val hooks: List<Hook<*>> = emptyList()
     override val metadata: ProviderMetadata = object : ProviderMetadata {
         override val name: String? = this@RecordingBooleanProvider.name
@@ -20,6 +30,7 @@ class RecordingBooleanProvider(
         private set
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
         // no-op
     }
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/RecordingBooleanProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/RecordingBooleanProvider.kt
@@ -31,7 +31,6 @@ class RecordingBooleanProvider(
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
         statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
-        // no-op
     }
 
     override fun shutdown() {

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/SlowProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/SlowProvider.kt
@@ -3,36 +3,48 @@ package dev.openfeature.kotlin.sdk.helpers
 import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 
 class SlowProvider(
     override val hooks: List<Hook<*>> = listOf(),
     private var dispatcher: CoroutineDispatcher,
     override val metadata: ProviderMetadata = SlowProviderMetadata("Slow provider")
 ) : FeatureProvider {
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     internal var ready = false
     override suspend fun initialize(initialContext: EvaluationContext?) {
         CoroutineScope(dispatcher).async {
             delay(2000)
         }.await()
         ready = true
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
     override fun shutdown() {
-        // no-op
+        ready = false
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
-    ) {
+    ) = statusTracker.reconciling {
         CoroutineScope(dispatcher).async {
             delay(2000)
         }.await()

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/SpyProvider.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/helpers/SpyProvider.kt
@@ -3,12 +3,22 @@ package dev.openfeature.kotlin.sdk.helpers
 import dev.openfeature.kotlin.sdk.EvaluationContext
 import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.Flow
 
 class SpyProvider : FeatureProvider {
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     override val hooks: List<Hook<*>>
         get() = TODO("Not yet implemented")
     override val metadata: ProviderMetadata
@@ -19,17 +29,19 @@ class SpyProvider : FeatureProvider {
     val shutdownCalls = atomic(0)
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
         initializeCalls.add(initialContext)
     }
 
     override fun shutdown() {
         shutdownCalls.incrementAndGet()
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
-    ) {
+    ) = statusTracker.reconciling {
         onContextSetCalls.add(Pair(oldContext, newContext))
     }
 

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
@@ -12,6 +12,7 @@ import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
@@ -486,6 +487,40 @@ class MultiProviderTests {
         advanceUntilIdle()
 
         assertEquals(OpenFeatureStatus.NotReady, multi.status)
+    }
+
+    @Test
+    fun aChildCancellingItsOwnShutdownDoesNotStopTheOthers() {
+        // A child that throws CancellationException out of its own teardown — cancelling an internal
+        // scope, say. shutdown is not suspending, so that is an ordinary failure, not this call being
+        // cancelled: rethrowing it would abandon every child after this one.
+        val first = FakeEventProvider(
+            name = "first",
+            shutdownThrowable = CancellationException("child cancelled its own scope")
+        )
+        val second = FakeEventProvider(name = "second")
+
+        val multi = MultiProvider(listOf(first, second))
+        val error = assertFailsWith<OpenFeatureError.GeneralError> { multi.shutdown() }
+
+        assertEquals(1, first.shutdownCalls)
+        assertEquals(1, second.shutdownCalls, "a cancelling sibling must not stop this one")
+        assertTrue(error.message.contains("first: child cancelled its own scope"), error.message)
+    }
+
+    @Test
+    fun aChildCancellingItsOwnTrackingDoesNotStopTheOthers() {
+        val first = FakeEventProvider(
+            name = "first",
+            trackThrowable = CancellationException("child cancelled its own scope")
+        )
+        val second = FakeEventProvider(name = "second")
+
+        val multi = MultiProvider(listOf(first, second))
+        assertFailsWith<OpenFeatureError.GeneralError> { multi.track("event", null, null) }
+
+        assertEquals(1, first.trackingCalls)
+        assertEquals(1, second.trackingCalls, "a cancelling sibling must not stop this one")
     }
 
     @Test

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
@@ -14,6 +14,7 @@ import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -350,6 +351,144 @@ class MultiProviderTests {
     }
 
     @Test
+    fun aCancelledContextSetDoesNotLeaveTheAggregateReconciling() = runTest {
+        val provider = FakeEventProvider(
+            name = "A",
+            eventsToEmitOnInit = listOf(OpenFeatureProviderEvents.ProviderReady()),
+            gateContextSet = true
+        )
+        val multi = MultiProvider(listOf(provider))
+        multi.initialize(null)
+        advanceUntilIdle()
+        assertEquals(OpenFeatureStatus.Ready, multi.status)
+
+        val contextSet = launch { multi.onContextSet(null, ImmutableContext("ctx")) }
+        provider.contextSetStarted.receive()
+        assertEquals(OpenFeatureStatus.Reconciling, multi.status)
+
+        contextSet.cancelAndJoin()
+        advanceUntilIdle()
+
+        // The tracker restores the status that preceded the reconciliation rather than stranding it.
+        assertEquals(OpenFeatureStatus.Ready, multi.status)
+    }
+
+    @Test
+    fun overlappingContextSetsReportReconcilingOnceAndOnlyTheLastOutcome() = runTest {
+        val provider = FakeEventProvider(
+            name = "A",
+            eventsToEmitOnInit = listOf(OpenFeatureProviderEvents.ProviderReady()),
+            gateContextSet = true
+        )
+        val multi = MultiProvider(listOf(provider))
+        multi.initialize(null)
+        advanceUntilIdle()
+
+        val collected = mutableListOf<OpenFeatureProviderEvents>()
+        val collectJob = launch { multi.observe().collect { collected.add(it) } }
+        advanceUntilIdle()
+        collected.clear()
+
+        val first = launch { multi.onContextSet(null, ImmutableContext("first")) }
+        provider.contextSetStarted.receive()
+        val second = launch { multi.onContextSet(null, ImmutableContext("second")) }
+        provider.contextSetStarted.receive()
+
+        provider.allowContextSetToComplete.send(Unit)
+        first.join()
+        advanceUntilIdle()
+        // The first to terminate must not resolve a reconciliation the second is still running.
+        assertEquals(OpenFeatureStatus.Reconciling, multi.status)
+
+        provider.allowContextSetToComplete.send(Unit)
+        second.join()
+        advanceUntilIdle()
+        collectJob.cancelAndJoin()
+
+        assertEquals(OpenFeatureStatus.Ready, multi.status)
+        assertEquals(
+            listOf(
+                OpenFeatureProviderEvents.ProviderReconciling::class,
+                OpenFeatureProviderEvents.ProviderContextChanged::class
+            ),
+            collected.map { it::class }
+        )
+    }
+
+    @Test
+    fun anErrorAggregateCarriesTheTriggeringChildDetails() = runTest {
+        val provider = FakeEventProvider(
+            name = "A",
+            eventsToEmitOnInit = listOf(OpenFeatureProviderEvents.ProviderReady())
+        )
+        val multi = MultiProvider(listOf(provider))
+        multi.initialize(null)
+        advanceUntilIdle()
+
+        val collected = mutableListOf<OpenFeatureProviderEvents>()
+        val collectJob = launch { multi.observe().collect { collected.add(it) } }
+        advanceUntilIdle()
+        collected.clear()
+
+        provider.emit(
+            OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(
+                    flagsChanged = setOf("a", "b"),
+                    message = "child failed",
+                    eventMetadata = mapOf("origin" to "A")
+                )
+            )
+        )
+        advanceUntilIdle()
+        collectJob.cancelAndJoin()
+
+        val reported = assertIs<OpenFeatureProviderEvents.ProviderError>(collected.single())
+        assertEquals(setOf("a", "b"), reported.eventDetails?.flagsChanged)
+        assertEquals(mapOf<String, Any>("origin" to "A"), reported.eventDetails?.eventMetadata)
+    }
+
+    @Test
+    fun aChildFailingToInitializeDoesNotStopItsSiblings() = runTest {
+        val failing = FakeEventProvider(
+            name = "failing",
+            initializeThrowable = OpenFeatureError.GeneralError("cannot start")
+        )
+        val healthy = FakeEventProvider(
+            name = "healthy",
+            eventsToEmitOnInit = listOf(OpenFeatureProviderEvents.ProviderReady())
+        )
+        val multi = MultiProvider(listOf(failing, healthy))
+
+        multi.initialize(null)
+        advanceUntilIdle()
+
+        assertEquals(1, failing.initializeCalls)
+        assertEquals(1, healthy.initializeCalls, "a failing sibling must not cancel this one")
+        // The failing child reported nothing, so it is still not-ready and outranks the healthy one.
+        assertEquals(OpenFeatureStatus.NotReady, multi.status)
+    }
+
+    @Test
+    fun anAggregateReturningToNotReadyIsReported() = runTest {
+        val provider = FakeEventProvider(
+            name = "A",
+            eventsToEmitOnInit = listOf(OpenFeatureProviderEvents.ProviderReady())
+        )
+        val multi = MultiProvider(listOf(provider))
+        multi.initialize(null)
+        advanceUntilIdle()
+        assertEquals(OpenFeatureStatus.Ready, multi.status)
+
+        // The child is taken down on its own, so the aggregate is no longer ready. There is no event
+        // describing not-ready, so this is observable through the status rather than through observe().
+        provider.shutdown()
+        provider.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+        advanceUntilIdle()
+
+        assertEquals(OpenFeatureStatus.NotReady, multi.status)
+    }
+
+    @Test
     fun shutdownAggregatesErrorsAndReportsProviderNames() {
         val ok = FakeEventProvider(name = "ok")
         val bad1 = FakeEventProvider(name = "bad1", shutdownThrowable = IllegalStateException("oops1"))
@@ -427,8 +566,12 @@ private class FakeEventProvider(
     private val name: String?,
     private val eventsToEmitOnInit: List<OpenFeatureProviderEvents> = emptyList(),
     private val shutdownThrowable: Throwable? = null,
-    private val trackThrowable: Throwable? = null
+    private val trackThrowable: Throwable? = null,
+    private val initializeThrowable: Throwable? = null,
+    private val gateContextSet: Boolean = false
 ) : FeatureProvider {
+    val contextSetStarted = Channel<Unit>(Channel.UNLIMITED)
+    val allowContextSetToComplete = Channel<Unit>(Channel.UNLIMITED)
     override val hooks: List<Hook<*>> = emptyList()
     override val metadata: ProviderMetadata = object : ProviderMetadata {
         override val name: String? = this@FakeEventProvider.name
@@ -453,17 +596,23 @@ private class FakeEventProvider(
         initializeCalls += 1
         // Emit any preconfigured events during initialize so MultiProvider observers receive them
         eventsToEmitOnInit.forEach { statusTracker.send(it) }
+        initializeThrowable?.let { throw it }
     }
 
     fun emit(event: OpenFeatureProviderEvents) = statusTracker.send(event)
 
     override fun shutdown() {
         shutdownCalls += 1
+        statusTracker.reset()
         shutdownThrowable?.let { throw it }
     }
 
     override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
         onContextSetCalls += 1
+        if (gateContextSet) {
+            contextSetStarted.send(Unit)
+            allowContextSetToComplete.receive()
+        }
     }
 
     override fun getBooleanEvaluation(

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
@@ -480,8 +480,7 @@ class MultiProviderTests {
         advanceUntilIdle()
         assertEquals(OpenFeatureStatus.Ready, multi.status)
 
-        // The child is taken down on its own, so the aggregate is no longer ready. There is no event
-        // describing not-ready, so this is observable through the status rather than through observe().
+        // No event describes not-ready, so this is observable through the status, not observe().
         provider.shutdown()
         provider.emit(OpenFeatureProviderEvents.ProviderConfigurationChanged())
         advanceUntilIdle()
@@ -490,10 +489,29 @@ class MultiProviderTests {
     }
 
     @Test
+    fun aChildReconcilingOnItsOwnAccountDoesNotLatchTheAggregate() = runTest {
+        val provider = FakeEventProvider(
+            name = "A",
+            eventsToEmitOnInit = listOf(OpenFeatureProviderEvents.ProviderReady())
+        )
+        val multi = MultiProvider(listOf(provider))
+        multi.initialize(null)
+        advanceUntilIdle()
+
+        // Not driven by MultiProvider.onContextSet, so there is no reconciliation of its own to
+        // report the outcome: the aggregate has to follow the child back to ready.
+        provider.emit(OpenFeatureProviderEvents.ProviderReconciling())
+        advanceUntilIdle()
+        assertEquals(OpenFeatureStatus.Reconciling, multi.status)
+
+        provider.emit(OpenFeatureProviderEvents.ProviderContextChanged())
+        advanceUntilIdle()
+        assertEquals(OpenFeatureStatus.Ready, multi.status)
+    }
+
+    @Test
     fun aChildCancellingItsOwnShutdownDoesNotStopTheOthers() {
-        // A child that throws CancellationException out of its own teardown — cancelling an internal
-        // scope, say. shutdown is not suspending, so that is an ordinary failure, not this call being
-        // cancelled: rethrowing it would abandon every child after this one.
+        // shutdown is not suspending, so a child's CancellationException is an ordinary failure.
         val first = FakeEventProvider(
             name = "first",
             shutdownThrowable = CancellationException("child cancelled its own scope")

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
@@ -174,7 +174,7 @@ class MultiProviderTests {
         advanceUntilIdle()
 
         // Final aggregate status should be ERROR (C ends in ERROR; beats READY and STALE)
-        val finalStatus = multi.statusFlow.value
+        val finalStatus = multi.status
         assertIs<OpenFeatureStatus.Error>(finalStatus)
         initJob.cancelAndJoin()
     }
@@ -205,7 +205,7 @@ class MultiProviderTests {
         val initJob = launch { multi.initialize(null) }
         advanceUntilIdle()
 
-        val finalStatus = multi.statusFlow.value
+        val finalStatus = multi.status
         val errStatus = assertIs<OpenFeatureStatus.Fatal>(finalStatus)
         assertIs<OpenFeatureError.ProviderFatalError>(errStatus.error)
         initJob.cancelAndJoin()
@@ -245,7 +245,7 @@ class MultiProviderTests {
         val initJob = launch { multi.initialize(null) }
         advanceUntilIdle()
 
-        val finalStatus = multi.statusFlow.value
+        val finalStatus = multi.status
         assertIs<OpenFeatureStatus.Error>(finalStatus)
         initJob.cancelAndJoin()
     }
@@ -283,7 +283,7 @@ class MultiProviderTests {
         val initJob = launch { multi.initialize(null) }
         advanceUntilIdle()
 
-        val finalStatus = multi.statusFlow.value
+        val finalStatus = multi.status
         assertIs<OpenFeatureStatus.NotReady>(finalStatus)
         initJob.cancelAndJoin()
     }
@@ -294,8 +294,7 @@ class MultiProviderTests {
             name = "A",
             eventsToEmitOnInit = listOf(
                 OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderReady(),
-                OpenFeatureProviderEvents.ProviderStale()
+                OpenFeatureProviderEvents.ProviderReady()
             )
         )
         val multi = MultiProvider(listOf(provider))
@@ -306,11 +305,16 @@ class MultiProviderTests {
         val initJob = launch { multi.initialize(null) }
         advanceUntilIdle()
 
+        // A later transition is reported, an unchanged aggregate is not.
+        provider.emit(OpenFeatureProviderEvents.ProviderStale())
+        advanceUntilIdle()
+        provider.emit(OpenFeatureProviderEvents.ProviderStale())
+        advanceUntilIdle()
+
         collectJob.cancelAndJoin()
         initJob.cancelAndJoin()
 
         val nonConfig = collected.filter { it !is OpenFeatureProviderEvents.ProviderConfigurationChanged }
-        // Should only emit Ready once (transition) and Stale once (transition)
         assertEquals(
             listOf(
                 OpenFeatureProviderEvents.ProviderReady(),
@@ -450,6 +454,8 @@ private class FakeEventProvider(
         // Emit any preconfigured events during initialize so MultiProvider observers receive them
         eventsToEmitOnInit.forEach { statusTracker.send(it) }
     }
+
+    fun emit(event: OpenFeatureProviderEvents) = statusTracker.send(event)
 
     override fun shutdown() {
         shutdownCalls += 1

--- a/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
+++ b/kotlin-sdk/src/commonTest/kotlin/dev/openfeature/kotlin/sdk/multiprovider/MultiProviderTests.kt
@@ -7,6 +7,7 @@ import dev.openfeature.kotlin.sdk.ImmutableContext
 import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.TrackingEventDetails
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
@@ -14,7 +15,6 @@ import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -430,7 +430,11 @@ private class FakeEventProvider(
         override val name: String? = this@FakeEventProvider.name
     }
 
-    private val events = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1, extraBufferCapacity = 16)
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
 
     var initializeCalls: Int = 0
         private set
@@ -444,7 +448,7 @@ private class FakeEventProvider(
     override suspend fun initialize(initialContext: EvaluationContext?) {
         initializeCalls += 1
         // Emit any preconfigured events during initialize so MultiProvider observers receive them
-        eventsToEmitOnInit.forEach { events.emit(it) }
+        eventsToEmitOnInit.forEach { statusTracker.send(it) }
     }
 
     override fun shutdown() {
@@ -503,8 +507,6 @@ private class FakeEventProvider(
     ): ProviderEvaluation<Value> {
         return ProviderEvaluation(defaultValue)
     }
-
-    override fun observe(): Flow<OpenFeatureProviderEvents> = events
 
     override fun track(
         trackingEventName: String,

--- a/kotlin-sdk/src/iosMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/iosMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -21,10 +21,7 @@ actual object LoggerFactory {
 internal class IosLogger(private val tag: String) : Logger {
     private fun prefix(level: String) = "[$level] $tag - "
 
-    /**
-     * NSLog is variadic, and its format reads this argument as an NSObject pointer. Passing a Kotlin
-     * String straight through hands it a raw value instead and segfaults, so it is bridged first.
-     */
+    /** Bridged through NSString: variadic NSLog reads the argument as a pointer and segfaults. */
     private fun log(line: String) = NSLog("%@", NSString.create(string = line))
 
     override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {

--- a/kotlin-sdk/src/iosMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
+++ b/kotlin-sdk/src/iosMain/kotlin/dev/openfeature/kotlin/sdk/logging/LoggerFactory.kt
@@ -1,6 +1,8 @@
 package dev.openfeature.kotlin.sdk.logging
 
 import platform.Foundation.NSLog
+import platform.Foundation.NSString
+import platform.Foundation.create
 
 /**
  * iOS platform implementation of LoggerFactory.
@@ -19,19 +21,25 @@ actual object LoggerFactory {
 internal class IosLogger(private val tag: String) : Logger {
     private fun prefix(level: String) = "[$level] $tag - "
 
+    /**
+     * NSLog is variadic, and its format reads this argument as an NSObject pointer. Passing a Kotlin
+     * String straight through hands it a raw value instead and segfaults, so it is bridged first.
+     */
+    private fun log(line: String) = NSLog("%@", NSString.create(string = line))
+
     override fun debug(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
-        NSLog("%@", formatLogLine(prefix("DEBUG") + message(), attributes(), throwable))
+        log(formatLogLine(prefix("DEBUG") + message(), attributes(), throwable))
     }
 
     override fun info(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
-        NSLog("%@", formatLogLine(prefix("INFO") + message(), attributes(), throwable))
+        log(formatLogLine(prefix("INFO") + message(), attributes(), throwable))
     }
 
     override fun warn(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
-        NSLog("%@", formatLogLine(prefix("WARN") + message(), attributes(), throwable))
+        log(formatLogLine(prefix("WARN") + message(), attributes(), throwable))
     }
 
     override fun error(message: () -> String, attributes: () -> Map<String, Any?>, throwable: Throwable?) {
-        NSLog("%@", formatLogLine(prefix("ERROR") + message(), attributes(), throwable))
+        log(formatLogLine(prefix("ERROR") + message(), attributes(), throwable))
     }
 }

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleOrderingTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderLifecycleOrderingTest.kt
@@ -1,0 +1,63 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.isolated.ExperimentalIsolatedApi
+import dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val ITERATIONS = 300
+
+/**
+ * Racing setProvider against a concurrent setEvaluationContext, which only JVM and native can do —
+ * JS is single-threaded.
+ */
+@OptIn(ExperimentalIsolatedApi::class)
+class ProviderLifecycleOrderingTest {
+
+    @AfterTest
+    fun tearDown() {
+        OpenFeatureAPIInstance.clearBoundProviders()
+    }
+
+    private class OrderRecordingProvider(private val order: MutableList<String>) : NoOpProvider() {
+        override suspend fun initialize(initialContext: EvaluationContext?) {
+            order += "initialize"
+            super.initialize(initialContext)
+        }
+
+        override suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
+            order += "onContextSet"
+        }
+    }
+
+    @Test
+    fun aConcurrentContextSetNeverEntersBeforeInitializeOnTheSameRegistration() = runBlocking {
+        repeat(ITERATIONS) { iteration ->
+            val instance = createOpenFeatureAPIInstance()
+            val order = CopyOnWriteArrayList<String>()
+            val provider = OrderRecordingProvider(order)
+
+            val setProviderJob = launch(Dispatchers.Default) { instance.setProvider(provider) }
+            val setContextJob = launch(Dispatchers.Default) { instance.setEvaluationContext(ImmutableContext()) }
+            setProviderJob.join()
+            setContextJob.join()
+            // Both calls only start work on the registration's own scope; give it time to run.
+            delay(20)
+
+            val recorded = order.toList()
+            if (recorded.contains("onContextSet")) {
+                assertEquals(
+                    "initialize",
+                    recorded.first(),
+                    "iteration $iteration observed onContextSet before initialize: $recorded"
+                )
+            }
+        }
+    }
+}

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderRetirementTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderRetirementTest.kt
@@ -2,7 +2,9 @@ package dev.openfeature.kotlin.sdk
 
 import dev.openfeature.kotlin.sdk.isolated.ExperimentalIsolatedApi
 import dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
@@ -10,11 +12,11 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 /**
- * Retiring a replaced provider must not happen on the caller's thread. `shutdown` is documented as
- * releasing resources and threads, and `MultiProvider` fans it out over every child, so a provider
- * registered from a UI thread would otherwise block on its predecessor's whole teardown.
+ * Retiring a replaced provider must not happen on the caller's thread, or registering a provider
+ * from a UI thread blocks on its predecessor's whole teardown.
  *
  * JVM-only because it needs to block a real thread, which common test code cannot portably do.
  */
@@ -33,6 +35,7 @@ class ProviderRetirementTest {
         override fun shutdown() {
             shutdownEntered.countDown()
             releaseShutdown.await(30, TimeUnit.SECONDS)
+            super.shutdown()
         }
     }
 
@@ -57,6 +60,32 @@ class ProviderRetirementTest {
             "the outgoing provider was never shut down"
         )
         outgoing.releaseShutdown.countDown()
+    }
+
+    @Test
+    fun aProviderRegisteredAgainWhileItsRetirementIsPendingIsNotTornDown() {
+        val instance = createOpenFeatureAPIInstance()
+        val provider = BlockingShutdownProvider()
+        runBlocking { instance.setProviderAndWait(provider) }
+
+        instance.setProvider(NoOpProvider())
+        assertTrue(
+            provider.shutdownEntered.await(5, TimeUnit.SECONDS),
+            "the replaced provider was never retired"
+        )
+
+        // Registered again while its own teardown is still running: initializing over that would
+        // leave the live registration reporting the status its retirement reset.
+        instance.setProvider(provider)
+        provider.releaseShutdown.countDown()
+
+        runBlocking {
+            withTimeout(5.seconds) {
+                instance.statusFlow.first { it == OpenFeatureStatus.Ready }
+            }
+        }
+        assertTrue(instance.getProvider() === provider)
+        assertEquals(OpenFeatureStatus.Ready, instance.getStatus())
     }
 
     @Test

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderRetirementTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderRetirementTest.kt
@@ -1,0 +1,74 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.isolated.ExperimentalIsolatedApi
+import dev.openfeature.kotlin.sdk.isolated.createOpenFeatureAPIInstance
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Retiring a replaced provider must not happen on the caller's thread. `shutdown` is documented as
+ * releasing resources and threads, and `MultiProvider` fans it out over every child, so a provider
+ * registered from a UI thread would otherwise block on its predecessor's whole teardown.
+ *
+ * JVM-only because it needs to block a real thread, which common test code cannot portably do.
+ */
+@OptIn(ExperimentalIsolatedApi::class)
+class ProviderRetirementTest {
+
+    @AfterTest
+    fun tearDown() {
+        OpenFeatureAPIInstance.clearBoundProviders()
+    }
+
+    private class BlockingShutdownProvider : NoOpProvider() {
+        val shutdownEntered = CountDownLatch(1)
+        val releaseShutdown = CountDownLatch(1)
+
+        override fun shutdown() {
+            shutdownEntered.countDown()
+            releaseShutdown.await(30, TimeUnit.SECONDS)
+        }
+    }
+
+    @Test
+    fun setProviderDoesNotBlockOnTheOutgoingProvidersShutdown() {
+        val instance = createOpenFeatureAPIInstance()
+        val outgoing = BlockingShutdownProvider()
+        runBlocking { instance.setProviderAndWait(outgoing) }
+
+        val returned = CountDownLatch(1)
+        thread {
+            instance.setProvider(NoOpProvider())
+            returned.countDown()
+        }
+
+        assertTrue(
+            returned.await(5, TimeUnit.SECONDS),
+            "setProvider blocked on the outgoing provider's shutdown"
+        )
+        assertTrue(
+            outgoing.shutdownEntered.await(5, TimeUnit.SECONDS),
+            "the outgoing provider was never shut down"
+        )
+        outgoing.releaseShutdown.countDown()
+    }
+
+    @Test
+    fun setProviderAndWaitReportsTheOutgoingProviderDown() {
+        val instance = createOpenFeatureAPIInstance()
+        val outgoing = BlockingShutdownProvider()
+        outgoing.releaseShutdown.countDown()
+        runBlocking { instance.setProviderAndWait(outgoing) }
+
+        // A suspending caller can be told the provider it replaced is actually down.
+        runBlocking { instance.setProviderAndWait(NoOpProvider()) }
+
+        assertEquals(0, outgoing.shutdownEntered.count)
+    }
+}

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderRetirementTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderRetirementTest.kt
@@ -51,15 +51,18 @@ class ProviderRetirementTest {
             returned.countDown()
         }
 
-        assertTrue(
-            returned.await(5, TimeUnit.SECONDS),
-            "setProvider blocked on the outgoing provider's shutdown"
-        )
-        assertTrue(
-            outgoing.shutdownEntered.await(5, TimeUnit.SECONDS),
-            "the outgoing provider was never shut down"
-        )
-        outgoing.releaseShutdown.countDown()
+        try {
+            assertTrue(
+                returned.await(5, TimeUnit.SECONDS),
+                "setProvider blocked on the outgoing provider's shutdown"
+            )
+            assertTrue(
+                outgoing.shutdownEntered.await(5, TimeUnit.SECONDS),
+                "the outgoing provider was never shut down"
+            )
+        } finally {
+            outgoing.releaseShutdown.countDown()
+        }
     }
 
     @Test

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -15,13 +14,11 @@ private const val ITERATIONS = 500
 private const val EVENTS_PER_ITERATION = 8
 
 /**
- * Racing subscribe against send, which only JVM and native can do — JS is single-threaded, and the
- * common tests can only drive the deterministic ordering.
+ * Racing subscribe against send, which only JVM and native can do — JS is single-threaded.
  *
- * The sequence fence in [ProviderStatusTracker.observe] exists because a subscriber's slot is
- * allocated before it reads the status to replay, so an event landing in between is both folded into
- * the replayed status and buffered for delivery. What that must never produce is a duplicate or a
- * reordering, which is what these assertions pin.
+ * A subscriber's slot is allocated before it reads the status to replay, so an event landing in
+ * between is both folded into the replay and buffered for delivery. These assertions pin that this
+ * never produces a duplicate or a reordering.
  */
 class ProviderStatusTrackerConcurrencyTest {
 
@@ -80,9 +77,8 @@ class ProviderStatusTrackerConcurrencyTest {
             val tracker = ProviderStatusTracker()
             tracker.send(OpenFeatureProviderEvents.ProviderReady())
 
-            // Two invocations on different threads. The mark, the registration and the reconciling
-            // report have to be one step, or one of them mistakes the other's report for its own and
-            // neither ends up reporting the outcome.
+            // The mark, the registration and the reconciling report have to be one step, or one
+            // invocation mistakes the other's report for its own and neither reports the outcome.
             (1..2).map { launch(Dispatchers.Default) { tracker.reconciling { } } }.forEach { it.join() }
 
             assertEquals(
@@ -101,10 +97,12 @@ class ProviderStatusTrackerConcurrencyTest {
 
             val observed = mutableListOf<OpenFeatureProviderEvents>()
             val replayed = CompletableDeferred<Unit>()
+            val handedOff = CompletableDeferred<Unit>()
             val collector = launch(Dispatchers.Default) {
                 tracker.observe().collect {
                     observed.add(it)
                     replayed.complete(Unit)
+                    if (observed.size == 3) handedOff.complete(Unit)
                 }
             }
             // Sent only once the replay has arrived, so the handover point is unambiguous.
@@ -114,7 +112,9 @@ class ProviderStatusTrackerConcurrencyTest {
                 tracker.send(OpenFeatureProviderEvents.ProviderReconciling())
             }.join()
 
-            withTimeout(5_000) { while (observed.size < 3) yield() }
+            // Signalled by the collector rather than polled: observed is the collector's alone until
+            // it has joined.
+            withTimeout(5_000) { handedOff.await() }
             collector.cancel()
             collector.join()
 
@@ -130,14 +130,10 @@ class ProviderStatusTrackerConcurrencyTest {
         }
     }
 
-    // The fence's third clause — an event carrying no status is never fenced out, because the replay
-    // cannot stand in for it — is deliberately not tested here, and cannot be. It only decides
-    // anything for an event buffered after the collector's slot was allocated but before the snapshot
-    // was read, and that window is not observable from outside the class: an event sent a moment
-    // earlier is correctly never delivered at all, so "the later event arrived but the earlier one did
-    // not" has a legitimate reading as well as a buggy one. A test asserting the buggy reading has a
-    // false-positive mode, which is what it did under load. The clause is covered by construction and
-    // by the deterministic aStatelessEventIsDeliveredButNeverReplayed in ProviderStatusTrackerTests.
+    // The fence's third clause — an event carrying no status is never fenced out — has no sound race
+    // test: its window is not observable from outside the class, and an event sent a moment earlier is
+    // correctly never delivered, so the buggy and the legitimate reading are indistinguishable. It is
+    // covered by aStatelessEventIsDeliveredButNeverReplayed in ProviderStatusTrackerTests.
 
     private fun errorNumbered(number: Int) = OpenFeatureProviderEvents.ProviderError(
         OpenFeatureProviderEvents.EventDetails(message = number.toString())

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
@@ -1,0 +1,82 @@
+package dev.openfeature.kotlin.sdk
+
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val ITERATIONS = 500
+private const val EVENTS_PER_ITERATION = 8
+
+/**
+ * Racing subscribe against send, which only JVM and native can do — JS is single-threaded, and the
+ * common tests can only drive the deterministic ordering.
+ *
+ * The sequence fence in [ProviderStatusTracker.observe] exists because a subscriber's slot is
+ * allocated before it reads the status to replay, so an event landing in between is both folded into
+ * the replayed status and buffered for delivery. What that must never produce is a duplicate or a
+ * reordering, which is what these assertions pin.
+ */
+class ProviderStatusTrackerConcurrencyTest {
+
+    @Test
+    fun subscribingWhileEventsAreSentNeverDuplicatesOrReordersThem() = runBlocking {
+        repeat(ITERATIONS) { iteration ->
+            val tracker = ProviderStatusTracker()
+            tracker.send(errorNumbered(0))
+
+            val observed = mutableListOf<Int>()
+            val subscribed = CompletableDeferred<Unit>()
+            val collector = launch(Dispatchers.Default) {
+                tracker.observe().collect { event ->
+                    subscribed.complete(Unit)
+                    observed.add(event.number())
+                }
+            }
+
+            // Deliberately not waiting for the subscription: the point is to land inside the window.
+            launch(Dispatchers.Default) {
+                for (number in 1..EVENTS_PER_ITERATION) tracker.send(errorNumbered(number))
+            }.join()
+
+            withTimeout(5_000) { subscribed.await() }
+            collector.cancel()
+            collector.join()
+
+            // Strict monotonicity forbids both a replay that repeats a live event and any reordering.
+            val snapshot = observed.toList()
+            assertTrue(
+                snapshot.zipWithNext().all { (previous, next) -> previous < next },
+                "iteration $iteration observed a duplicate or out-of-order sequence: $snapshot"
+            )
+        }
+    }
+
+    @Test
+    fun statusIsConsistentWithTheLastEventSentUnderConcurrentSenders() = runBlocking {
+        repeat(ITERATIONS) {
+            val tracker = ProviderStatusTracker()
+            val senders = (1..4).map {
+                launch(Dispatchers.Default) {
+                    repeat(EVENTS_PER_ITERATION) { tracker.send(OpenFeatureProviderEvents.ProviderStale()) }
+                }
+            }
+            senders.forEach { it.join() }
+            tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+            assertEquals(OpenFeatureStatus.Ready, tracker.status)
+        }
+    }
+
+    private fun errorNumbered(number: Int) = OpenFeatureProviderEvents.ProviderError(
+        OpenFeatureProviderEvents.EventDetails(message = number.toString())
+    )
+
+    private fun OpenFeatureProviderEvents.number(): Int =
+        requireNotNull(eventDetails?.message) { "event carried no number" }.toInt()
+}

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
@@ -130,39 +130,14 @@ class ProviderStatusTrackerConcurrencyTest {
         }
     }
 
-    @Test
-    fun aStatelessEventIsNotFencedOutFromUnderALaterOne() = runBlocking {
-        repeat(ITERATIONS) { iteration ->
-            val tracker = ProviderStatusTracker()
-            tracker.send(OpenFeatureProviderEvents.ProviderReady())
-
-            val observed = mutableListOf<OpenFeatureProviderEvents>()
-            val collector = launch(Dispatchers.Default) {
-                tracker.observe().collect { observed.add(it) }
-            }
-            // Racing the subscription: the configuration change is sent first, so if the later stale
-            // report got through then the configuration change must have too. Fencing an event that
-            // carries no status would drop it here, because the replay cannot stand in for it.
-            launch(Dispatchers.Default) {
-                tracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
-                tracker.send(OpenFeatureProviderEvents.ProviderStale())
-            }.join()
-
-            withTimeout(5_000) { while (tracker.status != OpenFeatureStatus.Stale) yield() }
-            collector.cancel()
-            collector.join()
-
-            val snapshot = observed.toList()
-            val sawStaleLive = snapshot.drop(1).any { it is OpenFeatureProviderEvents.ProviderStale }
-            if (sawStaleLive) {
-                assertTrue(
-                    snapshot.any { it is OpenFeatureProviderEvents.ProviderConfigurationChanged },
-                    "iteration $iteration delivered the later event but dropped the earlier one: " +
-                        snapshot.map { it::class.simpleName }
-                )
-            }
-        }
-    }
+    // The fence's third clause — an event carrying no status is never fenced out, because the replay
+    // cannot stand in for it — is deliberately not tested here, and cannot be. It only decides
+    // anything for an event buffered after the collector's slot was allocated but before the snapshot
+    // was read, and that window is not observable from outside the class: an event sent a moment
+    // earlier is correctly never delivered at all, so "the later event arrived but the earlier one did
+    // not" has a legitimate reading as well as a buggy one. A test asserting the buggy reading has a
+    // false-positive mode, which is what it did under load. The clause is covered by construction and
+    // by the deterministic aStatelessEventIsDeliveredButNeverReplayed in ProviderStatusTrackerTests.
 
     private fun errorNumbered(number: Int) = OpenFeatureProviderEvents.ProviderError(
         OpenFeatureProviderEvents.EventDetails(message = number.toString())

--- a/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
+++ b/kotlin-sdk/src/jvmTest/kotlin/dev/openfeature/kotlin/sdk/ProviderStatusTrackerConcurrencyTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -70,6 +71,96 @@ class ProviderStatusTrackerConcurrencyTest {
             tracker.send(OpenFeatureProviderEvents.ProviderReady())
 
             assertEquals(OpenFeatureStatus.Ready, tracker.status)
+        }
+    }
+
+    @Test
+    fun racingReconciliationsNeverLeaveTheTrackerReconciling() = runBlocking {
+        repeat(ITERATIONS) { iteration ->
+            val tracker = ProviderStatusTracker()
+            tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+            // Two invocations on different threads. The mark, the registration and the reconciling
+            // report have to be one step, or one of them mistakes the other's report for its own and
+            // neither ends up reporting the outcome.
+            (1..2).map { launch(Dispatchers.Default) { tracker.reconciling { } } }.forEach { it.join() }
+
+            assertEquals(
+                OpenFeatureStatus.Ready,
+                tracker.status,
+                "iteration $iteration was left mid-reconciliation"
+            )
+        }
+    }
+
+    @Test
+    fun theReplayHandsOffToTheLiveStreamWithoutLoss() = runBlocking {
+        repeat(ITERATIONS) { iteration ->
+            val tracker = ProviderStatusTracker()
+            tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+            val observed = mutableListOf<OpenFeatureProviderEvents>()
+            val replayed = CompletableDeferred<Unit>()
+            val collector = launch(Dispatchers.Default) {
+                tracker.observe().collect {
+                    observed.add(it)
+                    replayed.complete(Unit)
+                }
+            }
+            // Sent only once the replay has arrived, so the handover point is unambiguous.
+            withTimeout(5_000) { replayed.await() }
+            launch(Dispatchers.Default) {
+                tracker.send(OpenFeatureProviderEvents.ProviderStale())
+                tracker.send(OpenFeatureProviderEvents.ProviderReconciling())
+            }.join()
+
+            withTimeout(5_000) { while (observed.size < 3) yield() }
+            collector.cancel()
+            collector.join()
+
+            assertEquals(
+                listOf(
+                    OpenFeatureProviderEvents.ProviderReady::class,
+                    OpenFeatureProviderEvents.ProviderStale::class,
+                    OpenFeatureProviderEvents.ProviderReconciling::class
+                ),
+                observed.take(3).map { it::class },
+                "iteration $iteration"
+            )
+        }
+    }
+
+    @Test
+    fun aStatelessEventIsNotFencedOutFromUnderALaterOne() = runBlocking {
+        repeat(ITERATIONS) { iteration ->
+            val tracker = ProviderStatusTracker()
+            tracker.send(OpenFeatureProviderEvents.ProviderReady())
+
+            val observed = mutableListOf<OpenFeatureProviderEvents>()
+            val collector = launch(Dispatchers.Default) {
+                tracker.observe().collect { observed.add(it) }
+            }
+            // Racing the subscription: the configuration change is sent first, so if the later stale
+            // report got through then the configuration change must have too. Fencing an event that
+            // carries no status would drop it here, because the replay cannot stand in for it.
+            launch(Dispatchers.Default) {
+                tracker.send(OpenFeatureProviderEvents.ProviderConfigurationChanged())
+                tracker.send(OpenFeatureProviderEvents.ProviderStale())
+            }.join()
+
+            withTimeout(5_000) { while (tracker.status != OpenFeatureStatus.Stale) yield() }
+            collector.cancel()
+            collector.join()
+
+            val snapshot = observed.toList()
+            val sawStaleLive = snapshot.drop(1).any { it is OpenFeatureProviderEvents.ProviderStale }
+            if (sawStaleLive) {
+                assertTrue(
+                    snapshot.any { it is OpenFeatureProviderEvents.ProviderConfigurationChanged },
+                    "iteration $iteration delivered the later event but dropped the earlier one: " +
+                        snapshot.map { it::class.simpleName }
+                )
+            }
         }
     }
 

--- a/sampleapp/src/main/kotlin/dev/openfeature/kotlin/sdk/sampleapp/ExampleProvider.kt
+++ b/sampleapp/src/main/kotlin/dev/openfeature/kotlin/sdk/sampleapp/ExampleProvider.kt
@@ -1,7 +1,9 @@
 package dev.openfeature.kotlin.sdk.sampleapp
 
 import dev.openfeature.kotlin.sdk.*
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 
 class ExampleProvider(override val hooks: List<Hook<*>> = listOf()) : FeatureProvider {
 
@@ -25,20 +27,27 @@ class ExampleProvider(override val hooks: List<Hook<*>> = listOf()) : FeaturePro
             override val name: String = "ExampleProvider"
         }
 
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: OpenFeatureStatus get() = statusTracker.status
+
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
+
     override suspend fun initialize(initialContext: EvaluationContext?) {
         currentContext = initialContext
         // Simulate a delay in the provider initialization
         delay(delayTime)
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
     override fun shutdown() {
-
+        statusTracker.reset()
     }
 
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
-    ) {
+    ) = statusTracker.reconciling {
         currentContext = newContext
         delay(delayTime)
     }


### PR DESCRIPTION
## Intent

The SDK derived `OpenFeatureStatus` from what a provider *did* — returning, throwing, or staying silent — while the provider emitted its own events. Two sources of truth for one piece of state left a window after `initialize` completed but before the SDK updated state, in which a provider's events had no defined order against the SDK's, and made the client's pre-evaluation status check unreliable by construction.

This ports [open-feature/swift-sdk#114](https://github.com/open-feature/swift-sdk/pull/114) (`fix!: move provider status tracking back to provider`) to Kotlin: the provider owns `status` and reports every transition as an event; the SDK reads status, republishes events, and infers nothing. It closes the same three upstream issues:

- [spec#365](https://github.com/open-feature/spec/issues/365) — provider lifecycle race from split status ownership.
- [spec#369](https://github.com/open-feature/spec/issues/369) — TOCTOU on the client's status check. This was **former** requirements 1.7.6 and 1.7.7, removed from the specification in [spec#385](https://github.com/open-feature/spec/pull/385) (v0.9.0). Not to be confused with today's 1.7.6, which is the unrelated "not-ready once `shutdown` terminates".
- [swift-sdk#108](https://github.com/open-feature/swift-sdk/issues/108) — lifecycle over-serialization.

## Changes

### Implementation

- **New `ProviderStatusTracker`** — public, provider-side. Derives status from the events sent through it, republishes them, and replays the current status to a new subscriber. `reconciling { }` reports the transitions around a reconciliation, collapsing overlapping invocations into one reported outcome per requirements 5.3.4.2/5.3.4.3.
- **`FeatureProvider`** gains an abstract `status`; `observe()` loses its default. `shutdown()` is retained (the Swift protocol has none) with a contract to return to not-ready if the provider can be registered again.
- **`OpenFeatureAPIInstance`** keeps no status. `getStatus()` and `statusFlow` both project `FeatureProvider.status`. The one inferred transition is shutdown, where requirement 1.7.6 makes it the SDK's own conclusion: `clearProvider` installs a provider that was never initialized.
- **Lifecycle dispatch** runs on the registration's own serial dispatcher, so calls are entered in order without the SDK waiting for one to finish before entering the next. A throw is no longer a status signal — it is logged, and the status stays where the provider put it. Cancellation propagates, and an awaited call waits for the provider to finish unwinding so the outcome it owes a reconciliation is reported first.
- **`OpenFeatureClient`** no longer checks status before evaluating. Evaluations always reach the provider and its error surfaces through the normal hook lifecycle. `EvaluationState` now carries hooks, so an evaluation takes one atomic snapshot instead of two reads.
- **`MultiProvider`** owns a tracker and reads children's statuses directly, so its bookkeeping map, status flow and event flow are gone. `Strategy` gains `status(providers)` with a default implementation.
- **`OpenFeatureStatus.Error`/`Fatal`** compare by the failure they describe. Without that, the same failure reported live and replayed to a late subscriber is two distinct statuses that `distinctUntilChanged` cannot collapse.
- **Two new events**, `ProviderReconciling` and `ProviderContextChanged`, plus the specification's event/status association table as shared helpers.

### Usage Examples

```kotlin
class MyProvider : FeatureProvider {
    private val statusTracker = ProviderStatusTracker()

    override val status: OpenFeatureStatus get() = statusTracker.status
    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()

    override suspend fun initialize(initialContext: EvaluationContext?) {
        connect(initialContext)
        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
    }

    override suspend fun onContextSet(
        oldContext: EvaluationContext?,
        newContext: EvaluationContext
    ) = statusTracker.reconciling { refresh(newContext) }

    override fun shutdown() = statusTracker.reset()

    fun onConnectionLost() = statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
}
```

Application code is unchanged:

```kotlin
OpenFeatureAPI.setProviderAndWait(MyProvider())
OpenFeatureAPI.getStatus()                           // now reads the provider
OpenFeatureAPI.statusFlow.collect { … }              // still available, now derived
OpenFeatureAPI.observe<OpenFeatureProviderEvents>()  // still available
```

## Testing

`./gradlew clean check` green on macOS across jvm, android debug + release, iosSimulatorArm64, js/node and js/browser.

- `ProviderStatusTrackerTests` — 22 tests over the event/status table, the replay contract (nothing replayed while not-ready, replayed once otherwise, per-subscriber, delivered before live events with no gap or duplicate, stateless events delivered but never replayed), status current by the time a subscriber sees the event, and the coalescing.
- `ProviderStatusTrackerConcurrencyTest`, JVM-only since JS and native are single-threaded — four tests racing subscribe against send over 500 iterations each: strict monotonicity (which forbids both a replay that repeats a live event and any reordering), the replay handing off to the live stream without loss, racing reconciliations never stranding the tracker, and status consistency under concurrent senders.
- Behaviour changes visible in existing tests, each now asserting the new truth: a provider that reconciles without reporting contributes no transition; a `ProviderConfigurationChanged` no longer clears an error; a double binding fails loudly instead of reporting an error status.
- `ProviderLifecycleTests` — the spec#365 contract (a `PROVIDER_STALE` reported *during* `initialize` is not overwritten when it returns), a provider that throws without reporting staying `NotReady`, one that reports and then throws keeping what it reported, a provider superseded before its registration ever ran still being shut down and released, and a same-instance rebind not shutting the provider down.
- `MultiProviderTests` — a cancelled context set not stranding the aggregate at `Reconciling`, overlapping context sets reporting `Reconciling` once and only the last outcome, an error aggregate carrying the triggering child's `flagsChanged` and `eventMetadata`, a child failing to initialize not cancelling its siblings, and an aggregate returning to `NotReady`.

## Breaking Changes

- `FeatureProvider` gains an abstract `status`, and `observe()` is no longer defaulted, so **every provider must be updated**. The migration is four lines: hold a `ProviderStatusTracker`, delegate `status` and `observe()` to it, report an outcome from `initialize`, and reset it from `shutdown`. There is no compatibility path — a provider that reports nothing stays `NotReady`.
- `initialize` and `onContextSet` failures are reported by emitting `ProviderError`, not by throwing; the SDK no longer converts a throw into a status.
- The client no longer short-circuits on `NotReady` or `Fatal`; callers see whatever the provider returns or throws.
- `OpenFeatureAPIInstance.providersFlow` is removed, and `observe()` is now an unparameterised member with a reified extension alongside it.
- `MultiProvider.statusFlow` is removed in favour of `MultiProvider.status`. `Strategy` gains `status(providers)`, which is defaulted, so existing strategies need no change.
- `setProviderAndWait`'s `dispatcher` now defaults to the caller's, and **`setEvaluationContext`'s `dispatcher` parameter is removed** — a registration's own dispatcher runs its reconciliations so they are ordered against its `initialize`.
- `OpenFeatureStatus.Error`/`Fatal` now define `equals`/`hashCode`, comparing by the failure they describe.
- An aggregate `MultiProvider` status of `NOT_READY` reaches `getStatus()` but not `observe()`/`statusFlow`: the specification has no `PROVIDER_NOT_READY` event to carry it. The Swift implementation has the same gap.
- Re-registering a provider that is already registered keeps the dispatcher it was first registered with, because its lifecycle calls have to stay ordered against each other on one dispatcher.
- `setProvider` no longer waits for the outgoing provider's `shutdown`; `setProviderAndWait` and `clearProvider` do.
- A reconciliation begun while the provider is `NOT_READY` reports no events at all, where it previously concluded `READY` on success.

## Known gaps, deliberately left

- `MultiProvider.updateStatus` reuses `statusTracker.reset()` to mean "the aggregate became not-ready", which also bumps the reconciliation generation and clears its restore point. Correct today, but it couples two concerns; a private "establish status without an event" path would say what is meant.
- For a child event carrying no status, the re-aggregation runs without a trigger, so a configuration change that also moves the aggregate loses `flagsChanged`/`eventMetadata`.
- `MultiProvider.watchScope` is an unsynchronized `var` touched from `initialize` and `shutdown`, so a swap racing a shutdown can leave a watch scope running.
- A child that throws from `initialize`/`onContextSet` without emitting a `ProviderError` leaves no trace: `MultiProvider` has no logger, where the top-level equivalent logs exactly that case.

## Recommended review order

1. `events/OpenFeatureProviderEvents.kt` — the two new events and the event/status table
2. `ProviderStatusTracker.kt` — the new component; read `observe()` closely, the sequence fence is what makes replay atomic
3. `FeatureProvider.kt` — the contract change
4. `OpenFeatureAPIInstance.kt` — what was deleted, and how `statusFlow` is derived
5. `OpenFeatureClient.kt` — the TOCTOU removal
6. `multiprovider/MultiProvider.kt` — aggregate status and the precedence divergence
7. `NoOpProvider.kt` — the smallest complete provider
8. `ProviderStatusTrackerTests.kt`, `jvmTest/ProviderStatusTrackerConcurrencyTest.kt`
9. Updated test helpers, then the updated existing tests
10. `README.md`, `docs/multiprovider/README.md`
